### PR TITLE
intel compiler

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -25,9 +25,6 @@ jobs:
             cmargs: >
               -DCMAKE_CXX_COMPILER=icpx
               -DCMAKE_CXX_FLAGS="--gcc-toolchain=${CONDA_PREFIX} --sysroot=${CONDA_PREFIX}/${HOST}/sysroot -target ${HOST}"
-              # flags are long-form of below (envvars not available at spinup)
-              # -DCMAKE_CXX_FLAGS="--gcc-toolchain=${CONDA_PREFIX} --sysroot=${CONDA_PREFIX}/${HOST}/sysroot -target ${HOST}"
-              # -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/einsums-dev --sysroot=/usr/share/miniconda3/envs/einsums-dev/x86_64-conda-linux-gnu/sysroot -target x86_64-conda-linux-gnu"
           - cxx: L-src
             os: ubuntu-latest
             build_type: Debug

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -24,12 +24,16 @@ jobs:
             os: ubuntu-latest
             cmargs: >
               -DCMAKE_CXX_COMPILER=icpx
-              -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/einsums-dev --sysroot=/usr/share/miniconda3/envs/einsums-dev/x86_64-conda-linux-gnu/sysroot -target x86_64-conda-linux-gnu"
+              -DCMAKE_CXX_FLAGS="--gcc-toolchain=${CONDA_PREFIX} --sysroot=${CONDA_PREFIX}/${HOST}/sysroot -target ${HOST}"
+              # flags are long-form of below (envvars not available at spinup)
+              # -DCMAKE_CXX_FLAGS="--gcc-toolchain=${CONDA_PREFIX} --sysroot=${CONDA_PREFIX}/${HOST}/sysroot -target ${HOST}"
+              # -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/einsums-dev --sysroot=/usr/share/miniconda3/envs/einsums-dev/x86_64-conda-linux-gnu/sysroot -target x86_64-conda-linux-gnu"
           - cxx: L-src
             os: ubuntu-latest
             build_type: Debug
             hptt: ON
             cmargs: >
+              -DFETCHCONTENT_QUIET=OFF
               -DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=NEVER
         exclude:
           - cxx: L-Intel

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -110,6 +110,12 @@ jobs:
         run: |
           conda remove liblapacke libcblas --solver=libmamba
 
+      # Step is unnecessary; remove step for debugging.
+      - name: Confound Environment - test fetched everything
+        if: matrix.cxx == 'L-src'
+        run: |
+          conda remove catch2 fmt range-v3 liblapacke libcblas --solver=libmamba
+
       - name: Conda environment
         run: |
           mamba info

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -19,13 +19,15 @@ jobs:
               -GNinja
           - os: ubuntu-latest
             cxx: g++
+            cmargs: >
+              -G"Unix Makefiles"
           - os: macos-latest
             cxx: clang++
           - os: ubuntu-latest
             cxx: icpx
             cmargs: >
               -DCMAKE_CXX_COMPILER=icpx
-              -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/test --sysroot=/usr/share/miniconda3/envs/test/x86_64-conda-linux-gnu/sysroot -target x86_64-conda-linux-gnu"
+              -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/einsums-dev --sysroot=/usr/share/miniconda3/envs/einsums-dev/x86_64-conda-linux-gnu/sysroot -target x86_64-conda-linux-gnu"
     name: "Build • ${{ matrix.os }} ${{ matrix.cxx }} ${{ matrix.build_type }} HPTT=${{ matrix.hptt }}"
     runs-on: ${{matrix.os}}
     defaults:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -26,8 +26,8 @@ jobs:
             cxx: icpx
             cmargs: >
               -DCMAKE_CXX_COMPILER=icpx
-              -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/mambaforge/envs/test --sysroot=/usr/share/mambaforge/envs/test/x86_64-conda-linux-gnu/sysroot -target x86_64
-    name: Build and Test
+              -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/test --sysroot=/usr/share/miniconda3/envs/test/x86_64-conda-linux-gnu/sysroot -target x86_64
+    name: "Build • ${{ matrix.os }} ${{ matrix.cxx }} ${{ matrix.build_type }} HPTT=${{ matrix.hptt }}"
     runs-on: ${{matrix.os}}
     defaults:
       run:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,26 +11,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        cxx: [ L-Gnu, M-Clang, L-Intel ]
         build_type: [ Release, Debug ]
-        cxx: [ g++, clang++, icpx]
         hptt: [ ON, OFF ]
         include:
           - cmargs: ""
-          - cxx: g++
+          - cxx: L-Gnu
             os: ubuntu-latest
-            #cmargs: >
-            #  -G"Unix Makefiles"
-          - cxx: clang++
+          - cxx: M-Clang
             os: macos-latest
-          - cxx: icpx
+          - cxx: L-Intel
             os: ubuntu-latest
             cmargs: >
               -DCMAKE_CXX_COMPILER=icpx
               -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/einsums-dev --sysroot=/usr/share/miniconda3/envs/einsums-dev/x86_64-conda-linux-gnu/sysroot -target x86_64-conda-linux-gnu"
-        exclude:
-          - cxx: icpx
+          - cxx: L-src
+            os: ubuntu-latest
             build_type: Debug
-    name: "Build • ${{ matrix.os }} ${{ matrix.cxx }} ${{ matrix.build_type }} HPTT=${{ matrix.hptt }}"
+            hptt: ON
+            cmargs: >
+              -DFETCHCONTENT_TRY_FIND_PACKAGE_MODE=NEVER
+        exclude:
+          - cxx: L-Intel
+            build_type: Debug
+    name: "Build • ${{ matrix.cxx }} • ${{ matrix.build_type }} • HPTT=${{ matrix.hptt }}"
     runs-on: ${{matrix.os}}
     defaults:
       run:
@@ -70,7 +74,7 @@ jobs:
             else
               sed -i "s;#OBL;;g" export.yaml
             fi
-            if [[ "${{ matrix.cxx }}" == "icpx" ]]; then
+            if [[ "${{ matrix.cxx }}" == "L-Intel" ]]; then
               sed -i "s/#- dpcpp_linux-64/- dpcpp_linux-64/g" export.yaml
             fi
           fi

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -22,11 +22,10 @@ jobs:
           - os: macos-latest
             cxx: clang++
           - os: ubuntu-latest
-            build_type: Release
             cxx: icpx
             cmargs: >
               -DCMAKE_CXX_COMPILER=icpx
-              -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/test --sysroot=/usr/share/miniconda3/envs/test/x86_64-conda-linux-gnu/sysroot -target x86_64
+              -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/test --sysroot=/usr/share/miniconda3/envs/test/x86_64-conda-linux-gnu/sysroot -target x86_64-conda-linux-gnu"
     name: "Build • ${{ matrix.os }} ${{ matrix.cxx }} ${{ matrix.build_type }} HPTT=${{ matrix.hptt }}"
     runs-on: ${{matrix.os}}
     defaults:

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,6 +1,10 @@
 name: CMake
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:
@@ -9,12 +13,20 @@ jobs:
       matrix:
         build_type: [ Release, Debug ]
         os: [ ubuntu-latest, macos-latest ]
-        hptt: [ HPTT=ON, HPTT=OFF ]
+        hptt: [ ON, OFF ]
         include:
+          - cmargs: >
+              -GNinja
           - os: ubuntu-latest
-            environment: linux-dev.yml
+            cxx: g++
           - os: macos-latest
-            environment: macos-dev.yml
+            cxx: clang++
+          - os: ubuntu-latest
+            build_type: Release
+            cxx: icpx
+            cmargs: >
+              -DCMAKE_CXX_COMPILER=icpx
+              -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/mambaforge/envs/test --sysroot=/usr/share/mambaforge/envs/test/x86_64-conda-linux-gnu/sysroot -target x86_64
     name: Build and Test
     runs-on: ${{matrix.os}}
     defaults:
@@ -47,12 +59,16 @@ jobs:
             - hdf5
             - zlib
             - elfutils
+            #- dpcpp_linux-64
           EOF
           if [[ "${{ runner.os }}" == "Linux" ]]; then
             if [[ "${{ matrix.build_type }}" == "Release" ]]; then
               sed -i "s;#MKL;;g" export.yaml
             else
               sed -i "s;#OBL;;g" export.yaml
+            fi
+            if [[ "${{ matrix.cxx }}" == "icpx" ]]; then
+              sed -i "s/#- dpcpp_linux-64/- dpcpp_linux-64/g" export.yaml
             fi
           fi
           if [[ "${{ runner.os }}" == "macOS" ]]; then
@@ -82,7 +98,7 @@ jobs:
 
       # Step is unnecessary; remove step for debugging.
       - name: Confound Environment - test fetched cblas/lapacke
-        if: ${{ matrix.os == 'ubuntu-latest' && matrix.build_type == 'Debug' && matrix.hptt == 'HPTT=OFF' }}
+        if: ${{ matrix.os == 'ubuntu-latest' && matrix.build_type == 'Debug' && matrix.hptt == 'OFF' }}
         run: |
           conda remove liblapacke libcblas --solver=libmamba
 
@@ -92,7 +108,17 @@ jobs:
           mamba list
 
       - name: Configure CMake
-        run: cmake -G Ninja -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{matrix.build_type}} -DEINSUMS_SHOW_WARNING=OFF -DEINSUMS_USE_${{matrix.hptt}}
+        run: |
+          cmake \
+            -S . \
+            -B ${{github.workspace}}/build \
+            -D CMAKE_BUILD_TYPE=${{matrix.build_type}} \
+            -D EINSUMS_SHOW_WARNING=OFF \
+            -D EINSUMS_USE_HPTT=${{matrix.hptt}} \
+            -D EINSUMS_STATIC_BUILD=${{matrix.hptt}} \
+            -D CMAKE_INSTALL_PREFIX="${{github.workspace}}/installed" \
+            -DCMAKE_PREFIX_PATH="${CONDA_PREFIX}" \
+            ${{ matrix.cmargs }}
 
       - name: Build
         run: cmake --build ${{github.workspace}}/build --config ${{matrix.build_type}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,22 +12,24 @@ jobs:
       fail-fast: false
       matrix:
         build_type: [ Release, Debug ]
-        os: [ ubuntu-latest, macos-latest ]
+        cxx: [ g++, clang++, icpx]
         hptt: [ ON, OFF ]
         include:
-          - cmargs: >
-              -GNinja
-          - os: ubuntu-latest
-            cxx: g++
-            cmargs: >
-              -G"Unix Makefiles"
-          - os: macos-latest
-            cxx: clang++
-          - os: ubuntu-latest
-            cxx: icpx
+          - cmargs: ""
+          - cxx: g++
+            os: ubuntu-latest
+            #cmargs: >
+            #  -G"Unix Makefiles"
+          - cxx: clang++
+            os: macos-latest
+          - cxx: icpx
+            os: ubuntu-latest
             cmargs: >
               -DCMAKE_CXX_COMPILER=icpx
               -DCMAKE_CXX_FLAGS="--gcc-toolchain=/usr/share/miniconda3/envs/einsums-dev --sysroot=/usr/share/miniconda3/envs/einsums-dev/x86_64-conda-linux-gnu/sysroot -target x86_64-conda-linux-gnu"
+        exclude:
+          - cxx: icpx
+            build_type: Debug
     name: "Build • ${{ matrix.os }} ${{ matrix.cxx }} ${{ matrix.build_type }} HPTT=${{ matrix.hptt }}"
     runs-on: ${{matrix.os}}
     defaults:
@@ -113,6 +115,7 @@ jobs:
           cmake \
             -S . \
             -B ${{github.workspace}}/build \
+            -G Ninja \
             -D CMAKE_BUILD_TYPE=${{matrix.build_type}} \
             -D EINSUMS_SHOW_WARNING=OFF \
             -D EINSUMS_USE_HPTT=${{matrix.hptt}} \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,10 +27,22 @@ include(EinsumsBuildTypeASAN)
 include(EinsumsBuildTypeMSAN)
 include(EinsumsBuildTypeUBSAN)
 
+set(ein Einsums)  # Namespace
+
 # ##############################################################################
 # User input options                                                           #
 # ##############################################################################
 include(einsums_option)
+
+# borrowed from pybind11 since einsums_option doesn't work
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+  message(STATUS "Setting tests build type to Release as none was specified")
+  set(CMAKE_BUILD_TYPE
+      Release
+      CACHE STRING "Choose the type of build." FORCE)
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release" "MinSizeRel"
+                                               "RelWithDebInfo")
+endif()
 
 einsums_option(EINSUMS_CONTINUOUSLY_TEST_EINSUM BOOL
                "Every call to TensorAlgebra::einsum is tested" OFF)
@@ -49,6 +61,9 @@ einsums_option(EINSUMS_USE_HPTT BOOL
                "Use the HPTT package for tensor transpositions" ON)
 einsums_option(EINSUMS_ENABLE_TESTING BOOL "Build testing (requires Catch2)"
                ${PROJECT_IS_TOP_LEVEL})
+einsums_option(EINSUMS_INSTALL_CMAKEDIR STRING
+               "Directory to which Einsums CMake config files installed."
+               share/cmake/Einsums)
 
 add_feature_info(
   EINSUMS_CONTINUOUSLY_TEST_EINSUM ${EINSUMS_CONTINUOUSLY_TEST_EINSUM}
@@ -66,6 +81,8 @@ add_feature_info(EINSUMS_RUNTIME_INDICES_CHECK ${EINSUMS_RUNTIME_INDICES_CHECK}
                  "Check the sizes of corresponding indices at runtime")
 add_feature_info(EINSUMS_USE_HPTT ${EINSUMS_USE_HPTT}
                  "Build with internal HPTT version")
+
+include(autocmake_safeguards)
 
 include(cmake/DetectHostArch.cmake)
 detect_host_arch()

--- a/cmake/EinsumsAPI.cmake
+++ b/cmake/EinsumsAPI.cmake
@@ -156,37 +156,37 @@ function(add_einsums_library name)
         set(COMPONENT_OPTION "COMPONENT" "${_arg_COMPONENT}")
     endif()
 
-    if (NOT EINSUMS_STATIC_BUILD OR _arg_SHARED)
-        install(TARGETS ${name}
-            EXPORT Einsums
-            RUNTIME
-                DESTINATION "${_DESTINATION}"
-                ${COMPONENT_OPTION}
-                OPTIONAL
-            LIBRARY
-                DESTINATION "${EINSUMS_LIBRARY_PATH}"
-                ${NAMELINK_OPTION}
-                ${COMPONENT_OPTION}
-                OPTIONAL
-            OBJECTS
-                DESTINATION "${EINSUMS_LIBRARY_PATH}"
-                COMPONENT Devel EXCLUDE_FROM_ALL
-            ARCHIVE
-                DESTINATION "${EINSUMS_LIBRARY_ARCHIVE_PATH}"
-                COMPONENT Devel EXCLUDE_FROM_ALL
-                OPTIONAL
-        )
-    endif()
-
-    if (NAMELINK_OPTION AND NOT EINSUMS_STATIC_BUILD)
-        install(TARGETS ${name}
-            LIBRARY
-                DESTINATION "${EINSUMS_LIBRARY_PATH}"
-                NAMELINK_ONLY
-                COMPONENT Devel EXCLUDE_FROM_ALL
-                OPTIONAL
-        )
-    endif()
+#    if (NOT EINSUMS_STATIC_BUILD OR _arg_SHARED)
+#        install(TARGETS ${name}
+#            EXPORT Einsums
+#            RUNTIME
+#                DESTINATION "${_DESTINATION}"
+#                ${COMPONENT_OPTION}
+#                OPTIONAL
+#            LIBRARY
+#                DESTINATION "${EINSUMS_LIBRARY_PATH}"
+#                ${NAMELINK_OPTION}
+#                ${COMPONENT_OPTION}
+#                OPTIONAL
+#            OBJECTS
+#                DESTINATION "${EINSUMS_LIBRARY_PATH}"
+#                COMPONENT Devel EXCLUDE_FROM_ALL
+#            ARCHIVE
+#                DESTINATION "${EINSUMS_LIBRARY_ARCHIVE_PATH}"
+#                COMPONENT Devel EXCLUDE_FROM_ALL
+#                OPTIONAL
+#        )
+#    endif()
+#
+#    if (NAMELINK_OPTION AND NOT EINSUMS_STATIC_BUILD)
+#        install(TARGETS ${name}
+#            LIBRARY
+#                DESTINATION "${EINSUMS_LIBRARY_PATH}"
+#                NAMELINK_ONLY
+#                COMPONENT Devel EXCLUDE_FROM_ALL
+#                OPTIONAL
+#        )
+#    endif()
 endfunction(add_einsums_library)
 
 function(einsums_add_public_header header)
@@ -198,9 +198,9 @@ function(einsums_add_public_header header)
     get_filename_component(source_dir ${header} DIRECTORY)
     file(RELATIVE_PATH include_dir_relative_path ${_einsums_source_dir} ${source_dir})
 
-    install(
-        FILES ${header}
-        DESTINATION "${EINSUMS_HEADER_INSTALL_PATH}/${include_dir_relative_path}"
-        COMPONENT Devel EXCLUDE_FROM_ALL
-    )
+    #install(
+    #    FILES ${header}
+    #    DESTINATION "${EINSUMS_HEADER_INSTALL_PATH}/${include_dir_relative_path}"
+    #    COMPONENT Devel EXCLUDE_FROM_ALL
+    #)
 endfunction()

--- a/cmake/autocmake_safeguards.cmake
+++ b/cmake/autocmake_safeguards.cmake
@@ -1,0 +1,27 @@
+# Downloaded from
+#   https://github.com/coderefinery/autocmake/blob/master/modules/safeguards.cmake
+# * changed text of in-source message
+
+#.rst:
+#
+# Provides safeguards against in-source builds and bad build types.
+#
+# Variables used::
+#
+#   PROJECT_SOURCE_DIR
+#   PROJECT_BINARY_DIR
+#   CMAKE_BUILD_TYPE
+
+if(${PROJECT_SOURCE_DIR} STREQUAL ${PROJECT_BINARY_DIR})
+    message(FATAL_ERROR "In-source builds not allowed. Please run CMake from top directory and specify a build directory (e.g., cmake -S. -Bbuild).")
+endif()
+
+string(TOLOWER "${CMAKE_BUILD_TYPE}" cmake_build_type_tolower)
+string(TOUPPER "${CMAKE_BUILD_TYPE}" cmake_build_type_toupper)
+
+if(NOT cmake_build_type_tolower STREQUAL "debug" AND
+   NOT cmake_build_type_tolower STREQUAL "release" AND
+   NOT cmake_build_type_tolower STREQUAL "minsizerel" AND
+   NOT cmake_build_type_tolower STREQUAL "relwithdebinfo")
+    message(FATAL_ERROR "Unknown build type \"${CMAKE_BUILD_TYPE}\". Allowed values are Debug, Release, RelWithDebInfo, MinSizeRel (case-insensitive).")
+endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -111,11 +111,21 @@ install(
   )
 
 
-# <<< hptt >> Not using hptt is just asking for slow sorts.
+# <<< hptt >>>
+
+# * Not using hptt is just asking for slow sorts.
+
 if(EINSUMS_USE_HPTT)
   FetchContent_Declare(
     hptt
     GIT_REPOSITORY https://github.com/Einsums/hptt.git
-    GIT_TAG v1.0.5+22)
-  FetchContent_MakeAvailable(hptt)
+    GIT_TAG v1.0.5+22
+    OVERRIDE_FIND_PACKAGE
+    )
+  #FetchContent_MakeAvailable(hptt)  # alternative to below is to add_subdirectory(hptt EXCLUDE_FROM_ALL)
+  FetchContent_GetProperties(hptt)
+  if(NOT hptt_POPULATED)
+    FetchContent_Populate(hptt)
+    add_subdirectory(${hptt_SOURCE_DIR} ${hptt_BINARY_DIR} EXCLUDE_FROM_ALL)
+  endif()
 endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -125,7 +125,7 @@ if(EINSUMS_USE_HPTT)
   FetchContent_Declare(
     hptt
     GIT_REPOSITORY https://github.com/Einsums/hptt.git
-    GIT_TAG v1.0.5+22
+    GIT_TAG v1.0.5+23
     OVERRIDE_FIND_PACKAGE
     )
   #FetchContent_MakeAvailable(hptt)  # alternative to below is to add_subdirectory(hptt EXCLUDE_FROM_ALL)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -89,6 +89,12 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(h5cpp)
 
 add_library(Einsums_h5cpp INTERFACE)
+add_library("${ein}::h5cpp" ALIAS Einsums_h5cpp)
+set_target_properties(
+  Einsums_h5cpp
+  PROPERTIES
+    EXPORT_NAME h5cpp
+  )
 target_include_directories(
   Einsums_h5cpp
   SYSTEM  # supress warnings

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -12,8 +12,8 @@ include(FetchContent)
 if(EINSUMS_ENABLE_TESTING)
   FetchContent_Declare(
     catch2
-    GIT_REPOSITORY https://github.com/catchorg/Catch2.git
-    GIT_TAG v3.4.0
+    URL https://github.com/catchorg/Catch2/archive/v3.4.0.tar.gz
+    URL_HASH SHA256=122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb
     FIND_PACKAGE_ARGS 3 NAMES Catch2 GLOBAL)
 
   FetchContent_MakeAvailable(catch2)
@@ -22,8 +22,8 @@ endif()
 # <<< range-v3 >>>
 FetchContent_Declare(
   rangev3
-  GIT_REPOSITORY https://github.com/ericniebler/range-v3.git
-  GIT_TAG 0.12.0
+  URL https://github.com/ericniebler/range-v3/archive/0.12.0.tar.gz
+  URL_HASH SHA256=015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb
   FIND_PACKAGE_ARGS 0.12.0 NAMES range-v3 GLOBAL)
 # note that upstream uses `write_basic_package_version_file(... COMPATIBILITY
 # ExactVersion)` so no version range of compatibilty can be expressed here.
@@ -33,8 +33,8 @@ FetchContent_MakeAvailable(rangev3)
 # <<< fmt >>>
 FetchContent_Declare(
   fmt
-  GIT_REPOSITORY https://github.com/fmtlib/fmt.git
-  GIT_TAG 10.1.0
+  URL https://github.com/fmtlib/fmt/archive/10.1.0.tar.gz
+  URL_HASH SHA256=deb0a3ad2f5126658f2eefac7bf56a042488292de3d7a313526d667f3240ca0a
   FIND_PACKAGE_ARGS 10.1 GLOBAL)
 
 FetchContent_MakeAvailable(fmt)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -103,6 +103,14 @@ target_link_libraries(
     ZLIB::ZLIB
   )
 
+install(
+  DIRECTORY
+    ${h5cpp_SOURCE_DIR}/h5cpp
+  COMPONENT ${ein}_Development
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/einsums
+  )
+
+
 # <<< hptt >> Not using hptt is just asking for slow sorts.
 if(EINSUMS_USE_HPTT)
   FetchContent_Declare(

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -241,6 +241,8 @@ if (NOT LAPACKE_FOUND)
     message(WARNING "Reverting to pre-defined include/cblas_mangling.h")
     configure_file(${netlib_SOURCE_DIR}/CBLAS/include/cblas_mangling_with_flags.h.in
                    ${netlib_SOURCE_DIR}/CBLAS/include/cblas_mangling.h)
+    configure_file(${netlib_SOURCE_DIR}/LAPACKE/include/lapacke_mangling_with_flags.h.in
+                   ${netlib_SOURCE_DIR}/LAPACKE/include/lapacke_mangling.h)
 endif()
 
 extend_einsums_target(einsums

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2977,3 +2977,72 @@ extend_einsums_target(einsums
         ../utils/lapacke_z_nancheck.c
         ../utils/lapacke_ztr_trans.c
 )
+
+# <<<  Install & Export  >>>
+
+include(CMakePackageConfigHelpers)
+
+install(
+  DIRECTORY
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/
+  TYPE INCLUDE
+  COMPONENT ${ein}_Development
+  FILES_MATCHING
+    PATTERN "*.h"
+    PATTERN "*.hpp"
+  )
+
+install(
+  TARGETS
+    einsums
+    Einsums_h5cpp
+  EXPORT primary_set
+  RUNTIME
+    COMPONENT ${ein}_Runtime
+  LIBRARY
+    COMPONENT ${ein}_Runtime
+    NAMELINK_COMPONENT ${ein}_Development
+  ARCHIVE
+    COMPONENT ${ein}_Development
+  PUBLIC_HEADER
+    COMPONENT ${ein}_Development
+  INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+  )
+
+install(
+  EXPORT primary_set
+  FILE "${ein}Targets-CXX.cmake"
+  NAMESPACE "${ein}::"
+  DESTINATION ${EINSUMS_INSTALL_CMAKEDIR}
+  COMPONENT ${ein}_Development
+  )
+
+configure_package_config_file(
+  ../cmake/${ein}Config.cmake.in
+  "${CMAKE_CURRENT_BINARY_DIR}/${ein}Config.cmake"
+  INSTALL_DESTINATION ${EINSUMS_INSTALL_CMAKEDIR}
+  NO_SET_AND_CHECK_MACRO
+  )
+write_basic_package_version_file(
+  ${CMAKE_CURRENT_BINARY_DIR}/${ein}ConfigVersion.cmake
+  VERSION ${Einsums_VERSION}
+  COMPATIBILITY SameMinorVersion
+  )
+install(
+  FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/${ein}Config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/${ein}ConfigVersion.cmake
+  DESTINATION ${EINSUMS_INSTALL_CMAKEDIR}
+  COMPONENT ${ein}_Development
+  )
+
+#include(JoinPaths)
+#join_paths(libdir_for_pc_file "\${exec_prefix}" "${CMAKE_INSTALL_LIBDIR}")
+#join_paths(includedir_for_pc_file "\${prefix}" "${CMAKE_INSTALL_INCLUDEDIR}")
+#
+#configure_file(cmake/libint2.pc.cmake.in libint2.pc @ONLY)
+#install(
+#  FILES ${CMAKE_CURRENT_BINARY_DIR}/libint2.pc
+#  DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig/
+#  COMPONENT ${L2}_Development
+#  )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,7 +20,7 @@ add_einsums_library(einsums
     PUBLIC_DEPENDS
         range-v3::range-v3
         fmt::fmt
-        Einsums_h5cpp
+        Einsums::h5cpp
 )
 
 # extend_einsums_target(einsums
@@ -2994,10 +2994,15 @@ install(
     PATTERN "*.hpp"
   )
 
+if (TARGET hptt::hptt)
+    set(tgts einsums Einsums_h5cpp hptt)
+else()
+    set(tgts einsums Einsums_h5cpp)
+endif()
+
 install(
   TARGETS
-    einsums
-    Einsums_h5cpp
+    ${tgts}
   EXPORT primary_set
   RUNTIME
     COMPONENT ${ein}_Runtime

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2994,10 +2994,15 @@ install(
     PATTERN "*.hpp"
   )
 
+set(tgts einsums Einsums_h5cpp)
 if (TARGET hptt::hptt)
-    set(tgts einsums Einsums_h5cpp hptt)
-else()
-    set(tgts einsums Einsums_h5cpp)
+    list(APPEND tgts hptt)
+endif()
+if(TARGET cblas)
+    list(APPEND tgts cblas)
+endif()
+if(TARGET lapacke)
+    list(APPEND tgts lapacke)
 endif()
 
 install(


### PR DESCRIPTION
- [x] moves git_repository to url for downloads, as sometimes services only accept the latter
- [x] add icpx to build matrix (2 lanes)
- [x] add L-src lane that builds lots from src by disabling FIND_PACKAGE_ARGS
- [x] make sure `Release`, not `""` is default build type
- [x] add option to direct config.cmake install file and install it and the target and version files
- [x] get basic install working, albeit outside the EinsumsAPI structure.