### PR TITLE
regularize external deps

### DIFF
--- a/cmake/EinsumsAPIInternal.cmake
+++ b/cmake/EinsumsAPIInternal.cmake
@@ -99,7 +99,7 @@ function(add_einsums_depends target_name)
     else()
         list(APPEND object_lib_depends ${depends})
         list(APPEND object_public_depends ${public_depends})
-     endif()
+    endif()
 
     foreach(obj_lib IN LISTS object_lib_depends)
         target_compile_options(${target_name} PRIVATE $<TARGET_PROPERTY:${obj_lib},INTERFACE_COMPILE_OPTIONS>)

--- a/cmake/EinsumsConfig.cmake.in
+++ b/cmake/EinsumsConfig.cmake.in
@@ -5,7 +5,7 @@
 # Variables like Einsums_LIBRARIES and Einsums_INCLUDE_DIRS *are not set* as targets are preferred.
 # This module sets the following variables in your project::
 #
-#   Einsums_FOUND - true if ambit and all required components found on the system
+#   Einsums_FOUND - true if Einsums and all required components found on the system
 #   Einsums_VERSION - Einsums version in format Major.Minor.Release. Prefer target variable.
 #
 #
@@ -13,10 +13,9 @@
 #
 # It is preferred to use properties set on the base target rather than using the above variables. ::
 #
-##   ambit_VERSION - ambit version in format Major.Minor.Release
-##   ambit_PYMOD - path to ambit python module (suitable for appending PYTHONPATH). Only on pyambit target.
-##
-##   get_property(_ver TARGET ambit::ambit PROPERTY ambit_VERSION)
+#   Einsums_VERSION - Einsums version in format Major.Minor.Release
+#
+#   get_property(_ver TARGET Einsums::einsums PROPERTY Einsums_VERSION)
 #
 #
 # Available components: shared static hptt lp64 ilp64 ::

--- a/cmake/FindCBLAS.cmake
+++ b/cmake/FindCBLAS.cmake
@@ -36,7 +36,7 @@ else()
 
         find_package_handle_standard_args(CBLAS DEFAULT_MSG CBLAS_LIBRARIES CBLAS_INCLUDE_DIRS)
 
-        if (CBLAS_FOUND)
+        if (CBLAS_FOUND AND NOT (TARGET cblas))
             message(STATUS "Found components for CBLAS.")
 
             add_library(cblas INTERFACE)

--- a/cmake/FindLAPACKE.cmake
+++ b/cmake/FindLAPACKE.cmake
@@ -32,7 +32,7 @@ else()
 
         find_package_handle_standard_args(LAPACKE DEFAULT_MSG LAPACKE_LIBRARIES LAPACKE_INCLUDE_DIRS)
 
-        if (LAPACKE_FOUND)
+        if (LAPACKE_FOUND AND NOT (TARGET lapacke))
             set(HAVE_LAPACKE_H TRUE)
 
             message(STATUS "Found components for LAPACKE.")

--- a/cmake/FindTargetLAPACK.cmake
+++ b/cmake/FindTargetLAPACK.cmake
@@ -93,7 +93,7 @@ else()
 
                 else()
                     set(BLA_VENDOR Generic)
-                    set(BLA_SIZEOF_INTEGER Any)
+                    set(BLA_SIZEOF_INTEGER ANY)
                     find_package(BLAS MODULE)
                     find_package(LAPACK MODULE)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -34,8 +34,8 @@ if(EINSUMS_USE_HPTT)
 endif()
 
 if(EINSUMS_ENABLE_TESTING)
-    FetchContent_MakeAvailable(catch2)
+    FetchContent_MakeAvailable(Catch2)
 endif()
-FetchContent_MakeAvailable(rangev3)
+FetchContent_MakeAvailable(range-v3)
 FetchContent_MakeAvailable(fmt)
 

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -2,16 +2,24 @@ include(FetchContent)
 
 # <<<  general notes  >>>
 
-# * URL preferred over GIT_REPOSITORY
+# * URL preferred over GIT_REPOSITORY+GIT_TAG
 # * commit or permanent tag preferred over branch name for traceability
 # * to get the URL_HASH, run `curl -sL <URL> | openssl sha256`
 # * to use local source, put path in URL: `URL "/psi/gits/h5cpp"`
+# * generally, do all FetchContent_Declare before any FetchContent_MakeAvailable
+#   to allow for negotiation for any shared deps-of-deps. in practice,
+#   we MakeAvailable hptt in its own dir to suppress install and h5cpp in its
+#   own dir to collect build and install commands.
 
 if(EINSUMS_ENABLE_TESTING)
     add_subdirectory(catch2)
 endif()
+
 add_subdirectory(fmt)
+
 add_subdirectory(rangev3)
+
+add_subdirectory(netlib)
 
 find_package(ZLIB REQUIRED)
 find_package(TargetHDF5 REQUIRED)
@@ -19,14 +27,6 @@ find_package(TargetHDF5 REQUIRED)
 set(TargetHDF5_VERSION_Mm ${TargetHDF5_VERSION_Mm} PARENT_SCOPE)
 
 add_subdirectory(h5cpp)
-
-add_subdirectory(netlib)
-
-FetchContent_MakeAvailable(netlib)
-set(netlib_SOURCE_DIR
-    "${netlib_SOURCE_DIR}"
-    PARENT_SCOPE)
-
 
 if(EINSUMS_USE_HPTT)
     # EXCLUDE_FROM_ALL to suppress install
@@ -36,6 +36,11 @@ endif()
 if(EINSUMS_ENABLE_TESTING)
     FetchContent_MakeAvailable(Catch2)
 endif()
-FetchContent_MakeAvailable(range-v3)
+
 FetchContent_MakeAvailable(fmt)
 
+FetchContent_MakeAvailable(range-v3)
+
+FetchContent_MakeAvailable(netlib)
+# promote netlib src scope so that src/CM can build it
+set(netlib_SOURCE_DIR "${netlib_SOURCE_DIR}" PARENT_SCOPE)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -7,50 +7,14 @@ include(FetchContent)
 # * to get the URL_HASH, run `curl -sL <URL> | openssl sha256`
 # * to use local source, put path in URL: `URL "/psi/gits/h5cpp"`
 
-
-# <<< Catch2 >>>
 if(EINSUMS_ENABLE_TESTING)
-  FetchContent_Declare(
-    catch2
-    URL https://github.com/catchorg/Catch2/archive/v3.4.0.tar.gz
-    URL_HASH SHA256=122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb
-    FIND_PACKAGE_ARGS 3 NAMES Catch2 GLOBAL)
-
-  FetchContent_MakeAvailable(catch2)
+    add_subdirectory(catch2)
 endif()
+add_subdirectory(fmt)
+add_subdirectory(rangev3)
+add_subdirectory(h5cpp)
 
-# <<< range-v3 >>>
-FetchContent_Declare(
-  rangev3
-  URL https://github.com/ericniebler/range-v3/archive/0.12.0.tar.gz
-  URL_HASH SHA256=015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb
-  FIND_PACKAGE_ARGS 0.12.0 NAMES range-v3 GLOBAL)
-# note that upstream uses `write_basic_package_version_file(... COMPATIBILITY
-# ExactVersion)` so no version range of compatibilty can be expressed here.
-
-FetchContent_MakeAvailable(rangev3)
-
-# <<< fmt >>>
-FetchContent_Declare(
-  fmt
-  URL https://github.com/fmtlib/fmt/archive/10.1.0.tar.gz
-  URL_HASH SHA256=deb0a3ad2f5126658f2eefac7bf56a042488292de3d7a313526d667f3240ca0a
-  FIND_PACKAGE_ARGS 10.1 GLOBAL)
-
-FetchContent_MakeAvailable(fmt)
-
-# <<<  CBLAS/LAPACKE  >>>
-# * note nonexistant SOURCE_SUBDIR here so it fetches over the source but
-#   doesn't try to build it. Still built by local src/CMakeLists.txt . Could
-#   have done the same w/FetchContent_Populate instead of
-#   FetchContent_MakeAvailable but only the latter integrates w/find_package.
-
-FetchContent_Declare(
-  netlib
-  URL https://github.com/Reference-LAPACK/lapack/archive/v3.11.0.tar.gz
-  URL_HASH
-    SHA256=4b9ba79bfd4921ca820e83979db76ab3363155709444a787979e81c22285ffa9
-  SOURCE_SUBDIR fake FIND_PACKAGE_ARGS MODULE)
+add_subdirectory(netlib)
 
 FetchContent_MakeAvailable(netlib)
 set(netlib_SOURCE_DIR
@@ -72,23 +36,11 @@ find_package(ZLIB REQUIRED)
 find_package(TargetHDF5 REQUIRED)
 set(TargetHDF5_VERSION_Mm ${TargetHDF5_VERSION_Mm} PARENT_SCOPE)
 
+if(EINSUMS_USE_HPTT)
+    # EXCLUDE_FROM_ALL to suppress install
+    add_subdirectory(hptt EXCLUDE_FROM_ALL)
+endif()
 
-# <<< h5cpp >>>
-
-# * v1.10.4-6-EAT6 on EAT branch is upstream v1.10.4-6 tag +2, so last upstream tag
-#   plus extended array dimensions to support higher rank tensors plus deleter stuff.
-# * find_package() is disabled since we need patched source
-# * upstream CMakeLists.txt isn't useable and project is header-only, so to keep code
-#   changes and build changes separate, we won't let FetchContent build (`SOURCE_SUBDIR
-#   fake`) and will create the interface Einsums_h5cpp target after download.
-
-FetchContent_Declare(
-  h5cpp
-  URL https://github.com/Einsums/h5cpp/archive/v1.10.4-6-EAT6.tar.gz
-  URL_HASH SHA256=bc6370d2a2b11d9208c53d7815c2fbcfefc09f509f3a9f4d9cbd76a8c442feac
-  SOURCE_SUBDIR fake
-  OVERRIDE_FIND_PACKAGE
-  )
 FetchContent_MakeAvailable(h5cpp)
 
 add_library(Einsums_h5cpp INTERFACE)
@@ -120,22 +72,9 @@ install(
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/einsums
   )
 
-
-# <<< hptt >>>
-
-# * Not using hptt is just asking for slow sorts.
-
-if(EINSUMS_USE_HPTT)
-  FetchContent_Declare(
-    hptt
-    GIT_REPOSITORY https://github.com/Einsums/hptt.git
-    GIT_TAG v1.0.5+23
-    OVERRIDE_FIND_PACKAGE
-    )
-  #FetchContent_MakeAvailable(hptt)  # alternative to below is to add_subdirectory(hptt EXCLUDE_FROM_ALL)
-  FetchContent_GetProperties(hptt)
-  if(NOT hptt_POPULATED)
-    FetchContent_Populate(hptt)
-    add_subdirectory(${hptt_SOURCE_DIR} ${hptt_BINARY_DIR} EXCLUDE_FROM_ALL)
-  endif()
+if(EINSUMS_ENABLE_TESTING)
+    FetchContent_MakeAvailable(catch2)
 endif()
+FetchContent_MakeAvailable(rangev3)
+FetchContent_MakeAvailable(fmt)
+

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -12,6 +12,12 @@ if(EINSUMS_ENABLE_TESTING)
 endif()
 add_subdirectory(fmt)
 add_subdirectory(rangev3)
+
+find_package(ZLIB REQUIRED)
+find_package(TargetHDF5 REQUIRED)
+# promote Mm version's scope so that it can be baked into EinsumsConfig
+set(TargetHDF5_VERSION_Mm ${TargetHDF5_VERSION_Mm} PARENT_SCOPE)
+
 add_subdirectory(h5cpp)
 
 add_subdirectory(netlib)
@@ -20,57 +26,12 @@ FetchContent_MakeAvailable(netlib)
 set(netlib_SOURCE_DIR
     "${netlib_SOURCE_DIR}"
     PARENT_SCOPE)
-set(CBLAS_FOUND
-    "${CBLAS_FOUND}"
-    PARENT_SCOPE)
-set(LAPACKE_FOUND
-    "${LAPACKE_FOUND}"
-    PARENT_SCOPE)
 
-
-# <<<  HDF5  >>>
-
-# * promote Mm version's scope so that it can be baked into EinsumsConfig
-
-find_package(ZLIB REQUIRED)
-find_package(TargetHDF5 REQUIRED)
-set(TargetHDF5_VERSION_Mm ${TargetHDF5_VERSION_Mm} PARENT_SCOPE)
 
 if(EINSUMS_USE_HPTT)
     # EXCLUDE_FROM_ALL to suppress install
     add_subdirectory(hptt EXCLUDE_FROM_ALL)
 endif()
-
-FetchContent_MakeAvailable(h5cpp)
-
-add_library(Einsums_h5cpp INTERFACE)
-add_library("${ein}::h5cpp" ALIAS Einsums_h5cpp)
-set_target_properties(
-  Einsums_h5cpp
-  PROPERTIES
-    EXPORT_NAME h5cpp
-  )
-target_include_directories(
-  Einsums_h5cpp
-  SYSTEM  # supress warnings
-  INTERFACE
-    $<BUILD_INTERFACE:${h5cpp_SOURCE_DIR}>
-    # TODO return to this when build headers adjusted   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
-    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/einsums>
-  )
-target_link_libraries(
-  Einsums_h5cpp
-  INTERFACE
-    tgt::hdf5
-    ZLIB::ZLIB
-  )
-
-install(
-  DIRECTORY
-    ${h5cpp_SOURCE_DIR}/h5cpp
-  COMPONENT ${ein}_Development
-  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/einsums
-  )
 
 if(EINSUMS_ENABLE_TESTING)
     FetchContent_MakeAvailable(catch2)

--- a/external/catch2/CMakeLists.txt
+++ b/external/catch2/CMakeLists.txt
@@ -1,0 +1,6 @@
+FetchContent_Declare(
+  catch2
+  URL https://github.com/catchorg/Catch2/archive/v3.4.0.tar.gz
+  URL_HASH SHA256=122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb
+  FIND_PACKAGE_ARGS 3 NAMES Catch2
+  )

--- a/external/catch2/CMakeLists.txt
+++ b/external/catch2/CMakeLists.txt
@@ -1,6 +1,6 @@
 FetchContent_Declare(
-  catch2
+  Catch2
   URL https://github.com/catchorg/Catch2/archive/v3.4.0.tar.gz
   URL_HASH SHA256=122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb
-  FIND_PACKAGE_ARGS 3 NAMES Catch2
+  FIND_PACKAGE_ARGS 3
   )

--- a/external/fmt/CMakeLists.txt
+++ b/external/fmt/CMakeLists.txt
@@ -1,0 +1,7 @@
+FetchContent_Declare(
+  fmt
+  URL https://github.com/fmtlib/fmt/archive/10.1.0.tar.gz
+  URL_HASH SHA256=deb0a3ad2f5126658f2eefac7bf56a042488292de3d7a313526d667f3240ca0a
+  FIND_PACKAGE_ARGS 10.1
+  )
+

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -10,6 +10,37 @@ FetchContent_Declare(
   URL https://github.com/Einsums/h5cpp/archive/v1.10.4-6-EAT6.tar.gz
   URL_HASH SHA256=bc6370d2a2b11d9208c53d7815c2fbcfefc09f509f3a9f4d9cbd76a8c442feac
   SOURCE_SUBDIR fake
+  SYSTEM
   OVERRIDE_FIND_PACKAGE
+  )
+
+FetchContent_MakeAvailable(h5cpp)
+
+add_library(Einsums_h5cpp INTERFACE)
+add_library("${ein}::h5cpp" ALIAS Einsums_h5cpp)
+set_target_properties(
+  Einsums_h5cpp
+  PROPERTIES
+    EXPORT_NAME h5cpp
+  )
+target_include_directories(
+  Einsums_h5cpp
+  INTERFACE
+    $<BUILD_INTERFACE:${h5cpp_SOURCE_DIR}>
+    # TODO return to this when build headers adjusted   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/einsums>
+  )
+target_link_libraries(
+  Einsums_h5cpp
+  INTERFACE
+    tgt::hdf5
+    ZLIB::ZLIB
+  )
+
+install(
+  DIRECTORY
+    ${h5cpp_SOURCE_DIR}/h5cpp
+  COMPONENT ${ein}_Development
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/einsums
   )
 

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -28,6 +28,8 @@ set_target_properties(
   )
 target_include_directories(
   Einsums_h5cpp
+  # SYSTEM suppresses "error: non-constant-expression cannot be narrowed" for some compilers
+  SYSTEM
   INTERFACE
     $<BUILD_INTERFACE:${h5cpp_SOURCE_DIR}>
     # TODO return to this when build headers adjusted   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -18,7 +18,7 @@ FetchContent_MakeAvailable(h5cpp)
 
 add_library(Einsums_h5cpp INTERFACE)
 add_library("${ein}::h5cpp" ALIAS Einsums_h5cpp)
-target_compile_features(Einsums_h5cpp PUBLIC cxx_std_17)
+target_compile_features(Einsums_h5cpp INTERFACE cxx_std_17)
 set_target_properties(
   Einsums_h5cpp
   PROPERTIES

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -1,0 +1,15 @@
+# * v1.10.4-6-EAT6 on EAT branch is upstream v1.10.4-6 tag +2, so last upstream tag
+#   plus extended array dimensions to support higher rank tensors plus deleter stuff.
+# * find_package() is disabled since we need patched source
+# * upstream CMakeLists.txt isn't useable and project is header-only, so to keep code
+#   changes and build changes separate, we won't let FetchContent build (`SOURCE_SUBDIR
+#   fake`) and will create the interface Einsums_h5cpp target after download.
+
+FetchContent_Declare(
+  h5cpp
+  URL https://github.com/Einsums/h5cpp/archive/v1.10.4-6-EAT6.tar.gz
+  URL_HASH SHA256=bc6370d2a2b11d9208c53d7815c2fbcfefc09f509f3a9f4d9cbd76a8c442feac
+  SOURCE_SUBDIR fake
+  OVERRIDE_FIND_PACKAGE
+  )
+

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -18,6 +18,7 @@ FetchContent_MakeAvailable(h5cpp)
 
 add_library(Einsums_h5cpp INTERFACE)
 add_library("${ein}::h5cpp" ALIAS Einsums_h5cpp)
+target_compile_features(Einsums_h5cpp PUBLIC cxx_std_17)
 set_target_properties(
   Einsums_h5cpp
   PROPERTIES
@@ -25,6 +26,7 @@ set_target_properties(
   )
 target_include_directories(
   Einsums_h5cpp
+  SYSTEM  # supress warnings
   INTERFACE
     $<BUILD_INTERFACE:${h5cpp_SOURCE_DIR}>
     # TODO return to this when build headers adjusted   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -4,6 +4,8 @@
 # * upstream CMakeLists.txt isn't useable and project is header-only, so to keep code
 #   changes and build changes separate, we won't let FetchContent build (`SOURCE_SUBDIR
 #   fake`) and will create the interface Einsums_h5cpp target after download.
+# * MakeAvailable called here so that install (of vendored headers into einsums namespace)
+#   can be localized into this file.
 
 FetchContent_Declare(
   h5cpp

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -20,7 +20,7 @@ FetchContent_MakeAvailable(h5cpp)
 
 add_library(Einsums_h5cpp INTERFACE)
 add_library("${ein}::h5cpp" ALIAS Einsums_h5cpp)
-target_compile_features(Einsums_h5cpp INTERFACE cxx_std_17)
+
 set_target_properties(
   Einsums_h5cpp
   PROPERTIES
@@ -28,7 +28,7 @@ set_target_properties(
   )
 target_include_directories(
   Einsums_h5cpp
-  SYSTEM  # supress warnings
+  SYSTEM  # suppress warnings
   INTERFACE
     $<BUILD_INTERFACE:${h5cpp_SOURCE_DIR}>
     # TODO return to this when build headers adjusted   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -28,7 +28,6 @@ set_target_properties(
   )
 target_include_directories(
   Einsums_h5cpp
-  SYSTEM  # suppress warnings
   INTERFACE
     $<BUILD_INTERFACE:${h5cpp_SOURCE_DIR}>
     # TODO return to this when build headers adjusted   $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>

--- a/external/hptt/CMakeLists.txt
+++ b/external/hptt/CMakeLists.txt
@@ -4,7 +4,7 @@
 FetchContent_Declare(
   hptt
   GIT_REPOSITORY https://github.com/Einsums/hptt.git
-  GIT_TAG v1.0.5+23
+  GIT_TAG v1.0.5+24
   SYSTEM
   OVERRIDE_FIND_PACKAGE
   )

--- a/external/hptt/CMakeLists.txt
+++ b/external/hptt/CMakeLists.txt
@@ -1,10 +1,11 @@
 # * Not using hptt is just asking for slow sorts.
 # * find_package() is disabled since we need patched source
+# * hptt is built as an object library and not installed
 
 FetchContent_Declare(
   hptt
-  GIT_REPOSITORY https://github.com/Einsums/hptt.git
-  GIT_TAG v1.0.5+24
+  URL https://github.com/Einsums/hptt/archive/v1.0.5+24.tar.gz
+  URL_HASH SHA256=6cfe70bbd026005e059d0a4031c21eb6ac7c2d14f6e1914cc2b8c9ce2a8b616d
   SYSTEM
   OVERRIDE_FIND_PACKAGE
   )

--- a/external/hptt/CMakeLists.txt
+++ b/external/hptt/CMakeLists.txt
@@ -1,0 +1,12 @@
+# * Not using hptt is just asking for slow sorts.
+# * find_package() is disabled since we need patched source
+
+FetchContent_Declare(
+  hptt
+  GIT_REPOSITORY https://github.com/Einsums/hptt.git
+  GIT_TAG v1.0.5+23
+  SYSTEM
+  OVERRIDE_FIND_PACKAGE
+  )
+
+FetchContent_MakeAvailable(hptt)

--- a/external/netlib/CMakeLists.txt
+++ b/external/netlib/CMakeLists.txt
@@ -1,0 +1,14 @@
+# <<<  CBLAS/LAPACKE  >>>
+# * note nonexistant SOURCE_SUBDIR here so it fetches over the source but
+#   doesn't try to build it. Still built by local src/CMakeLists.txt . Could
+#   have done the same w/FetchContent_Populate instead of
+#   FetchContent_MakeAvailable but only the latter integrates w/find_package.
+
+FetchContent_Declare(
+  netlib
+  URL https://github.com/Reference-LAPACK/lapack/archive/v3.11.0.tar.gz
+  URL_HASH SHA256=4b9ba79bfd4921ca820e83979db76ab3363155709444a787979e81c22285ffa9
+  SOURCE_SUBDIR fake
+  FIND_PACKAGE_ARGS MODULE
+  )
+

--- a/external/rangev3/CMakeLists.txt
+++ b/external/rangev3/CMakeLists.txt
@@ -2,8 +2,8 @@
 #   ExactVersion)` so no version range of compatibilty can be expressed here.
 
 FetchContent_Declare(
-  rangev3
+  range-v3
   URL https://github.com/ericniebler/range-v3/archive/0.12.0.tar.gz
   URL_HASH SHA256=015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb
-  FIND_PACKAGE_ARGS 0.12.0 NAMES range-v3
+  FIND_PACKAGE_ARGS 0.12.0
   )

--- a/external/rangev3/CMakeLists.txt
+++ b/external/rangev3/CMakeLists.txt
@@ -1,0 +1,9 @@
+# * note that upstream uses `write_basic_package_version_file(... COMPATIBILITY
+#   ExactVersion)` so no version range of compatibilty can be expressed here.
+
+FetchContent_Declare(
+  rangev3
+  URL https://github.com/ericniebler/range-v3/archive/0.12.0.tar.gz
+  URL_HASH SHA256=015adb2300a98edfceaf0725beec3337f542af4915cec4d0b89fa0886f4ba9cb
+  FIND_PACKAGE_ARGS 0.12.0 NAMES range-v3
+  )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -226,6 +226,7 @@ endforeach()
 
 # Include downloaded cblas if it wasn't found installed. We require a
 # Fortran compiler for it.
+find_package(netlib)
 if (NOT CBLAS_FOUND)
     enable_language(Fortran)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,3 +1,6 @@
+find_package(range-v3)
+find_package(fmt)
+
 add_einsums_library(einsums
     SOURCES
         Blas.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,7 @@ target_compile_definitions(test-all
         EINSUMS_CONTINUOUSLY_TEST_EINSUM
         TEST_PATH="${CMAKE_CURRENT_LIST_DIR}"    
 )
+find_package(Catch2)
 target_link_libraries(test-all Catch2::Catch2 einsums)
 
 include(CTest)


### PR DESCRIPTION
- [x] try to organize the external/ folder based on https://discourse.cmake.org/t/fetchcontent-cache-variables/1538/8 guidance. Basically, 
 * all FC_Declare before any FC_MakeAvailable
 * put each in its own dir so one can set variables to affect build w/o side effects (though variables need to be around FC_MakeAvailable, not FC_Declare, so I'm still not sure if it's right.
 * after FC_MakeAvailable, any find_package finds it whether FC detected prebuilt or built from src, so introduce targets to the scope that needs them by later find_package calls, not by global scoping in the external/ dir.
- [x] I changed the `FetchContent_Declare(pkg)` back to the canonical capitalizations. authority of Scott's book (31.5 15th Ed.)
```
If a project calls FetchContent_Declare():
◦ Add the FIND_PACKAGE_ARGS keyword if the dependency package meets the criteria for being consumed that way. If CMake versions earlier than 3.24 need to be supported, use a CMake version test to add it conditionally.
◦ Reserve OVERRIDE_FIND_PACKAGE for meeting strict requirements in controlled environments (e.g. where dependencies must be built from source, or a particular patched version needs to be used).
◦ Use the same dependency name as would be used for find_package(), including upper/lowercase.
```
- [x] Fix the "Any" misspelling in findlapack
- [x] Find*cmake modules should only create a target if it doesn't already exist