### PR TITLE
add hptt and h5cpp licenses

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ einsums_option(EINSUMS_ENABLE_TESTING BOOL "Build testing (requires Catch2)"
 einsums_option(EINSUMS_INSTALL_CMAKEDIR STRING
                "Directory to which Einsums CMake config files installed."
                share/cmake/Einsums)
+einsums_option(EINSUMS_H5CPP_USE_OMP_ALIGNED_ALLOC BOOL
+               "On Mac, use omp_aligned_alloc instead of aligned_alloc. Helpful for old SDK." OFF)
 
 add_feature_info(
   EINSUMS_CONTINUOUSLY_TEST_EINSUM ${EINSUMS_CONTINUOUSLY_TEST_EINSUM}

--- a/THIRD-PARTY-LICENSES
+++ b/THIRD-PARTY-LICENSES
@@ -1,0 +1,86 @@
+This project incorporates material from the project(s) listed below
+(collectively, "Third Party Code"). Einsums is not the original author
+of the Third Party Code. The original copyright notice and license under
+which Einsums received such Third Party Code are set out below. This
+Third Party Code is licensed to you under their original license terms
+set forth below.
+
+
+<< 1 >> external/hptt
+
+Copyright 2018 Paul Springer
+
+BSD 3-Clause
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors
+   may be used to endorse or promote products derived from this software without
+   specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+<< 2 >> external/h5cpp
+
+ -------------------------------------------------------------------------------
+ H5CPP may be used for any purpose, including commercial purposes, at absolutely
+ no cost. It is distributed under  the terms of the MIT license reproduced here.
+
+ Copyright (c) 2018-2020 Steven Varga, Toronto,ON Canada
+ Author: Varga, Steven <steven@vargaconsulting.ca>
+ -------------------------------------------------------------------------------
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy of
+ this  software  and associated documentation files (the "Software"), to deal in
+ the Software  without   restriction, including without limitation the rights to
+ use, copy, modify, merge,  publish,  distribute, sublicense, and/or sell copies
+ of the Software, and to  permit persons to whom the Software is furnished to do
+ so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+
+ THE  SOFTWARE IS  PROVIDED  "AS IS",  WITHOUT  WARRANTY  OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT  SHALL THE AUTHORS OR
+ COPYRIGHT HOLDERS BE LIABLE FOR ANY  CLAIM,  DAMAGES OR OTHER LIABILITY, WHETHER
+ IN  AN  ACTION  OF  CONTRACT, TORT OR  OTHERWISE, ARISING  FROM,  OUT  OF  OR IN
+ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+ LLVM: University of Illinois/NCSA Open Source License
+ Copyright (c) 2003-2017 University of Illinois at Urbana-Champaign. All rights reserved.
+ see: LICENCE.LLVM
+
+ HDF5: HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+ Copyright (c) 2006, The HDF Group.
+
+ NCSA HDF5 (Hierarchical Data Format 5) Software Library and Utilities
+ Copyright (c) 1998-2006, The Board of Trustees of the University of Illinois. All rights reserved.
+ see: LICENCE.HDF5
+
+ HALF FLOAT: examples/half-float/christian-rau/half.hpp
+ Copyright (c) 2012-2019 Christian Rau
+ see: LICENSE.HALF-FLOAT
+
+ CSV: examples/csv/csv.h
+ Copyright (c) 2015, ben-strasser
+ see: LICENSE.CSV
+

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -10,7 +10,7 @@
 FetchContent_Declare(
   h5cpp
   URL https://github.com/loriab/h5cpp/archive/EAT_align.tar.gz
-  URL_HASH SHA256=72fa8338384223e2fc261b7700b8192010648fa38dc98f31bee3c03ae82a5cd8
+  URL_HASH SHA256=afdc47d62482643c26100be0902595010444af7ee478cc6fba87552ae3db5ea8
   SOURCE_SUBDIR fake
   SYSTEM
   OVERRIDE_FIND_PACKAGE

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -1,5 +1,6 @@
 # * v1.10.4-6-EAT6 on EAT branch is upstream v1.10.4-6 tag +2, so last upstream tag
 #   plus extended array dimensions to support higher rank tensors plus deleter stuff.
+#   * v1.10.4-6+3 Oct 2023 redirect aligned_alloc to omp_aligned_alloc
 # * find_package() is disabled since we need patched source
 # * upstream CMakeLists.txt isn't useable and project is header-only, so to keep code
 #   changes and build changes separate, we won't let FetchContent build (`SOURCE_SUBDIR
@@ -9,8 +10,8 @@
 
 FetchContent_Declare(
   h5cpp
-  URL https://github.com/loriab/h5cpp/archive/EAT_align.tar.gz
-  URL_HASH SHA256=12fc71709d01ee7e9d04d3c3de75696f3695b68ee63fd0f32734058e52dd5a7c
+  URL https://github.com/Einsums/h5cpp/archive/v1.10.4-6+3.tar.gz
+  URL_HASH SHA256=c790e38b3251fc2114c452858c85c86659aacb6037f24901bed55b72f6e2af03
   SOURCE_SUBDIR fake
   SYSTEM
   OVERRIDE_FIND_PACKAGE

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -10,7 +10,7 @@
 FetchContent_Declare(
   h5cpp
   URL https://github.com/loriab/h5cpp/archive/EAT_align.tar.gz
-  URL_HASH SHA256=afdc47d62482643c26100be0902595010444af7ee478cc6fba87552ae3db5ea8
+  URL_HASH SHA256=12fc71709d01ee7e9d04d3c3de75696f3695b68ee63fd0f32734058e52dd5a7c
   SOURCE_SUBDIR fake
   SYSTEM
   OVERRIDE_FIND_PACKAGE
@@ -21,6 +21,13 @@ FetchContent_MakeAvailable(h5cpp)
 add_library(Einsums_h5cpp INTERFACE)
 add_library("${ein}::h5cpp" ALIAS Einsums_h5cpp)
 
+if (EINSUMS_H5CPP_USE_OMP_ALIGNED_ALLOC)
+    target_compile_definitions(
+      Einsums_h5cpp
+      PRIVATE
+        $<BUILD_INTERFACE:H5CPP_USE_OMP_ALIGNED_ALLOC>
+      )
+endif()
 set_target_properties(
   Einsums_h5cpp
   PROPERTIES

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -9,8 +9,8 @@
 
 FetchContent_Declare(
   h5cpp
-  URL https://github.com/Einsums/h5cpp/archive/v1.10.4-6-EAT6.tar.gz
-  URL_HASH SHA256=bc6370d2a2b11d9208c53d7815c2fbcfefc09f509f3a9f4d9cbd76a8c442feac
+  URL https://github.com/loriab/h5cpp/archive/EAT_align.tar.gz
+  URL_HASH SHA256=72fa8338384223e2fc261b7700b8192010648fa38dc98f31bee3c03ae82a5cd8
   SOURCE_SUBDIR fake
   SYSTEM
   OVERRIDE_FIND_PACKAGE

--- a/external/h5cpp/CMakeLists.txt
+++ b/external/h5cpp/CMakeLists.txt
@@ -24,7 +24,7 @@ add_library("${ein}::h5cpp" ALIAS Einsums_h5cpp)
 if (EINSUMS_H5CPP_USE_OMP_ALIGNED_ALLOC)
     target_compile_definitions(
       Einsums_h5cpp
-      PRIVATE
+      INTERFACE
         $<BUILD_INTERFACE:H5CPP_USE_OMP_ALIGNED_ALLOC>
       )
 endif()


### PR DESCRIPTION
- [x] add hptt and h5cpp files in a 3rd party licenses file since sort-of vendoring them
- [x] add an option to build for really old osx sdk