### PR TITLE
Optimize some vector operations

### DIFF
--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -17,7 +17,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <stack>
+#include <deque>
 
 namespace einsums::timer {
 

--- a/src/Timer.cpp
+++ b/src/Timer.cpp
@@ -17,7 +17,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
-#include <vector>
+#include <stack>
 
 namespace einsums::timer {
 
@@ -37,7 +37,7 @@ struct TimerDetail {
 
     TimerDetail                       *parent{nullptr};
     std::map<std::string, TimerDetail> children;
-    std::vector<std::string>           order;
+    std::deque<std::string>           order;
 
     time_point start_time;
 };

--- a/src/include/einsums/BlockTensor.hpp
+++ b/src/include/einsums/BlockTensor.hpp
@@ -930,6 +930,8 @@ struct BlockDeviceTensor : public virtual tensor_props::BlockTensorBase<T, Rank,
     explicit BlockDeviceTensor(std::string name, detail::HostToDeviceMode mode, Dims... block_dims)
         : tensor_props::BlockTensorBase<T, Rank, DeviceTensor<T, Rank>>(name) {
 
+        this->_blocks.reserve(sizeof...(Dims));
+
         auto dims = std::array<size_t, sizeof...(Dims)>{static_cast<size_t>(block_dims)...};
 
         for (int i = 0; i < sizeof...(Dims); i++) {
@@ -963,6 +965,8 @@ struct BlockDeviceTensor : public virtual tensor_props::BlockTensorBase<T, Rank,
     template <typename ArrayArg>
     explicit BlockDeviceTensor(std::string name, detail::HostToDeviceMode mode, const ArrayArg &block_dims)
         : tensor_props::BlockTensorBase<T, Rank, DeviceTensor<T, Rank>>(name) {
+
+        this->_blocks.reserve(block_dims.size());
         for (int i = 0; i < block_dims.size(); i++) {
 
             Dim<Rank> pass_dims;
@@ -982,6 +986,7 @@ struct BlockDeviceTensor : public virtual tensor_props::BlockTensorBase<T, Rank,
     template <size_t Dims>
     explicit BlockDeviceTensor(detail::HostToDeviceMode mode, Dim<Dims> block_dims)
         : tensor_props::BlockTensorBase<T, Rank, DeviceTensor<T, Rank>>() {
+        this->_blocks.reserve(Dims);
         for (int i = 0; i < block_dims.size(); i++) {
 
             Dim<Rank> pass_dims;
@@ -1013,6 +1018,7 @@ struct BlockDeviceTensor : public virtual tensor_props::BlockTensorBase<T, Rank,
     template <typename... Dims>
         requires(NoneOfType<detail::HostToDeviceMode, Dims...>)
     explicit BlockDeviceTensor(std::string name, Dims... block_dims) : tensor_props::BlockTensorBase<T, Rank, DeviceTensor<T, Rank>>(name) {
+        this->_blocks.reserve(sizeof...(Dims));
 
         auto dims = std::array<size_t, sizeof...(Dims)>{static_cast<size_t>(block_dims)...};
 
@@ -1047,6 +1053,8 @@ struct BlockDeviceTensor : public virtual tensor_props::BlockTensorBase<T, Rank,
     template <typename ArrayArg>
     explicit BlockDeviceTensor(std::string name, const ArrayArg &block_dims)
         : tensor_props::BlockTensorBase<T, Rank, DeviceTensor<T, Rank>>(name) {
+        this->_blocks.reserve(block_dims.size());
+
         for (int i = 0; i < block_dims.size(); i++) {
 
             Dim<Rank> pass_dims;
@@ -1064,6 +1072,8 @@ struct BlockDeviceTensor : public virtual tensor_props::BlockTensorBase<T, Rank,
      */
     template <size_t Dims>
     explicit BlockDeviceTensor(Dim<Dims> block_dims) : tensor_props::BlockTensorBase<T, Rank, DeviceTensor<T, Rank>>() {
+        this->_blocks.reserve(Dims);
+        
         for (int i = 0; i < block_dims.size(); i++) {
 
             Dim<Rank> pass_dims;

--- a/src/include/einsums/BlockTensor.hpp
+++ b/src/include/einsums/BlockTensor.hpp
@@ -76,6 +76,7 @@ struct BlockTensorBase : public virtual CollectedTensorBase<T, Rank, TensorType>
      * @brief Construct a new BlockTensor object. Default copy constructor
      */
     BlockTensorBase(const BlockTensorBase &other) : _ranges{other._ranges}, _dims{other._dims}, _blocks{}, _dim{other._dim} {
+        _blocks.reserve(other._blocks.size());
         for (int i = 0; i < other._blocks.size(); i++) {
             _blocks.emplace_back((const TensorType &)other._blocks[i]);
         }
@@ -110,6 +111,7 @@ struct BlockTensorBase : public virtual CollectedTensorBase<T, Rank, TensorType>
         : _name{std::move(name)}, _dim{(static_cast<size_t>(block_dims) + ... + 0)}, _blocks(), _ranges(), _dims(sizeof...(Dims)) {
         auto dim_array   = Dim<sizeof...(Dims)>{block_dims...};
         auto _block_dims = Dim<Rank>();
+        _blocks.reserve(sizeof...(Dims));
 
         for (int i = 0; i < sizeof...(Dims); i++) {
             _block_dims.fill(dim_array[i]);
@@ -142,6 +144,7 @@ struct BlockTensorBase : public virtual CollectedTensorBase<T, Rank, TensorType>
         : _name{std::move(name)}, _dim{0}, _blocks(), _ranges(), _dims(block_dims.cbegin(), block_dims.cend()) {
 
         auto _block_dims = Dim<Rank>();
+        _blocks.reserve(block_dims.size());
 
         for (int i = 0; i < block_dims.size(); i++) {
             _block_dims.fill(block_dims[i]);
@@ -160,6 +163,8 @@ struct BlockTensorBase : public virtual CollectedTensorBase<T, Rank, TensorType>
     template <size_t Dims>
     explicit BlockTensorBase(Dim<Dims> block_dims) : _blocks(), _ranges(), _dims(block_dims) {
         auto _block_dims = Dim<Rank>();
+
+        _blocks.reserve(Dims);
 
         for (int i = 0; i < Dims; i++) {
             _block_dims.fill(_block_dims[i]);

--- a/src/include/einsums/Decomposition.hpp
+++ b/src/include/einsums/Decomposition.hpp
@@ -178,6 +178,7 @@ auto initialize_cp(std::vector<Tensor<TType, 2>> &folds, size_t rank) -> std::ve
     using namespace einsums::tensor_algebra::index;
 
     std::vector<Tensor<TType, 2>> factors;
+    factors.reserve(TRank);
 
     // Perform compile-time looping.
     for_sequence<TRank>([&](auto i) {
@@ -248,6 +249,7 @@ auto parafac(const TTensor<TType, TRank> &tensor, size_t rank, int n_iter_max = 
 
     // Compute set of unfolded matrices
     std::vector<Tensor<TType, 2>> unfolded_matrices;
+    unfolded_matrices.reserve(TRank);
     for_sequence<TRank>([&](auto i) { unfolded_matrices.push_back(tensor_algebra::unfold<i>(tensor)); });
 
     // Perform SVD guess for parafac decomposition procedure
@@ -345,6 +347,7 @@ auto weighted_parafac(const TTensor<TType, TRank> &tensor, const TTensor<TType, 
 
     // Compute set of unfolded matrices (unweighted)
     std::vector<Tensor<TType, 2>> unfolded_matrices;
+    unfolded_matrices.reserve(TRank);
     for_sequence<TRank>([&](auto i) { unfolded_matrices.push_back(tensor_algebra::unfold<i>(tensor)); });
 
     // Perform SVD guess for parafac decomposition procedure
@@ -532,6 +535,7 @@ auto tucker_ho_svd(const TTensor<TType, TRank> &tensor, std::vector<size_t> &ran
 
     // Compute set of unfolded matrices
     std::vector<Tensor<TType, 2>> unfolded_matrices;
+    unfolded_matrices.reserve(TRank);
     if (!folds.size()) {
         for_sequence<TRank>([&](auto i) { unfolded_matrices.push_back(tensor_algebra::unfold<i>(tensor)); });
     } else {
@@ -602,6 +606,7 @@ auto tucker_ho_oi(const TTensor<TType, TRank> &tensor, std::vector<size_t> &rank
     bool converged = false;
     while (iter < n_iter_max) {
         std::vector<Tensor<TType, 2>> new_folds;
+        new_folds.reserve(TRank);
 
         for_sequence<TRank>([&](auto i) {
             // Make the workspace for the contraction

--- a/src/include/einsums/Decomposition.hpp
+++ b/src/include/einsums/Decomposition.hpp
@@ -496,6 +496,7 @@ auto initialize_tucker(std::vector<Tensor<TType, 2>> &folds, std::vector<size_t>
     LabeledSection0();
 
     std::vector<Tensor<TType, 2>> factors;
+    factors.reserve(TRank);
 
     // Perform compile-time looping.
     for_sequence<TRank>([&](auto i) {

--- a/src/include/einsums/TiledTensor.hpp
+++ b/src/include/einsums/TiledTensor.hpp
@@ -89,7 +89,9 @@ struct TiledTensorBase : public virtual CollectedTensorBase<T, Rank, TensorType>
         }
         for (int i = 0; i < Rank; i++) {
             _tile_offsets[i] = std::vector<int>();
-            int sum          = 0;
+            _tile_offsets[i].reserve(_tile_sizes[i].size());
+
+            int sum = 0;
             for (int j = 0; j < _tile_sizes[i].size(); j++) {
                 _tile_offsets[i].push_back(sum);
                 sum += _tile_sizes[i].at(j);
@@ -110,6 +112,7 @@ struct TiledTensorBase : public virtual CollectedTensorBase<T, Rank, TensorType>
         _size = 1;
         for (int i = 0; i < Rank; i++) {
             _tile_offsets[i] = std::vector<int>();
+            _tile_offsets[i].reserve(_tile_sizes[i].size());
             int sum          = 0;
             for (int j = 0; j < _tile_sizes[i].size(); j++) {
                 _tile_offsets[i].push_back(sum);


### PR DESCRIPTION
Pushing to vectors can be slow if repeated due to repeated reallocations and copies. This pull reserves memory for vectors when applicable and when an upper bound is known. It also changes `TimerDetail` to use a deque instead of a vector for storing strings.