### PR TITLE
Add a way to create a tensor view of a pointer

### DIFF
--- a/docs/source/reference/function.create.tensors.rst
+++ b/docs/source/reference/function.create.tensors.rst
@@ -18,22 +18,22 @@ In Einsums, there are two-basic types of tensors: :cpp:class:`einsums::Tensor` a
 Tensor is an in-memory variant of a tensor and DiskTensor is an on-disk variant of a tensor. DiskTensor
 can and will use Tensors.
 
-.. doxygenfunction:: einsums::create_tensor(const std::string, Args...)
+.. doxygenfunction:: einsums::create_tensor(const std::string &, Args...)
 
-.. doxygenfunction:: einsums::create_disk_tensor(h5::fd_t&, const std::string, Args...)
+.. doxygenfunction:: einsums::create_disk_tensor
 
 .. doxygenfunction:: einsums::create_disk_tensor_like(h5::fd_t&, const Tensor<T, Rank>&)
 
 Functions for creating pre-filled tensors
 -----------------------------------------
 
-.. doxygenfunction:: einsums::create_incremented_tensor(const std::string&, MultiIndex...)
+.. doxygenfunction:: einsums::create_incremented_tensor
 
-.. doxygenfunction:: einsums::create_random_tensor(const std::string&, MultiIndex...)
+.. doxygenfunction:: einsums::create_random_tensor
 
-.. doxygenfunction:: einsums::create_identity_tensor(const std::string&, MultiIndex...)
+.. doxygenfunction:: einsums::create_identity_tensor
 
-.. doxygenfunction:: einsums::create_ones_tensor(const std::string&, MultiIndex...)
+.. doxygenfunction:: einsums::create_ones_tensor
 
 .. doxygenfunction:: einsums::create_tensor_like(const TensorType<DataType, Rank>&)
 

--- a/src/include/einsums/Tensor.hpp
+++ b/src/include/einsums/Tensor.hpp
@@ -17,6 +17,7 @@
 #include "einsums/utility/ComplexTraits.hpp"
 #include "einsums/utility/TensorBases.hpp"
 #include "einsums/utility/TensorTraits.hpp"
+#include "einsums/utility/IndexUtils.hpp"
 #include "range/v3/range_fwd.hpp"
 #include "range/v3/view/cartesian_product.hpp"
 #include "range/v3/view/iota.hpp"
@@ -1007,6 +1008,52 @@ struct TensorView final : public virtual tensor_props::CoreTensorBase,
         : _name{std::move(name)}, _dims{dim} {
         // println(" here 5");
         common_initialization(other, args...);
+    }
+
+    /**
+     * Wrap a const pointer in a tensor view, specifying the dimensions.
+     *
+     * @param data The pointer to wrap.
+     * @param dims The dimensions of the view.
+     */
+    explicit TensorView(const T *data, const Dim<Rank> &dims) : _data{const_cast<T *>(data)}, _dims(dims), _full_view_of_underlying{true} {
+        tensor_algebra::detail::dims_to_strides(dims, _strides);
+    }
+
+    /**
+     * Wrap a pointer in a tensor view, specifying the dimensions.
+     *
+     * @param data The pointer to wrap.
+     * @param dims The dimensions of the view.
+     */
+    explicit TensorView(T *data, const Dim<Rank> &dims) : _data{const_cast<T *>(data)}, _dims(dims), _full_view_of_underlying{true} {
+        tensor_algebra::detail::dims_to_strides(dims, _strides);
+    }
+
+    /**
+     * Wrap a const pointer in a tensor view, specifying the dimensions and strides.
+     *
+     * @param data The pointer to wrap.
+     * @param dims The dimensions of the view.
+     * @param strides The strides for the view.
+     */
+    explicit TensorView(const T *data, const Dim<Rank> &dims, const Stride<Rank> &strides) : _data{const_cast<T *>(data)}, _dims(dims), _strides(strides) {
+        Stride<Rank> temp_strides;
+        tensor_algebra::detail::dims_to_strides(dims, temp_strides);
+        _full_view_of_underlying = (strides == temp_strides);
+    }
+
+    /**
+     * Wrap a const pointer in a tensor view, specifying the dimensions and strides.
+     *
+     * @param data The pointer to wrap.
+     * @param dims The dimensions of the view.
+     * @param strides The strides for the view.
+     */
+    explicit TensorView(T *data, const Dim<Rank> &dims, const Stride<Rank> &strides) : _data{const_cast<T *>(data)}, _dims(dims), _strides(strides) {
+        Stride<Rank> temp_strides;
+        tensor_algebra::detail::dims_to_strides(dims, temp_strides);
+        _full_view_of_underlying = (strides == temp_strides);
     }
 
     // template <typename... Args>

--- a/src/include/einsums/Tensor.hpp
+++ b/src/include/einsums/Tensor.hpp
@@ -1955,7 +1955,7 @@ DiskTensor(h5::fd_t &file, std::string name, Chunk<sizeof...(Dims)> chunk, Dims.
  * @return A new tensor. By default memory is not initialized to anything. It may be filled with garbage.
  */
 template <typename Type = double, typename... Args>
-auto create_tensor(const std::string name, Args... args) {
+auto create_tensor(const std::string &name, Args... args) {
     return Tensor<Type, sizeof...(Args)>{name, args...};
 }
 
@@ -1983,7 +1983,7 @@ auto create_tensor(Args... args) {
  * @return A new disk tensor.
  */
 template <typename Type = double, typename... Args>
-auto create_disk_tensor(h5::fd_t &file, const std::string name, Args... args) -> DiskTensor<Type, sizeof...(Args)> {
+auto create_disk_tensor(h5::fd_t &file, const std::string &name, Args... args) -> DiskTensor<Type, sizeof...(Args)> {
     return DiskTensor<Type, sizeof...(Args)>{file, name, args...};
 }
 

--- a/src/include/einsums/Utilities.hpp
+++ b/src/include/einsums/Utilities.hpp
@@ -143,8 +143,8 @@ auto create_incremented_tensor(const std::string &name, MultiIndex... index) -> 
  * A \p name is required for the tensor. \p name is used when printing and performing disk operations.
  *
  * @code
- * auto a = create_incremented_tensor("a", 3, 3);          // auto -> Tensor<double, 2>
- * auto b = create_incremented_tensor<float>("b" 4, 5, 6); // auto -> Tensor<float, 3>
+ * auto a = create_random_tensor("a", 3, 3);          // auto -> Tensor<double, 2>
+ * auto b = create_random_tensor<float>("b" 4, 5, 6); // auto -> Tensor<float, 3>
  * @endcode
  *
  * @tparam T The datatype of the underlying tensor. Defaults to double.

--- a/src/include/einsums/utility/IndexUtils.hpp
+++ b/src/include/einsums/utility/IndexUtils.hpp
@@ -147,25 +147,18 @@ inline void sentinel_to_indices(size_t sentinel, const std::array<size_t, num_un
  *
  * @param dims The list of dimensions.
  * @param out The calculated strides.
+ * @return The size calculated from the dimensions. Can be safely ignored.
  */
-template <size_t Dims>
-void dims_to_strides(const ::std::array<size_t, Dims> &dims, std::array<size_t, Dims> &out) {
+template <typename arr_type1, typename arr_type2, size_t Dims>
+requires(std::is_integral_v<arr_type1> && std::is_integral_v<arr_type2>)
+size_t dims_to_strides(const ::std::array<arr_type1, Dims> &dims, std::array<arr_type2, Dims> &out) {
     size_t stride = 1;
 
     for (int i = Dims - 1; i >= 0; i--) {
         out[i] = stride;
         stride *= dims[i];
     }
-}
-
-template <size_t Dims>
-void dims_to_strides(const Dim<Dims> &dims, std::array<size_t, Dims> &out) {
-    size_t stride = 1;
-
-    for (int i = Dims - 1; i >= 0; i--) {
-        out[i] = stride;
-        stride *= dims[i];
-    }
+    return stride;
 }
 
 template <int I, typename Head, typename Index>

--- a/tests/Tensor.cpp
+++ b/tests/Tensor.cpp
@@ -160,6 +160,8 @@ TEST_CASE("TensorView creation", "[tensor]") {
 }
 
 TEST_CASE("Tensor-2D HDF5") {
+    using namespace einsums;
+
     einsums::Tensor A("A", 3, 3);
 
     for (int i = 0, ij = 0; i < 3; i++) {
@@ -185,6 +187,29 @@ TEST_CASE("Tensor-2D HDF5") {
         REQUIRE(B(3, 5) == 4.0);
         REQUIRE(B(3, 8) == 5.0);
     }
+
+    double *array = new double[100];
+
+    for (int i = 0; i < 100; i++) {
+        array[i] = i;
+    }
+    {
+
+        TensorView<double, 2>       view1{array, Dim<2>{10, 10}}, view2{array, Dim{10, 10}, Stride{10, 1}};
+        const TensorView<double, 2> const_view1{(const double *)array, Dim<2>{10, 10}},
+            const_view2{(const double *)array, Dim{10, 10}, Stride{10, 1}};
+
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 100; j++) {
+                REQUIRE(view1(i, j) == array[10 * i + j]);
+                REQUIRE(const_view1(i, j) == array[10 * i + j]);
+                REQUIRE(view2(i, j) == array[10 * i + j]);
+                REQUIRE(const_view2(i, j) == array[10 * i + j]);
+            }
+        }
+    }
+
+    delete[] array;
 }
 
 TEST_CASE("Tensor-1D HDF5") {

--- a/tests/Tensor.cpp
+++ b/tests/Tensor.cpp
@@ -157,6 +157,30 @@ TEST_CASE("TensorView creation", "[tensor]") {
     for (int i = 0, ij = 0; i < 3; i++)
         for (int j = 0; j < 9; j++, ij++)
             REQUIRE(viewA(i, j) == ij);
+
+    double *array = new double[100];
+
+    for (int i = 0; i < 100; i++) {
+        array[i] = i;
+    }
+
+    {
+
+        TensorView<double, 2>       view1{array, Dim<2>{10, 10}}, view2{array, Dim{10, 10}, Stride{10, 1}};
+        const TensorView<double, 2> const_view1{(const double *)array, Dim<2>{10, 10}},
+            const_view2{(const double *)array, Dim{10, 10}, Stride{10, 1}};
+
+        for (int i = 0; i < 10; i++) {
+            for (int j = 0; j < 10; j++) {
+                REQUIRE(view1(i, j) == array[10 * i + j]);
+                REQUIRE(const_view1(i, j) == array[10 * i + j]);
+                REQUIRE(view2(i, j) == array[10 * i + j]);
+                REQUIRE(const_view2(i, j) == array[10 * i + j]);
+            }
+        }
+    }
+
+    delete[] array;
 }
 
 TEST_CASE("Tensor-2D HDF5") {
@@ -187,29 +211,6 @@ TEST_CASE("Tensor-2D HDF5") {
         REQUIRE(B(3, 5) == 4.0);
         REQUIRE(B(3, 8) == 5.0);
     }
-
-    double *array = new double[100];
-
-    for (int i = 0; i < 100; i++) {
-        array[i] = i;
-    }
-    {
-
-        TensorView<double, 2>       view1{array, Dim<2>{10, 10}}, view2{array, Dim{10, 10}, Stride{10, 1}};
-        const TensorView<double, 2> const_view1{(const double *)array, Dim<2>{10, 10}},
-            const_view2{(const double *)array, Dim{10, 10}, Stride{10, 1}};
-
-        for (int i = 0; i < 10; i++) {
-            for (int j = 0; j < 100; j++) {
-                REQUIRE(view1(i, j) == array[10 * i + j]);
-                REQUIRE(const_view1(i, j) == array[10 * i + j]);
-                REQUIRE(view2(i, j) == array[10 * i + j]);
-                REQUIRE(const_view2(i, j) == array[10 * i + j]);
-            }
-        }
-    }
-
-    delete[] array;
 }
 
 TEST_CASE("Tensor-1D HDF5") {

--- a/tests/Tensor.cpp
+++ b/tests/Tensor.cpp
@@ -138,6 +138,7 @@ TEST_CASE("Tensor Invert") {
 }
 
 TEST_CASE("TensorView creation", "[tensor]") {
+    using namespace einsums;
     // With the aid of deduction guides we can choose to not specify the rank on the tensor
     einsums::Tensor     A("A", 3, 3, 3);
     einsums::TensorView viewA(A, einsums::Dim{3, 9});
@@ -164,8 +165,8 @@ TEST_CASE("TensorView creation", "[tensor]") {
         array[i] = i;
     }
 
+    // Drop down in scope to make sure the view is deleted before the array it is viewing.
     {
-
         TensorView<double, 2>       view1{array, Dim<2>{10, 10}}, view2{array, Dim{10, 10}, Stride{10, 1}};
         const TensorView<double, 2> const_view1{(const double *)array, Dim<2>{10, 10}},
             const_view2{(const double *)array, Dim{10, 10}, Stride{10, 1}};


### PR DESCRIPTION
Add a way to create a tensor view of a pointer. This is for compatibility with Psi4 shared matrices, but will also be useful with the Python compatibility layer.