### PR TITLE
Put configuration options in global configuration maps

### DIFF
--- a/docs/sphinx/user/arguments.rst
+++ b/docs/sphinx/user/arguments.rst
@@ -1,0 +1,67 @@
+..
+    ----------------------------------------------------------------------------------------------
+     Copyright (c) The Einsums Developers. All rights reserved.
+     Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+    ----------------------------------------------------------------------------------------------
+
+.. _arguments:
+
+######################
+Command Line Arguments
+######################
+
+There are several command line arguments that can control the behavior of Einsums. This is the documentation
+for these arguments.
+
+===============
+Basic Arguments
+===============
+
+.. option:: --einsums:log-level <level>
+
+    Set the level to see in the logger. Lower values provide more information.
+
+    * 0: Tracing messages. Very verbose.
+    * 1: Debugging messages.
+    * 2: Information messages
+    * 3: Warnings.
+    * 4: Errors.
+    * 5: Critical errors.
+
+.. option:: --einsums:log-destination [cerr | cout]
+
+    Set whether the logger will log to standard output or standard error.
+
+.. option:: --einsums:no-profiler-report
+
+    Tells Einsums not to output the profiling information.
+
+.. option:: --einsums:profiler-filename
+
+    The name of the file for the profiler output.
+
+
+==================
+Advanced Arguments
+==================
+
+.. option:: --einsums:no-install-signal-handlers
+
+    Tells Einsums not to install its custom signal handlers.
+
+.. option:: --einsums:no-attach-debugger
+
+    Tells Einsums not to allow users the ability to attach a debugger when an error is detected.
+
+.. option:: --einsums:no-diagnostics-on-terminate
+
+    When present, Einsums won't print extra diagnostics on termination.
+
+.. option:: --einsums:log-format
+
+    A format string used for the logger output.
+
+.. option:: --einsums:profiler-append
+
+    If present, the profiling information will be appended to the profiling file. Otherwise, the profiling
+    file will be overwritten.

--- a/docs/sphinx/user/arguments.rst
+++ b/docs/sphinx/user/arguments.rst
@@ -19,7 +19,8 @@ Basic Arguments
 
 .. option:: --einsums:log-level <level>
 
-    Set the level to see in the logger. Lower values provide more information.
+    Set the level to see in the logger. Lower values provide more information. By default, it is set to 
+    3 for the release build and 2 for the debug build.
 
     * 0: Tracing messages. Very verbose.
     * 1: Debugging messages.

--- a/docs/sphinx/user/index.rst
+++ b/docs/sphinx/user/index.rst
@@ -19,6 +19,7 @@ details are found in the reference. Follow the links below to find more informat
 
     absolute_beginners
     python
+    arguments
 
 .. toctree::
     :caption: User's Reference

--- a/libs/Einsums/Config/include/Einsums/Config/CompilerSpecific.hpp
+++ b/libs/Einsums/Config/include/Einsums/Config/CompilerSpecific.hpp
@@ -51,7 +51,8 @@
 #    define EINSUMS_DO_PRAGMA(X)                 _Pragma(#X)
 #    define EINSUMS_DISABLE_WARNING_PUSH         EINSUMS_DO_PRAGMA(GCC diagnostic push)
 #    define EINSUMS_DISABLE_WARNING_POP          EINSUMS_DO_PRAGMA(GCC diagnostic pop)
-#    define EINSUMS_DISABLE_WARNING(warningName) EINSUMS_DO_PRAGMA(GCC diagnostic ignored #warningName)
+#    define EINSUMS_DISABLE_WARNING_0(warningName) GCC diagnostic ignored warningName
+#    define EINSUMS_DISABLE_WARNING(warningName) EINSUMS_DO_PRAGMA(EINSUMS_DISABLE_WARNING_0(warningName))
 
 #    define EINSUMS_DISABLE_WARNING_RETURN_TYPE_C_LINKAGE EINSUMS_DISABLE_WARNING(-Wreturn-type-c-linkage)
 #    define EINSUMS_DISABLE_WARNING_DEPRECATED_DECLARATIONS EINSUMS_DISABLE_WARNING(-Wdeprecated-declarations)

--- a/libs/Einsums/Config/include/Einsums/Config/Types.hpp
+++ b/libs/Einsums/Config/include/Einsums/Config/Types.hpp
@@ -35,6 +35,9 @@ struct insensitive_hash {
 
         for (auto ch : str) {
             decltype(ch)   upper = std::toupper(ch);
+            if(upper == '-') { // Convert dashes to underscores.
+                upper = '_';
+            }
             uint8_t const *bytes = reinterpret_cast<uint8_t const *>(std::addressof(upper));
 
             for (int i = 0; i < sizeof(std::decay_t<decltype(ch)>); i++) {

--- a/libs/Einsums/Config/include/Einsums/Config/Types.hpp
+++ b/libs/Einsums/Config/include/Einsums/Config/Types.hpp
@@ -100,7 +100,7 @@ struct insensitive_equals {
 template <typename Value>
 class ConfigMap
     : public std::enable_shared_from_this<ConfigMap<Value>>,
-      public Observable<
+      public design_pats::Observable<
           std::unordered_map<std::string, Value, hashes::insensitive_hash<std::string>, detail::insensitive_equals<std::string>>> {
   private:
     /**
@@ -129,7 +129,7 @@ class ConfigMap
      * from this class.
      */
     ConfigMap(PrivateType)
-        : Observable<
+        : design_pats::Observable<
               std::unordered_map<std::string, Value, hashes::insensitive_hash<std::string>, detail::insensitive_equals<std::string>>>() {}
 
     /**

--- a/libs/Einsums/Config/include/Einsums/Config/Types.hpp
+++ b/libs/Einsums/Config/include/Einsums/Config/Types.hpp
@@ -190,8 +190,9 @@ class EINSUMS_EXPORT GlobalConfigMap {
      * Throws an error if the key is not in the map.
      *
      * @param key The key to query.
+     * @param dephault The default value. If the key is not in the map, this is what will be returned.
      */
-    std::string const &get_string(std::string const &key) const;
+    std::string const &get_string(std::string const &key, std::string const &dephault = "") const;
 
     /**
      * @brief Get the integer value stored at the given key.
@@ -199,8 +200,9 @@ class EINSUMS_EXPORT GlobalConfigMap {
      * Throws an error if the key is not in the map.
      *
      * @param key The key to query.
+     * @param dephault The default value. If the key is not in the map, this is what will be returned.
      */
-    std::int64_t get_int(std::string const &key) const;
+    std::int64_t get_int(std::string const &key, std::int64_t dephault = 0) const;
 
     /**
      * @brief Get the floating point value stored at the given key.
@@ -208,8 +210,9 @@ class EINSUMS_EXPORT GlobalConfigMap {
      * Throws an error if the key is not in the map.
      *
      * @param key The key to query.
+     * @param dephault The default value. If the key is not in the map, this is what will be returned.
      */
-    double get_double(std::string const &key) const;
+    double get_double(std::string const &key, double dephault = 0) const;
 
     /**
      * @brief Get the boolean flag stored at the given key.
@@ -217,8 +220,9 @@ class EINSUMS_EXPORT GlobalConfigMap {
      * Throws an error if the key is not in the map.
      *
      * @param key The key to query.
+     * @param dephault The default value. If the key is not in the map, this is what will be returned.
      */
-    bool get_bool(std::string const &key) const;
+    bool get_bool(std::string const &key, bool dephaul = false) const;
 
     /**
      * @brief Returns the map containing string options.

--- a/libs/Einsums/Config/include/Einsums/Config/Types.hpp
+++ b/libs/Einsums/Config/include/Einsums/Config/Types.hpp
@@ -34,8 +34,8 @@ struct insensitive_hash {
         constexpr size_t mask = (((size_t)1 << sizeof(size_t)) - 1) << (7 * sizeof(size_t));
 
         for (auto ch : str) {
-            decltype(ch)   upper = std::toupper(ch);
-            if(upper == '-') { // Convert dashes to underscores.
+            decltype(ch) upper = std::toupper(ch);
+            if (upper == '-') { // Convert dashes to underscores.
                 upper = '_';
             }
             uint8_t const *bytes = reinterpret_cast<uint8_t const *>(std::addressof(upper));
@@ -212,6 +212,15 @@ class EINSUMS_EXPORT GlobalConfigMap {
     double get_double(std::string const &key) const;
 
     /**
+     * @brief Get the boolean flag stored at the given key.
+     *
+     * Throws an error if the key is not in the map.
+     *
+     * @param key The key to query.
+     */
+    bool get_bool(std::string const &key) const;
+
+    /**
      * @brief Returns the map containing string options.
      */
     std::shared_ptr<ConfigMap<std::string>> get_string_map();
@@ -225,6 +234,11 @@ class EINSUMS_EXPORT GlobalConfigMap {
      * @brief Returns the map containing floating point options.
      */
     std::shared_ptr<ConfigMap<double>> get_double_map();
+
+    /**
+     * @brief Returns the map containing boolean flags.
+     */
+    std::shared_ptr<ConfigMap<bool>> get_bool_map();
 
     /**
      * @brief Attach an observer to the global configuration map.
@@ -259,6 +273,12 @@ class EINSUMS_EXPORT GlobalConfigMap {
                           T>) {
             double_map_->attach(obs);
         }
+
+        if constexpr (std::is_convertible_v<std::function<void(std::unordered_map<std::string, bool, hashes::insensitive_hash<std::string>,
+                                                                                  detail::insensitive_equals<std::string>> const &)>,
+                                            T>) {
+            bool_map_->attach(obs);
+        }
     }
 
     /**
@@ -288,6 +308,12 @@ class EINSUMS_EXPORT GlobalConfigMap {
                           T>) {
             double_map_->detach(obs);
         }
+
+        if constexpr (std::is_convertible_v<std::function<void(std::unordered_map<std::string, bool, hashes::insensitive_hash<std::string>,
+                                                                                  detail::insensitive_equals<std::string>> const &)>,
+                                            T>) {
+            bool_map_->detach(obs);
+        }
     }
 
   private:
@@ -313,6 +339,13 @@ class EINSUMS_EXPORT GlobalConfigMap {
      * @brief Holds the floating-point valued options.
      */
     std::shared_ptr<ConfigMap<double>> double_map_;
+
+    /**
+     * @property bool_map_
+     *
+     * @brief Holds the Boolean flag options.
+     */
+    std::shared_ptr<ConfigMap<bool>> bool_map_;
 };
 
 } // namespace einsums

--- a/libs/Einsums/Config/src/Types.cpp
+++ b/libs/Einsums/Config/src/Types.cpp
@@ -7,7 +7,8 @@ namespace einsums {
 EINSUMS_SINGLETON_IMPL(GlobalConfigMap)
 
 GlobalConfigMap::GlobalConfigMap()
-    : str_map_{ConfigMap<std::string>::create()}, int_map_{ConfigMap<std::int64_t>::create()}, double_map_{ConfigMap<double>::create()} {
+    : str_map_{ConfigMap<std::string>::create()}, int_map_{ConfigMap<std::int64_t>::create()}, double_map_{ConfigMap<double>::create()},
+      bool_map_{ConfigMap<bool>::create()} {
 }
 
 bool GlobalConfigMap::empty() const noexcept {

--- a/libs/Einsums/Config/src/Types.cpp
+++ b/libs/Einsums/Config/src/Types.cpp
@@ -52,6 +52,9 @@ size_t einsums::hashes::insensitive_hash<std::string>::operator()(std::string co
 
     for (char ch : str) {
         char upper = std::toupper(ch);
+        if(upper == '-') { // Convert dashes to underscores.
+            upper = '_';
+        }
 
         hash <<= sizeof(size_t); // Shift left a number of bits equal to the number of bytes in size_t.
         hash += (uint8_t)upper;

--- a/libs/Einsums/Config/src/Types.cpp
+++ b/libs/Einsums/Config/src/Types.cpp
@@ -23,17 +23,33 @@ size_t GlobalConfigMap::max_size() const noexcept {
     return str_map_->get_value().max_size() + int_map_->get_value().max_size() + double_map_->get_value().max_size();
 }
 
-std::string const &GlobalConfigMap::get_string(std::string const &key) const {
-    return str_map_->get_value().at(key);
+std::string const &GlobalConfigMap::get_string(std::string const &key, std::string const &dephault) const {
+    if (str_map_->get_value().contains(key)) {
+        return str_map_->get_value().at(key);
+    } else {
+        return dephault;
+    }
 }
-std::int64_t GlobalConfigMap::get_int(std::string const &key) const {
-    return int_map_->get_value().at(key);
+std::int64_t GlobalConfigMap::get_int(std::string const &key, std::int64_t dephault) const {
+    if (int_map_->get_value().contains(key)) {
+        return int_map_->get_value().at(key);
+    } else {
+        return dephault;
+    }
 }
-double GlobalConfigMap::get_double(std::string const &key) const {
-    return double_map_->get_value().at(key);
+double GlobalConfigMap::get_double(std::string const &key, double dephault) const {
+    if (double_map_->get_value().contains(key)) {
+        return double_map_->get_value().at(key);
+    } else {
+        return dephault;
+    }
 }
-bool GlobalConfigMap::get_bool(std::string const &key) const {
-    return bool_map_->get_value().at(key);
+bool GlobalConfigMap::get_bool(std::string const &key, bool dephault) const {
+    if (bool_map_->get_value().contains(key)) {
+        return bool_map_->get_value().at(key);
+    } else {
+        return dephault;
+    }
 }
 
 std::shared_ptr<ConfigMap<std::string>> GlobalConfigMap::get_string_map() {

--- a/libs/Einsums/Config/src/Types.cpp
+++ b/libs/Einsums/Config/src/Types.cpp
@@ -42,4 +42,26 @@ std::shared_ptr<ConfigMap<double>> GlobalConfigMap::get_double_map() {
     return double_map_;
 }
 
+size_t einsums::hashes::insensitive_hash<std::string>::operator()(std::string const &str) const noexcept{
+    size_t hash = 0;
+
+    // Calculate the mask. If size_t is N bytes, mask for the top N bits.
+    // The first part creates a Mersenne value with the appropriate number of bits.
+    // The second shifts it to the top.
+    constexpr size_t mask = (((size_t)1 << sizeof(size_t)) - 1) << (7 * sizeof(size_t));
+
+    for (char ch : str) {
+        char upper = std::toupper(ch);
+
+        hash <<= sizeof(size_t); // Shift left a number of bits equal to the number of bytes in size_t.
+        hash += (uint8_t)upper;
+
+        if ((hash & mask) != (size_t)0) {
+            hash ^= mask >> (6 * sizeof(size_t));
+            hash &= ~mask;
+        }
+    }
+    return hash;
+}
+
 } // namespace einsums

--- a/libs/Einsums/Config/src/Types.cpp
+++ b/libs/Einsums/Config/src/Types.cpp
@@ -31,6 +31,9 @@ std::int64_t GlobalConfigMap::get_int(std::string const &key) const {
 double GlobalConfigMap::get_double(std::string const &key) const {
     return double_map_->get_value().at(key);
 }
+bool GlobalConfigMap::get_bool(std::string const &key) const {
+    return bool_map_->get_value().at(key);
+}
 
 std::shared_ptr<ConfigMap<std::string>> GlobalConfigMap::get_string_map() {
     return str_map_;
@@ -41,8 +44,11 @@ std::shared_ptr<ConfigMap<std::int64_t>> GlobalConfigMap::get_int_map() {
 std::shared_ptr<ConfigMap<double>> GlobalConfigMap::get_double_map() {
     return double_map_;
 }
+std::shared_ptr<ConfigMap<bool>> GlobalConfigMap::get_bool_map() {
+    return bool_map_;
+}
 
-size_t einsums::hashes::insensitive_hash<std::string>::operator()(std::string const &str) const noexcept{
+size_t einsums::hashes::insensitive_hash<std::string>::operator()(std::string const &str) const noexcept {
     size_t hash = 0;
 
     // Calculate the mask. If size_t is N bytes, mask for the top N bits.
@@ -52,7 +58,7 @@ size_t einsums::hashes::insensitive_hash<std::string>::operator()(std::string co
 
     for (char ch : str) {
         char upper = std::toupper(ch);
-        if(upper == '-') { // Convert dashes to underscores.
+        if (upper == '-') { // Convert dashes to underscores.
             upper = '_';
         }
 

--- a/libs/Einsums/Runtime/include/Einsums/Runtime/ShutdownFunction.hpp
+++ b/libs/Einsums/Runtime/include/Einsums/Runtime/ShutdownFunction.hpp
@@ -52,4 +52,18 @@ EINSUMS_EXPORT void register_pre_shutdown_function(ShutdownFunctionType f);
 /// \see    \a einsums::register_pre_shutdown_function()
 EINSUMS_EXPORT void register_shutdown_function(ShutdownFunctionType f);
 
+namespace detail {
+
+/**
+ * @brief Registers a pointer to be freed at program exit.
+ *
+ * There are certain cases where a pointer can't necessarily be freed when it is no longer in use by the main thread.
+ * This function makes the shutdown routine aware of these pointers so that they can be freed.
+ *
+ * @param f The function that deletes the pointer.
+ */
+EINSUMS_EXPORT void register_free_pointer(std::function<void()> f);
+
+} // namespace detail
+
 } // namespace einsums

--- a/libs/Einsums/Runtime/src/Finalize.cpp
+++ b/libs/Einsums/Runtime/src/Finalize.cpp
@@ -30,11 +30,7 @@ int finalize() {
     }
 
     // this function destroys the runtime.
-    auto *rt_ptr = runtime_ptr();
     rt.deinit_global_data();
-
-    // Free the current runtime.
-    delete rt_ptr;
 
     // This is the only explicit finalization routine. This is because the runtime depends on the
     // profiler. If the profiler used the normal finalization, then it would also depend on the runtime.

--- a/libs/Einsums/Runtime/src/Finalize.cpp
+++ b/libs/Einsums/Runtime/src/Finalize.cpp
@@ -23,13 +23,18 @@ int finalize() {
     rt.call_shutdown_functions(false);
     EINSUMS_LOG_INFO("ran shutdown functions");
 
-    detail::Profiler const &prof = rt.config().einsums.profiler;
-    if (prof.generate_report) {
-        profile::report(prof.filename, prof.append);
+    auto &global_config = GlobalConfigMap::get_singleton();
+
+    if (global_config.get_bool("profiler-report")) {
+        profile::report(global_config.get_string("profiler-filename"), global_config.get_bool("profiler-append"));
     }
 
     // this function destroys the runtime.
+    auto *rt_ptr = runtime_ptr();
     rt.deinit_global_data();
+
+    // Free the current runtime.
+    delete rt_ptr;
 
     // This is the only explicit finalization routine. This is because the runtime depends on the
     // profiler. If the profiler used the normal finalization, then it would also depend on the runtime.

--- a/libs/Einsums/Runtime/src/InitLogging.cpp
+++ b/libs/Einsums/Runtime/src/InitLogging.cpp
@@ -63,24 +63,25 @@ struct HostnameFormatterFlag : spdlog::custom_flag_formatter {
 };
 
 void init_logging(RuntimeConfiguration &config) {
+    auto &global_config = GlobalConfigMap::get_singleton();
     // Set log destination
     auto &sinks = get_einsums_logger().sinks();
     sinks.clear();
-    sinks.push_back(get_spdlog_sink(config.einsums.log.destination));
+    sinks.push_back(get_spdlog_sink(global_config.get_string("log-destination")));
 
     // Set log pattern
     auto formatter = std::make_unique<spdlog::pattern_formatter>();
     formatter->add_flag<ThreadIdFormatterFlag>('k');
     formatter->add_flag<ParentThreadIdFormatterFlag>('q');
     formatter->add_flag<HostnameFormatterFlag>('j');
-    formatter->set_pattern(config.einsums.log.format);
+    formatter->set_pattern(global_config.get_string("log-format"));
     get_einsums_logger().set_formatter(std::move(formatter));
 
     // Set log level
-    get_einsums_logger().set_level(static_cast<spdlog::level::level_enum>(config.einsums.log.level));
+    get_einsums_logger().set_level(static_cast<spdlog::level::level_enum>(global_config.get_int("log-level")));
 
     EINSUMS_LOG_INFO("logging submodule has been initialized");
-    EINSUMS_LOG_INFO("log level: {} (0=TRACE,1=DEBUG,2=INFO,3=WARN,4=ERROR,5=CRITICAL)", config.einsums.log.level);
+    EINSUMS_LOG_INFO("log level: {} (0=TRACE,1=DEBUG,2=INFO,3=WARN,4=ERROR,5=CRITICAL)", global_config.get_int("log-level"));
     // EINSUMS_LOG_DEBUG("test debug");
     // EINSUMS_LOG_TRACE("test trace");
     // EINSUMS_LOG_INFO("test info");

--- a/libs/Einsums/Runtime/src/InitRuntime.cpp
+++ b/libs/Einsums/Runtime/src/InitRuntime.cpp
@@ -120,7 +120,9 @@ int run(std::function<int()> const &f, std::vector<std::string> const &argv, Ini
     run(f, *rt, params);
 
     // pointer to runtime is stored in TLS
-    [[maybe_unused]] Runtime *p = rt.release();
+    Runtime *p = rt.release();
+
+    detail::register_free_pointer([p]() { delete p; });
 
     return 0;
 }

--- a/libs/Einsums/Runtime/src/InitRuntime.cpp
+++ b/libs/Einsums/Runtime/src/InitRuntime.cpp
@@ -95,7 +95,9 @@ int run(std::function<int()> const &f, std::vector<std::string> const &argv, Ini
     // Before this line logging does not work.
     init_logging(config);
 
-    if (config.einsums.install_signal_handlers) {
+    auto &global_config = GlobalConfigMap::get_singleton();
+
+    if (global_config.get_bool("install-signal-handlers")) {
         EINSUMS_LOG_TRACE("Installing signal handlers...");
         set_signal_handlers();
     }

--- a/libs/Einsums/Runtime/src/Runtime.cpp
+++ b/libs/Einsums/Runtime/src/Runtime.cpp
@@ -65,7 +65,16 @@ EINSUMS_EXPORT BOOL WINAPI termination_handler(DWORD ctrl_type) {
 
 #else
 [[noreturn]] EINSUMS_EXPORT void termination_handler(int signum) {
-    if (signum != SIGINT && runtime_config().einsums.attach_debugger) {
+    bool attach = true;
+
+    try {
+        auto &global_config = GlobalConfigMap::get_singleton();
+        attach = global_config.get_bool("attach-debugger");
+    } catch(...) {
+        attach = true;
+    }
+
+    if (signum != SIGINT && attach) {
         util::attach_debugger();
     }
 

--- a/libs/Einsums/Runtime/src/Runtime.cpp
+++ b/libs/Einsums/Runtime/src/Runtime.cpp
@@ -69,7 +69,7 @@ EINSUMS_EXPORT BOOL WINAPI termination_handler(DWORD ctrl_type) {
 
     try {
         auto &global_config = GlobalConfigMap::get_singleton();
-        attach = global_config.get_bool("attach-debugger");
+        attach = global_config.get_bool("attach-debugger", true);
     } catch(...) {
         attach = true;
     }

--- a/libs/Einsums/RuntimeConfiguration/include/Einsums/RuntimeConfiguration/RuntimeConfiguration.hpp
+++ b/libs/Einsums/RuntimeConfiguration/include/Einsums/RuntimeConfiguration/RuntimeConfiguration.hpp
@@ -24,102 +24,6 @@ namespace einsums {
 
 namespace detail {
 
-/**
- * Settings for the logger.
- */
-struct EINSUMS_EXPORT Log {
-    /**
-     * The log level. This is compatible with spdlog::level::level_enum.
-     * Default value is 2, currently.
-     */
-    int level;
-
-    /**
-     * The destination sink for the logging messages.
-     * Default value is "cerr" which is mapped to std::cerr.
-     */
-    std::string destination;
-
-    /**
-     * The format string for logging messages.
-     */
-    std::string format;
-};
-
-/**
- * Settings for the timer/profiler system.
- */
-struct EINSUMS_EXPORT Profiler {
-    /**
-     * Generate a timing report.
-     */
-    bool generate_report;
-
-    /**
-     * Filename to save the timing data to.
-     */
-    std::string filename;
-
-    /**
-     * If true, append to the filename. Otherwise, truncate the file before writing.
-     */
-    bool append;
-};
-
-/**
- * Information regarding the running executable. These are filled in automatically
- * by the RuntimeConfiguration constructor.
- */
-struct EINSUMS_EXPORT System {
-    /// The process id of the running instance.
-    int pid{-1};
-    /**
-     * The root directory of the executable.
-     * For example, if the executable is /usr/local/bin/einsums then the executable prefix is /usr/local.
-     */
-    std::string executable_prefix;
-};
-
-struct EINSUMS_EXPORT Einsums {
-    /**
-     * This will eventually be the master config file name.
-     *
-     * Defaults are set in RuntimeConfiguration::pre_initialize() then
-     * The master_yaml_path will be read in changing the defaults.
-     */
-    std::string master_yaml_path;
-
-    /**
-     * Install Einsums signal handlers.
-     *
-     * Can be useful in debugging segfaults, bus errors, etc.
-     */
-    bool install_signal_handlers{true};
-
-    /**
-     * Provide a mechanism to attach a debugger to the running instance.
-     *
-     * For example, if install_signal_handlers is true and attach_debugger is true
-     * then when a signal is caught the user will be presented with a message
-     * telling them how to attach a debugger to the instance.
-     */
-    bool attach_debugger{true};
-
-    /**
-     * Provide more detailed information when a signal is handled, an
-     * unhandled exception is caught, or an assertion is thrown.
-     *
-     * Diagnostics include version and compilation configuration
-     * and a stack trace of what was caught.
-     */
-    bool diagnostics_on_terminate{true};
-
-    /// Settings for the logging submodule.
-    Log log;
-
-    /// Setting for the profile submodule.
-    Profiler profiler;
-};
 } // namespace detail
 
 /**
@@ -135,20 +39,6 @@ struct EINSUMS_EXPORT Einsums {
  * from Runtime::config() or from runtime_config() functions.
  */
 struct EINSUMS_EXPORT RuntimeConfiguration {
-    /**
-     * @property system
-     *
-     * @todo Document.
-     */
-    detail::System  system;
-
-    /**
-     * @property einsums
-     *
-     * @todo Document.
-     */
-    detail::Einsums einsums;
-
     /**
      * @property original
      *
@@ -183,6 +73,12 @@ struct EINSUMS_EXPORT RuntimeConfiguration {
 
     RuntimeConfiguration() = delete;
 
+    RuntimeConfiguration(RuntimeConfiguration const &) = delete;
+
+    RuntimeConfiguration(RuntimeConfiguration &&) = default;
+
+    ~RuntimeConfiguration() = default;
+
   private:
     /**
      * Currently sets reasonable defaults for the development of Einsums.
@@ -190,9 +86,9 @@ struct EINSUMS_EXPORT RuntimeConfiguration {
     void pre_initialize();
 
     /**
-     * Parse the command line arguments provided in argc and argv.
+     * Parse the command line arguments provided in argc and argv. Returns unknown command line arguments.
      */
-    void parse_command_line(std::function<void(argparse::ArgumentParser &)> const &user_command_line = {});
+    std::vector<std::string> parse_command_line(std::function<void(argparse::ArgumentParser &)> const &user_command_line = {});
 };
 
 } // namespace einsums

--- a/libs/Einsums/RuntimeConfiguration/include/Einsums/RuntimeConfiguration/RuntimeConfiguration.hpp
+++ b/libs/Einsums/RuntimeConfiguration/include/Einsums/RuntimeConfiguration/RuntimeConfiguration.hpp
@@ -73,12 +73,6 @@ struct EINSUMS_EXPORT RuntimeConfiguration {
 
     RuntimeConfiguration() = delete;
 
-    RuntimeConfiguration(RuntimeConfiguration const &) = delete;
-
-    RuntimeConfiguration(RuntimeConfiguration &&) = default;
-
-    ~RuntimeConfiguration() = default;
-
   private:
     /**
      * Currently sets reasonable defaults for the development of Einsums.

--- a/libs/Einsums/RuntimeConfiguration/src/RuntimeConfiguration.cpp
+++ b/libs/Einsums/RuntimeConfiguration/src/RuntimeConfiguration.cpp
@@ -162,7 +162,11 @@ RuntimeConfiguration::parse_command_line(std::function<void(argparse::ArgumentPa
             .store_into(global_bools["diagnostics-on-terminate"]);
 
         argument_parser->add_argument("--einsums:log-level")
+        #ifdef EINSUMS_DEBUG
             .default_value<std::int64_t>(2)
+        #else
+            .default_value<std::int64_t>(3)
+        #endif
             .help("set log level")
             .choices(0, 1, 2, 3, 4)
             .store_into(global_ints["log-level"]);

--- a/libs/Einsums/RuntimeConfiguration/src/RuntimeConfiguration.cpp
+++ b/libs/Einsums/RuntimeConfiguration/src/RuntimeConfiguration.cpp
@@ -86,17 +86,20 @@ void RuntimeConfiguration::pre_initialize() {
         // clang-format on
     };
 
-    // For now set the values to their default values.
-    system.pid               = getpid();
-    system.executable_prefix = detail::get_executable_prefix();
-    einsums.master_yaml_path = detail::get_executable_prefix();
-    einsums.log.level        = 3;
-    einsums.log.destination  = "cerr";
-    // einsums.log.format               = "[%Y-%m-%d %H:%M:%S.%F] [%n] [%^%l%$] [host:%j] [pid:%P] [tid:%t] [%s:%#/%!] %v";
-    einsums.log.format = "[%Y-%m-%d %H:%M:%S.%F] [%n] [%^%-8l%$] [%s:%#/%!] %v";
+    /*
+     * Acquire locks for the different maps.
+     */
+    auto            &global_config  = GlobalConfigMap::get_singleton();
+    auto            &global_strings = global_config.get_string_map()->get_value();
+    auto            &global_ints    = global_config.get_int_map()->get_value();
+    auto            &global_doubles = global_config.get_double_map()->get_value();
+    auto            &global_bools   = global_config.get_bool_map()->get_value();
+    std::scoped_lock lock{*global_config.get_string_map(), *global_config.get_int_map(), *global_config.get_double_map(),
+                          *global_config.get_bool_map()};
 
-    einsums.profiler.filename = "profile.txt";
-    einsums.profiler.append   = true;
+    // For now set the values to their default values.
+    global_strings["executable-prefix"] = detail::get_executable_prefix();
+    global_ints["pid"]                  = getpid();
 }
 
 RuntimeConfiguration::RuntimeConfiguration(int argc, char const *const argv[],
@@ -122,7 +125,8 @@ RuntimeConfiguration::RuntimeConfiguration(std::vector<std::string> const       
     parse_command_line(user_command_line);
 }
 
-void RuntimeConfiguration::parse_command_line(std::function<void(argparse::ArgumentParser &)> const &user_command_line) {
+std::vector<std::string>
+RuntimeConfiguration::parse_command_line(std::function<void(argparse::ArgumentParser &)> const &user_command_line) {
     EINSUMS_LOG_INFO("Configuring command line parser and parsing user provided command line");
 
     // Imperative that pre_initialize is called first as it is responsible for setting
@@ -130,54 +134,61 @@ void RuntimeConfiguration::parse_command_line(std::function<void(argparse::Argum
     // There should be a mechanism that allows the user to change the program name.
     argument_parser.reset(new argparse::ArgumentParser("einsums"));
 
-    einsums.install_signal_handlers = true;
-    argument_parser->add_argument("--einsums:no-install-signal-handlers")
-        .default_value(false)
-        .implicit_value(true)
-        .help("do not install signal handlers")
-        .action([&](auto const &) { einsums.install_signal_handlers = false; });
+    /*
+     * Acquire locks for the different maps.
+     */
+    auto &global_config  = GlobalConfigMap::get_singleton();
+    auto &global_strings = global_config.get_string_map()->get_value();
+    auto &global_ints    = global_config.get_int_map()->get_value();
+    auto &global_doubles = global_config.get_double_map()->get_value();
+    auto &global_bools   = global_config.get_bool_map()->get_value();
+    {
+        std::scoped_lock lock{*global_config.get_string_map(), *global_config.get_int_map(), *global_config.get_double_map(),
+                              *global_config.get_bool_map()};
 
-    einsums.attach_debugger = true;
-    argument_parser->add_argument("--einsums:no-attach-debugger")
-        .default_value(false)
-        .implicit_value(true)
-        .help("do not provide mechanism to attach debugger on detected errors")
-        .action([&](auto const &) { einsums.attach_debugger = false; });
+        argument_parser->add_argument("--einsums:no-install-signal-handlers")
+            .flag()
+            .help("do not install signal handlers")
+            .store_into(global_bools["install-signal-handlers"]);
 
-    einsums.diagnostics_on_terminate = true;
-    argument_parser->add_argument("--einsums:no-diagnostics-on-terminate")
-        .default_value(false)
-        .implicit_value(true)
-        .help("do not print additional diagnostic information on termination")
-        .action([&](auto const &) { einsums.diagnostics_on_terminate = false; });
+        argument_parser->add_argument("--einsums:no-attach-debugger")
+            .flag()
+            .help("do not provide mechanism to attach debugger on detected errors")
+            .store_into(global_bools["attach-debugger"]);
 
-    argument_parser->add_argument("--einsums:log-level")
-        .default_value(einsums.log.level)
-        .help("set log level")
-        .choices(0, 1, 2, 3, 4)
-        .store_into(einsums.log.level);
-    argument_parser->add_argument("--einsums:log-destination")
-        .default_value(einsums.log.destination)
-        .help("set log destination")
-        .choices("cerr", "cout")
-        .store_into(einsums.log.destination);
-    argument_parser->add_argument("--einsums:log-format").default_value(einsums.log.format).store_into(einsums.log.format);
+        argument_parser->add_argument("--einsums:no-diagnostics-on-terminate")
+            .flag()
+            .help("do not print additional diagnostic information on termination")
+            .store_into(global_bools["diagnostics-on-terminate"]);
 
-    einsums.profiler.generate_report = true;
-    argument_parser->add_argument("--einsums:no-profiler-report")
-        .default_value(false)
-        .implicit_value(true)
-        .help("generate profiling report")
-        .action([&](auto const &) { einsums.profiler.generate_report = false; });
+        argument_parser->add_argument("--einsums:log-level")
+            .default_value<std::int64_t>(2)
+            .help("set log level")
+            .choices(0, 1, 2, 3, 4)
+            .store_into(global_ints["log-level"]);
+        argument_parser->add_argument("--einsums:log-destination")
+            .default_value("cerr")
+            .help("set log destination")
+            .choices("cerr", "cout")
+            .store_into(global_strings["log-destination"]);
+        argument_parser->add_argument("--einsums:log-format")
+            .default_value("[%Y-%m-%d %H:%M:%S.%F] [%n] [%^%-8l%$] [%s:%#/%!] %v")
+            .store_into(global_strings["log-format"]);
 
-    argument_parser->add_argument("--einsums:profiler-filename")
-        .default_value(einsums.profiler.filename)
-        .help("filename of the profiling report")
-        .store_into(einsums.profiler.filename);
-    argument_parser->add_argument("--einsums:profiler-append")
-        .default_value(einsums.profiler.append)
-        .help("append to an existing file")
-        .store_into(einsums.profiler.append);
+        argument_parser->add_argument("--einsums:no-profiler-report")
+            .flag()
+            .help("generate profiling report")
+            .store_into(global_bools["profiler-report"]);
+
+        argument_parser->add_argument("--einsums:profiler-filename")
+            .default_value("profile.txt")
+            .help("filename of the profiling report")
+            .store_into(global_strings["profiler-filename"]);
+        argument_parser->add_argument("--einsums:profiler-append")
+            .default_value(true)
+            .help("append to an existing file")
+            .store_into(global_bools["profiler-append"]);
+    }
 
     // Allow the user to inject their own command line options
     if (user_command_line) {
@@ -186,7 +197,7 @@ void RuntimeConfiguration::parse_command_line(std::function<void(argparse::Argum
     }
 
     try {
-        argument_parser->parse_known_args(original);
+        return argument_parser->parse_known_args(original);
     } catch (std::exception const &err) {
         std::cerr << err.what() << std::endl;
         std::cerr << argument_parser;

--- a/libs/Einsums/TypeSupport/include/Einsums/TypeSupport/Observable.hpp
+++ b/libs/Einsums/TypeSupport/include/Einsums/TypeSupport/Observable.hpp
@@ -120,7 +120,7 @@ struct Observable {
     void wait_for_change() {
         size_t                       check_changed = _value_changed;
         std::unique_lock<std::mutex> lock(_mutex);
-        _cv.wait(lock, [this]() { return _value_changed == check_changed; });
+        _cv.wait(lock, [this, check_changed]() { return _value_changed == check_changed; });
     }
 
     /**

--- a/libs/Einsums/TypeSupport/include/Einsums/TypeSupport/Observable.hpp
+++ b/libs/Einsums/TypeSupport/include/Einsums/TypeSupport/Observable.hpp
@@ -15,6 +15,8 @@
 
 namespace einsums {
 
+namespace design_pats {
+
 /**
  * @struct Observable
  *
@@ -79,37 +81,46 @@ struct Observable {
     operator T() const { return get_value(); }
 
     /**
-     * @brief Explicit value assignment.
-     *
-     * @param value The value to assign to the observable.
-     */
-    void set_value(T const &value) {
-        {
-            std::lock_guard<std::mutex> lock(_mutex);
-            if (_state != value) {
-                _state         = value;
-                _value_changed = true;
-                notify_observers(value); // Notify registered observers
-            }
-        }
-        _cv.notify_all(); // Notify threads waiting on value change
-    }
-
-    /**
      * @brief Explicit getter.
      */
-    const T &get_value() const {
+    T const &get_value() const {
         std::lock_guard<std::mutex> lock(_mutex);
         return _state;
     }
 
     /**
+     * @brief Get a lock that updates internal values as well as the state.
+     */
+    T &get_value() { return _state; }
+
+    /**
+     * @brief Lock the state.
+     */
+    void lock() { _mutex.lock(); }
+
+    /**
+     * @brief Unlock the state.
+     *
+     * This will automatically notify observers when done if no arguments are passed.
+     * If false is passed, then it will not notify the observers.
+     */
+    void unlock(bool notify = true) {
+        _mutex.unlock();
+
+        if (notify) {
+            notify_observers();
+        }
+    }
+
+    bool try_lock() { return _mutex.try_lock(); }
+
+    /**
      * @brief Wait for the value to change.
      */
     void wait_for_change() {
+        size_t                       check_changed = _value_changed;
         std::unique_lock<std::mutex> lock(_mutex);
-        _cv.wait(lock, [this]() { return _value_changed; });
-        _value_changed = false; // Reset the change flag after notification
+        _cv.wait(lock, [this]() { return _value_changed == check_changed; });
     }
 
     /**
@@ -138,10 +149,15 @@ struct Observable {
     /**
      * @brief Notify all of the observers that observe this observable.
      */
-    void notify_observers(T const &value) {
+    void notify_observers() {
+        // Notify things that are waiting for changes.
+        _mutex.lock();
+        _value_changed++;
+        _mutex.unlock();
+
         std::lock_guard<std::mutex> lock(_observer_mutex);
         for (auto const &observer : _observers) {
-            observer(value); // Call each registered observer with the new value
+            observer(*this); // Call each registered observer with the new values
         }
     }
 
@@ -151,12 +167,12 @@ struct Observable {
      * @brief The internal state of the observable.
      */
     T                       _state;
-    mutable std::mutex      _mutex;                 /// For thread-safe value access
-    std::condition_variable _cv;                    /// For thread synchronization
-    bool                    _value_changed = false; /// Flag indicating value change
+    mutable std::mutex      _mutex{};           /// For thread-safe value access
+    std::condition_variable _cv{};              /// For thread synchronization
+    size_t                  _value_changed = 0; /// Counter indicating how many times the value has changed.
 
-    std::list<std::function<void(T const &)>> _observers;      /// List of observers
-    std::mutex                                _observer_mutex; /// Protects the observer list
+    std::list<std::function<void(T const &)>> _observers{};      /// List of observers
+    std::mutex                                _observer_mutex{}; /// Protects the observer list
 };
-
+} // namespace design_pats
 } // namespace einsums

--- a/libs/EinsumsExperimental/modules.rst
+++ b/libs/EinsumsExperimental/modules.rst
@@ -5,7 +5,7 @@
 .. _EinsumsExperimental_modules:
 
 ===========================
-EinsumsExperimental modules
+EinsumsExperimental Modules
 ===========================
 
 .. toctree::

--- a/libs/EinsumsPy/modules.rst
+++ b/libs/EinsumsPy/modules.rst
@@ -5,7 +5,7 @@
 .. _EinsumsPy_modules:
 
 =================
-EinsumsPy modules
+EinsumsPy Modules
 =================
 
 .. toctree::

--- a/testing/testing/src/main.cpp
+++ b/testing/testing/src/main.cpp
@@ -17,18 +17,25 @@
 #include <catch2/catch_all.hpp>
 
 int einsums_main(int argc, char *const *const argv) {
-    Catch::Session session;
-    session.applyCommandLine(argc, argv);
+    int result;
+#pragma omp parallel
+    {
+#pragma omp single
+        {
+            Catch::Session session;
+            session.applyCommandLine(argc, argv);
 
-    Catch::StringMaker<float>::precision  = std::numeric_limits<float>::digits10;
-    Catch::StringMaker<double>::precision = std::numeric_limits<double>::digits10;
-    auto seed                             = session.config().rngSeed();
+            Catch::StringMaker<float>::precision  = std::numeric_limits<float>::digits10;
+            Catch::StringMaker<double>::precision = std::numeric_limits<double>::digits10;
+            auto seed                             = session.config().rngSeed();
 
-    einsums::seed_random(seed);
+            einsums::seed_random(seed);
 
-    int result = session.run();
-    einsums::finalize();
+            result = session.run();
+            einsums::finalize();
 
+        }
+    }
     return result;
 }
 


### PR DESCRIPTION
We have these global configuration maps, so why not use them for global options. The option keys are case insensitive, and dashes and underscores are considered to be the same. Also fixes a few memory leaks, some of which may be due to this change, others may have been stirred up from before.