### PR TITLE
Runtime views

### DIFF
--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -757,6 +757,26 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
 #    undef OPERATOR
 #endif
 
+    template <size_t Rank>
+    operator TensorView<T, Rank>() {
+        if (rank() != Rank) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can not convert a rank-{} RuntimeTensor into a rank-{} TensorView!", rank(), Rank);
+        }
+        Dim<Rank> dims(_dims.begin(), _dims.end());
+        Dim<Rank> strides(_strides.begin(), _strides.end());
+        return TensorView<T, Rank>(_data, dims, strides);
+    }
+
+    template <size_t Rank>
+    operator TensorView<T, Rank>() const {
+        if (rank() != Rank) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can not convert a rank-{} RuntimeTensor into a rank-{} TensorView!", rank(), Rank);
+        }
+        Dim<Rank> dims(_dims.begin(), _dims.end());
+        Dim<Rank> strides(_strides.begin(), _strides.end());
+        return TensorView<T, Rank>(const_cast<T const *>(_data), dims, strides);
+    }
+
     /**
      * @brief Get the length of the tensor along a given axis.
      *
@@ -1855,6 +1875,26 @@ struct EINSUMS_EXPORT RuntimeTensorView : public tensor_base::CoreTensor,
 
 #    undef OPERATOR
 #endif
+
+    template <size_t Rank>
+    operator TensorView<T, Rank>() {
+        if (rank() != Rank) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can not convert a rank-{} RuntimeTensorView into a rank-{} TensorView!", rank(), Rank);
+        }
+        Dim<Rank> dims(_dims.begin(), _dims.end());
+        Dim<Rank> strides(_strides.begin(), _strides.end());
+        return TensorView<T, Rank>(_data, dims, strides);
+    }
+
+    template <size_t Rank>
+    operator TensorView<T, Rank>() const {
+        if (rank() != Rank) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can not convert a rank-{} RuntimeTensorView into a rank-{} TensorView!", rank(), Rank);
+        }
+        Dim<Rank> dims(_dims.begin(), _dims.end());
+        Dim<Rank> strides(_strides.begin(), _strides.end());
+        return TensorView<T, Rank>(const_cast<T const *>(_data), dims, strides);
+    }
 
     /**
      * @brief Get the length of the tensor along the given axis.

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -762,9 +762,13 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
         if (rank() != Rank) {
             EINSUMS_THROW_EXCEPTION(dimension_error, "Can not convert a rank-{} RuntimeTensor into a rank-{} TensorView!", rank(), Rank);
         }
-        Dim<Rank> dims(_dims.begin(), _dims.end());
-        Dim<Rank> strides(_strides.begin(), _strides.end());
-        return TensorView<T, Rank>(_data, dims, strides);
+        Dim<Rank>    dims;
+        Stride<Rank> strides;
+        for (int i = 0; i < Rank; i++) {
+            dims[i]    = _dims[i];
+            strides[i] = _strides[i];
+        }
+        return TensorView<T, Rank>(_data.data(), dims, strides);
     }
 
     template <size_t Rank>
@@ -772,9 +776,13 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
         if (rank() != Rank) {
             EINSUMS_THROW_EXCEPTION(dimension_error, "Can not convert a rank-{} RuntimeTensor into a rank-{} TensorView!", rank(), Rank);
         }
-        Dim<Rank> dims(_dims.begin(), _dims.end());
-        Dim<Rank> strides(_strides.begin(), _strides.end());
-        return TensorView<T, Rank>(const_cast<T const *>(_data), dims, strides);
+        Dim<Rank>    dims;
+        Stride<Rank> strides;
+        for (int i = 0; i < Rank; i++) {
+            dims[i]    = _dims[i];
+            strides[i] = _strides[i];
+        }
+        return TensorView<T, Rank>(const_cast<T const *>(_data.data()), dims, strides);
     }
 
     /**
@@ -1879,20 +1887,30 @@ struct EINSUMS_EXPORT RuntimeTensorView : public tensor_base::CoreTensor,
     template <size_t Rank>
     operator TensorView<T, Rank>() {
         if (rank() != Rank) {
-            EINSUMS_THROW_EXCEPTION(dimension_error, "Can not convert a rank-{} RuntimeTensorView into a rank-{} TensorView!", rank(), Rank);
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can not convert a rank-{} RuntimeTensorView into a rank-{} TensorView!", rank(),
+                                    Rank);
         }
-        Dim<Rank> dims(_dims.begin(), _dims.end());
-        Dim<Rank> strides(_strides.begin(), _strides.end());
+        Dim<Rank>    dims;
+        Stride<Rank> strides;
+        for (int i = 0; i < Rank; i++) {
+            dims[i]    = _dims[i];
+            strides[i] = _strides[i];
+        }
         return TensorView<T, Rank>(_data, dims, strides);
     }
 
     template <size_t Rank>
     operator TensorView<T, Rank>() const {
         if (rank() != Rank) {
-            EINSUMS_THROW_EXCEPTION(dimension_error, "Can not convert a rank-{} RuntimeTensorView into a rank-{} TensorView!", rank(), Rank);
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can not convert a rank-{} RuntimeTensorView into a rank-{} TensorView!", rank(),
+                                    Rank);
         }
-        Dim<Rank> dims(_dims.begin(), _dims.end());
-        Dim<Rank> strides(_strides.begin(), _strides.end());
+        Dim<Rank>    dims;
+        Stride<Rank> strides;
+        for (int i = 0; i < Rank; i++) {
+            dims[i]    = _dims[i];
+            strides[i] = _strides[i];
+        }
         return TensorView<T, Rank>(const_cast<T const *>(_data), dims, strides);
     }
 

--- a/libs/Einsums/Tensor/tests/unit/CMakeLists.txt
+++ b/libs/Einsums/Tensor/tests/unit/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 #----------------------------------------------------------------------------------------------
 
-set(TensorTests ArithmeticTensor BlockTensor TensorView)
+set(TensorTests ArithmeticTensor BlockTensor TensorView RuntimeTensors)
 
 foreach(test ${TensorTests})
   set(sources ${test}.cpp)

--- a/libs/Einsums/Tensor/tests/unit/RuntimeTensors.cpp
+++ b/libs/Einsums/Tensor/tests/unit/RuntimeTensors.cpp
@@ -1,0 +1,109 @@
+//--------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//--------------------------------------------------------------------------------------------
+
+#include <Einsums/Tensor/RuntimeTensor.hpp>
+#include <Einsums/Tensor/Tensor.hpp>
+#include <Einsums/TensorUtilities/CreateRandomTensor.hpp>
+
+#include <Einsums/Testing.hpp>
+
+TEMPLATE_TEST_CASE("Subset RuntimeTensorView", "[tensor]", float, double, std::complex<float>, std::complex<double>) {
+    using namespace einsums;
+
+    SECTION("Subset View 7x7[1,:] -> 1x7") {
+        size_t const size = 7;
+        size_t const row  = 1;
+
+        RuntimeTensor<TestType> I_original = create_random_tensor<TestType>("Original", size, size);
+        auto                    I_view     = I_original(row, All);
+
+        for (size_t i = 0; i < size; i++) {
+            REQUIRE(I_original(row, i) == I_view(i));
+        }
+    }
+
+    SECTION("Subset RuntimeView 7x7x7[4,:,:] -> 7x7") {
+        size_t const size = 7;
+        size_t const d1   = 4;
+
+        RuntimeTensor<TestType> I_original = create_random_tensor<TestType>("Original", size, size, size);
+        auto                    I_view     = I_original(d1, All, All);
+
+        for (size_t i = 0; i < size; i++) {
+            for (size_t j = 0; j < size; j++) {
+                REQUIRE(I_original(d1, i, j) == I_view(i, j));
+            }
+        }
+    }
+
+    SECTION("Subset RuntimeView 7x7x7[4,3,:] -> 7") {
+        size_t const size = 7;
+        size_t const d1   = 4;
+        size_t const d2   = 3;
+
+        RuntimeTensor<TestType> I_original = create_random_tensor<TestType>("Original", size, size, size);
+        auto                    I_view     = I_original(d1, d2, All);
+
+        for (size_t i = 0; i < size; i++) {
+            REQUIRE(I_original(d1, d2, i) == I_view(i));
+        }
+    }
+}
+
+TEMPLATE_TEST_CASE("Subset RuntimeTensor Conversion", "[tensor]", float, double, std::complex<float>, std::complex<double>) {
+    using namespace einsums;
+
+    SECTION("Subset View 7x7[1,:] -> 1x7") {
+        size_t const size = 7;
+        size_t const row  = 1;
+
+        RuntimeTensor<TestType> I_original = create_random_tensor<TestType>("Original", size, size);
+        auto                    I_view     = (TensorView<TestType, 1>)I_original(row, All);
+
+        for (size_t i = 0; i < size; i++) {
+            REQUIRE(I_original(row, i) == I_view(i));
+        }
+    }
+
+    SECTION("Subset RuntimeView 7x7x7[4,:,:] -> 7x7") {
+        size_t const size = 7;
+        size_t const d1   = 4;
+
+        RuntimeTensor<TestType> I_original = create_random_tensor<TestType>("Original", size, size, size);
+        auto                    I_view     = (TensorView<TestType, 2>)I_original(d1, All, All);
+
+        for (size_t i = 0; i < size; i++) {
+            for (size_t j = 0; j < size; j++) {
+                REQUIRE(I_original(d1, i, j) == I_view(i, j));
+            }
+        }
+    }
+
+    SECTION("Subset RuntimeView 7x7x7[4,3,:] -> 7") {
+        size_t const size = 7;
+        size_t const d1   = 4;
+        size_t const d2   = 3;
+
+        RuntimeTensor<TestType> I_original = create_random_tensor<TestType>("Original", size, size, size);
+        auto                    I_view     = (TensorView<TestType, 1>)I_original(d1, d2, All);
+
+        for (size_t i = 0; i < size; i++) {
+            REQUIRE(I_original(d1, d2, i) == I_view(i));
+        }
+    }
+
+    SECTION("Full View") {
+        size_t const size = 7;
+
+        RuntimeTensor<TestType> I_original = create_random_tensor<TestType>("Original", size, size);
+        auto                    I_view     = (TensorView<TestType, 2>)I_original;
+
+        for (size_t i = 0; i < size; i++) {
+            for (size_t j = 0; j < size; j++) {
+                REQUIRE(I_original(i, j) == I_view(i, j));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a way to wrap runtime tensors in compile-time views. Closes #113.