### PR TITLE
Add special view creation from block and tiled tensors

### DIFF
--- a/libs/Einsums/Concepts/CMakeLists.txt
+++ b/libs/Einsums/Concepts/CMakeLists.txt
@@ -8,9 +8,10 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(ConceptsHeaders Einsums/Concepts/Complex.hpp Einsums/Concepts/File.hpp
                     Einsums/Concepts/SmartPointer.hpp Einsums/Concepts/TensorConcepts.hpp
                     Einsums/Concepts/SubscriptChooser.hpp
+                    Einsums/Concepts/NamedRequirements.hpp
 )
 
-set(ConceptsSources)
+set(ConceptsSources CheckRequirements.cpp)
 
 include(Einsums_AddModule)
 einsums_add_module(

--- a/libs/Einsums/Concepts/include/Einsums/Concepts/NamedRequirements.hpp
+++ b/libs/Einsums/Concepts/include/Einsums/Concepts/NamedRequirements.hpp
@@ -51,16 +51,6 @@ concept Container = requires(T a, T b, T const ca, T const cb, T &ra, T &rb, T c
     {ca.end()} -> std::same_as<typename T::const_iterator>;
     {a.cbegin()} -> std::same_as<typename T::const_iterator>;
     {a.cend()} -> std::same_as<typename T::const_iterator>;
-    requires !std::random_access_iterator<typename T::iterator> || requires(typename T::iterator i, typename T::iterator j) {
-        {i <=> j} -> std::same_as<std::strong_ordering>;
-    };
-    requires !std::random_access_iterator<typename T::const_iterator> || requires(typename T::const_iterator ci, typename T::const_iterator cj) {
-        {ci <=> cj} -> std::same_as<std::strong_ordering>;
-    };
-    requires !std::random_access_iterator<typename T::iterator> || !std::random_access_iterator<typename T::const_iterator> || requires(typename T::iterator i, typename T::const_iterator cj) {
-        {i <=> cj} -> std::same_as<std::strong_ordering>;
-        {cj <=> i} -> std::same_as<std::strong_ordering>;
-    };
 
     {a == b} -> std::same_as<bool>;
     {a == cb} -> std::same_as<bool>;

--- a/libs/Einsums/Concepts/include/Einsums/Concepts/NamedRequirements.hpp
+++ b/libs/Einsums/Concepts/include/Einsums/Concepts/NamedRequirements.hpp
@@ -1,0 +1,135 @@
+//--------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//--------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <iterator>
+namespace einsums {
+
+/**
+ * @concept Container
+ *
+ * Checks that a type satisfies the Container requirement.
+ */
+template <typename T>
+concept Container = requires(T a, T b, T const ca, T const cb, T &ra, T &rb, T const &rca, T const &rcb, T &&rra, T &&rrb) {
+    // Check that the types exist.
+    typename T::value_type;
+    typename T::reference;
+    typename T::const_reference;
+    typename T::iterator;
+    typename T::const_iterator;
+    typename T::difference_type;
+    typename T::size_type;
+
+    // Check the properties of the types.
+    requires std::forward_iterator<typename T::iterator>;
+    requires std::is_same_v<std::iter_value_t<typename T::iterator>, typename T::value_type>;
+    requires std::is_convertible_v<typename T::iterator, typename T::const_iterator>;
+    requires std::forward_iterator<typename T::const_iterator>;
+    requires std::is_same_v<std::iter_value_t<typename T::const_iterator>, typename T::value_type>;
+    requires std::is_integral_v<typename T::difference_type>;
+    requires std::is_signed_v<typename T::difference_type>;
+    requires std::is_integral_v<typename T::size_type>;
+    requires std::is_unsigned_v<typename T::size_type>;
+    requires sizeof(typename T::size_type) >= sizeof(typename T::difference_type);
+
+    // Expressions.
+    T();
+    T(a);
+    T(ca);
+    a = b;
+    a = ca;
+    ra = a;
+    ra = ca;
+    a.~T();
+    {a.begin()} -> std::same_as<typename T::iterator>;
+    {ca.begin()} -> std::same_as<typename T::const_iterator>;
+    {a.end()} -> std::same_as<typename T::iterator>;
+    {ca.end()} -> std::same_as<typename T::const_iterator>;
+    {a.cbegin()} -> std::same_as<typename T::const_iterator>;
+    {a.cend()} -> std::same_as<typename T::const_iterator>;
+    requires !std::random_access_iterator<typename T::iterator> || requires(typename T::iterator i, typename T::iterator j) {
+        {i <=> j} -> std::same_as<std::strong_ordering>;
+    };
+    requires !std::random_access_iterator<typename T::const_iterator> || requires(typename T::const_iterator ci, typename T::const_iterator cj) {
+        {ci <=> cj} -> std::same_as<std::strong_ordering>;
+    };
+    requires !std::random_access_iterator<typename T::iterator> || !std::random_access_iterator<typename T::const_iterator> || requires(typename T::iterator i, typename T::const_iterator cj) {
+        {i <=> cj} -> std::same_as<std::strong_ordering>;
+        {cj <=> i} -> std::same_as<std::strong_ordering>;
+    };
+
+    {a == b} -> std::same_as<bool>;
+    {a == cb} -> std::same_as<bool>;
+    {ca == b} -> std::same_as<bool>;
+    {ca == cb} -> std::same_as<bool>;
+    {a != b} -> std::same_as<bool>;
+    {a != cb} -> std::same_as<bool>;
+    {ca != b} -> std::same_as<bool>;
+    {ca != cb} -> std::same_as<bool>;
+
+    a.swap(b);
+    ra.swap(b);
+    a.swap(rb);
+    ra.swap(rb);
+    requires std::swappable<T>;
+
+    {a.size()} -> std::same_as<typename T::size_type>;
+    {ca.size()} -> std::same_as<typename T::size_type>;
+    {a.max_size()} -> std::same_as<typename T::size_type>;
+    {ca.max_size()} -> std::same_as<typename T::size_type>;
+
+    {a.empty()} -> std::same_as<bool>;
+    {ca.empty()} -> std::same_as<bool>;
+};
+
+/**
+ * @concept ContainerOrInitializer
+ *
+ * Checks that a type satisfies the Container requirement or is an inizializer list.
+ */
+ template <typename T>
+ concept ContainerOrInitializer = requires(T a, T b, T const ca, T const cb, T &ra, T &rb, T const &rca, T const &rcb, T &&rra, T &&rrb) {
+     // Check that the types exist.
+     typename T::value_type;
+     typename T::reference;
+     typename T::const_reference;
+     typename T::iterator;
+     typename T::const_iterator;
+     typename T::size_type;
+ 
+     // Check the properties of the types.
+     requires std::forward_iterator<typename T::iterator>;
+     requires std::is_same_v<std::iter_value_t<typename T::iterator>, typename T::value_type>;
+     requires std::is_convertible_v<typename T::iterator, typename T::const_iterator>;
+     requires std::forward_iterator<typename T::const_iterator>;
+     requires std::is_same_v<std::iter_value_t<typename T::const_iterator>, typename T::value_type>;
+     requires std::is_integral_v<typename T::size_type>;
+     requires std::is_unsigned_v<typename T::size_type>;
+ 
+     // Expressions.
+     T();
+     {a.begin()} -> std::same_as<typename T::iterator>;
+     {ca.begin()} -> std::same_as<typename T::const_iterator>;
+     {a.end()} -> std::same_as<typename T::iterator>;
+     {ca.end()} -> std::same_as<typename T::const_iterator>;
+     requires !std::random_access_iterator<typename T::iterator> || requires(typename T::iterator i, typename T::iterator j) {
+         {i <=> j} -> std::same_as<std::strong_ordering>;
+     };
+     requires !std::random_access_iterator<typename T::const_iterator> || requires(typename T::const_iterator ci, typename T::const_iterator cj) {
+         {ci <=> cj} -> std::same_as<std::strong_ordering>;
+     };
+     requires !std::random_access_iterator<typename T::iterator> || !std::random_access_iterator<typename T::const_iterator> || requires(typename T::iterator i, typename T::const_iterator cj) {
+         {i <=> cj} -> std::same_as<std::strong_ordering>;
+         {cj <=> i} -> std::same_as<std::strong_ordering>;
+     };
+ 
+     {a.size()} -> std::same_as<typename T::size_type>;
+     {ca.size()} -> std::same_as<typename T::size_type>;
+     {a.max_size()} -> std::same_as<typename T::size_type>;
+ };
+
+} // namespace einsums

--- a/libs/Einsums/Concepts/include/Einsums/Concepts/NamedRequirements.hpp
+++ b/libs/Einsums/Concepts/include/Einsums/Concepts/NamedRequirements.hpp
@@ -106,16 +106,6 @@ concept Container = requires(T a, T b, T const ca, T const cb, T &ra, T &rb, T c
      {ca.begin()} -> std::same_as<typename T::const_iterator>;
      {a.end()} -> std::same_as<typename T::iterator>;
      {ca.end()} -> std::same_as<typename T::const_iterator>;
-     requires !std::random_access_iterator<typename T::iterator> || requires(typename T::iterator i, typename T::iterator j) {
-         {i <=> j} -> std::same_as<std::strong_ordering>;
-     };
-     requires !std::random_access_iterator<typename T::const_iterator> || requires(typename T::const_iterator ci, typename T::const_iterator cj) {
-         {ci <=> cj} -> std::same_as<std::strong_ordering>;
-     };
-     requires !std::random_access_iterator<typename T::iterator> || !std::random_access_iterator<typename T::const_iterator> || requires(typename T::iterator i, typename T::const_iterator cj) {
-         {i <=> cj} -> std::same_as<std::strong_ordering>;
-         {cj <=> i} -> std::same_as<std::strong_ordering>;
-     };
  
      {a.size()} -> std::same_as<typename T::size_type>;
      {ca.size()} -> std::same_as<typename T::size_type>;

--- a/libs/Einsums/Concepts/src/CheckRequirements.cpp
+++ b/libs/Einsums/Concepts/src/CheckRequirements.cpp
@@ -1,0 +1,17 @@
+//--------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//--------------------------------------------------------------------------------------------
+
+#include <Einsums/Concepts/NamedRequirements.hpp>
+
+#include <array>
+#include <list>
+#include <vector>
+
+using namespace einsums;
+
+static_assert(Container<std::vector<int>>);
+static_assert(Container<std::array<int, 10>>);
+static_assert(Container<std::list<int>>);
+static_assert(!Container<std::initializer_list<int>>); // initializer_list does not have difference_type, so it is not a container.

--- a/libs/Einsums/Config/include/Einsums/Config/CompilerSpecific.hpp
+++ b/libs/Einsums/Config/include/Einsums/Config/CompilerSpecific.hpp
@@ -10,7 +10,8 @@
 #include <complex>
 
 #if defined(__INTEL_LLVM_COMPILER) || defined(__INTEL_COMPILER)
-#    define EINSUMS_OMP_PARALLEL_FOR _Pragma("omp parallel for simd")
+#    define EINSUMS_OMP_PARALLEL_FOR_SIMD _Pragma("omp parallel for simd")
+#    define EINSUMS_OMP_PARALLEL_FOR _Pragma("omp parallel for")
 #    define EINSUMS_OMP_SIMD         _Pragma("omp simd")
 #    define EINSUMS_OMP_PARALLEL     _Pragma("omp parallel")
 #    define EINSUMS_OMP_TASK_FOR     _Pragma("omp taskloop simd")
@@ -18,6 +19,7 @@
 #    define EINSUMS_OMP_FOR_NOWAIT   _Pragma("omp for nowait")
 #    define EINSUMS_OMP_CRITICAL     _Pragma("omp critical")
 #else
+#    define EINSUMS_OMP_PARALLEL_FOR_SIMD _Pragma("omp parallel for")
 #    define EINSUMS_OMP_PARALLEL_FOR _Pragma("omp parallel for")
 #    define EINSUMS_OMP_SIMD
 #    define EINSUMS_OMP_PARALLEL   _Pragma("omp parallel")

--- a/libs/Einsums/LinearAlgebra/include/Einsums/LinearAlgebra/Base.hpp
+++ b/libs/Einsums/LinearAlgebra/include/Einsums/LinearAlgebra/Base.hpp
@@ -435,7 +435,7 @@ void direct_product(typename AType::ValueType alpha, AType const &A, BType const
             C->data()[C_ord] = beta * C->data()[C_ord] + alpha * (A.data()[A_ord] * B.data()[B_ord]);
         }
     } else {
-        EINSUMS_OMP_PARALLEL_FOR
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
         for (size_t item = 0; item < elements; item++) {
             C->data()[item] = beta * C->data()[item] + alpha * (A.data()[item] * B.data()[item]);
         }

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/DeviceTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/DeviceTensor.hpp
@@ -1567,6 +1567,16 @@ DeviceTensor<T, rank>::operator Tensor<T, rank>() const {
     return out;
 }
 
+template <typename T, size_t rank>
+DeviceTensor<T, rank>::operator DeviceTensorView<T, rank>() {
+    return DeviceTensorView<T, rank>(*this, _dims);
+}
+
+template <typename T, size_t rank>
+DeviceTensor<T, rank>::operator DeviceTensorView<T, rank> const() const {
+    return DeviceTensorView<T, rank>(*this, _dims);
+}
+
 #endif
 
 } // namespace einsums

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/BlockTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/BlockTensor.hpp
@@ -14,6 +14,8 @@
 #include <Einsums/Concepts/SubscriptChooser.hpp>
 #include <Einsums/Concepts/TensorConcepts.hpp>
 #include <Einsums/Tensor/Tensor.hpp>
+#include <Einsums/Tensor/TensorForward.hpp>
+#include <Einsums/Tensor/TiledTensor.hpp>
 #include <Einsums/TensorBase/IndexUtilities.hpp>
 #include <Einsums/TensorBase/TensorBase.hpp>
 
@@ -1152,7 +1154,43 @@ struct BlockTensor : public tensor_base::BlockTensor<T, Rank, Tensor<T, Rank>>, 
     template <size_t Dims>
     explicit BlockTensor(Dim<Dims> block_dims) : tensor_base::BlockTensor<T, Rank, Tensor<T, Rank>>(block_dims) {}
 
-    // size_t dim(int d) const override { return detail::BlockTensorBase<T, Rank, Tensor>::dim(d); }
+    operator TiledTensorView<T, Rank>() {
+        std::array<std::vector<size_t>, Rank> block_dims;
+
+        for (int i = 0; i < Rank; i++) {
+            block_dims[i] = this->_dims;
+        }
+
+        TiledTensorView<T, Rank> out{"block view", block_dims};
+
+        std::array<int, Rank> index;
+
+        for (int i = 0; i < this->_blocks.size(); i++) {
+            index.fill(i);
+            out.insert_tile(index, TensorView<T, Rank>(this->_blocks[i], this->_blocks[i].dims()));
+        }
+
+        return out;
+    }
+
+    operator TiledTensorView<T, Rank> const() const {
+        std::array<std::vector<size_t>, Rank> block_dims;
+
+        for (int i = 0; i < Rank; i++) {
+            block_dims[i] = this->_dims;
+        }
+
+        TiledTensorView<T, Rank> out{"block view", block_dims};
+
+        std::array<int, Rank> index;
+
+        for (int i = 0; i < this->_blocks.size(); i++) {
+            index.fill(i);
+            out.insert_tile(index, TensorView<T, Rank>(this->_blocks[i], this->_blocks[i].dims()));
+        }
+
+        return out;
+    }
 };
 
 #ifdef EINSUMS_COMPUTE_CODE
@@ -1467,6 +1505,44 @@ struct BlockDeviceTensor : public tensor_base::BlockTensor<T, Rank, einsums::Dev
         }
 
         return subscript_tensor(this->_blocks.at(block), index_list);
+    }
+
+    operator TiledDeviceTensorView<T, Rank>() {
+        std::array<std::vector<size_t>, Rank> block_dims;
+
+        for (int i = 0; i < Rank; i++) {
+            block_dims[i] = this->_dims;
+        }
+
+        TiledDeviceTensorView<T, Rank> out("block view", block_dims);
+
+        std::array<int, Rank> index;
+
+        for (int i = 0; i < this->_blocks.size(); i++) {
+            index.fill(i);
+            out.insert_tile(index, DeviceTensorView<T, Rank>(this->_blocks[i], this->_blocks[i].dims()));
+        }
+
+        return out;
+    }
+
+    operator TiledDeviceTensorView<T, Rank> const() const {
+        std::array<std::vector<size_t>, Rank> block_dims;
+
+        for (int i = 0; i < Rank; i++) {
+            block_dims[i] = this->_dims;
+        }
+
+        TiledDeviceTensorView<T, Rank> out("block view", block_dims);
+
+        std::array<int, Rank> index;
+
+        for (int i = 0; i < this->_blocks.size(); i++) {
+            index.fill(i);
+            out.insert_tile(index, DeviceTensorView<T, Rank>(this->_blocks[i], this->_blocks[i].dims()));
+        }
+
+        return out;
     }
 };
 #endif

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/DeviceTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/DeviceTensor.hpp
@@ -3,7 +3,6 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 //--------------------------------------------------------------------------------------------
 
-
 #ifndef DEVICE_TENSOR_HPP
 #define DEVICE_TENSOR_HPP
 // We use this so that the implementation headers work on their own.
@@ -821,6 +820,10 @@ struct DeviceTensor : public einsums::tensor_base::DeviceTensorBase,
      * @copydoc DeviceTensor::add_assign(DeviceTensor<T, rank> const &)
      */
     DeviceTensor<T, rank> &operator/=(DeviceTensor<T, rank> const &other) { return this->div_assign(other); }
+
+    operator DeviceTensorView<T, rank>();
+
+    operator DeviceTensorView<T, rank> const() const;
 
     /**
      * @brief Get the dimension for the given rank.

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -715,23 +715,16 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             T            *this_data = this->data();                                                                                        \
             const TOther *b_data    = b.data();                                                                                            \
             size_t        elements  = size();                                                                                              \
-            if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                            \
-                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
-                for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
+            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
+            for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                                   \
+                if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
                     this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                         \
-                }                                                                                                                          \
-            } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                                   \
-                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
-                for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
+                } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                               \
                     this_data[sentinel] OP(T) b_data[sentinel].real();                                                                     \
-                }                                                                                                                          \
-            } else {                                                                                                                       \
-                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
-                for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
+                } else {                                                                                                                   \
                     this_data[sentinel] OP(T) b_data[sentinel];                                                                            \
                 }                                                                                                                          \
             }                                                                                                                              \
-                                                                                                                                           \
             return *this;                                                                                                                  \
         }                                                                                                                                  \
                                                                                                                                            \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -39,9 +39,7 @@ namespace einsums {
  * @tparam T The data type stored by the tensor.
  */
 template <typename T>
-struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
-                                      tensor_base::RuntimeTensorNoType,
-                                      design_pats::Lockable<std::recursive_mutex> {
+struct RuntimeTensor : public tensor_base::CoreTensor, tensor_base::RuntimeTensorNoType, design_pats::Lockable<std::recursive_mutex> {
   public:
     /**
      * @typedef Vector
@@ -152,7 +150,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
 
         _data.resize(size);
 
-        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        EINSUMS_OMP_PARALLEL_FOR
         for (size_t sentinel = 0; sentinel < this->size(); sentinel++) {
             size_t hold = sentinel, ord = 0;
             for (int i = 0; i < Rank; i++) {
@@ -163,7 +161,8 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
         }
     }
 
-    virtual ~RuntimeTensor() = default;
+    // HIP clang doesn't like it when this is defaulted.
+    virtual ~RuntimeTensor() {}
 
     /**
      * @brief Set all of the data in the tensor to zero.
@@ -291,7 +290,8 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
     T &operator()(Args... args) {
         if (sizeof...(Args) < rank()) {
             EINSUMS_THROW_EXCEPTION(todo_error,
-                                    "Not yet implemented: can not handle fewer integral indices than rank in (non-const) runtime tensor.");
+                                    "Not yet implemented: can not handle fewer integral indices than rank in (non-const) runtime"
+                                    "tensor.");
         } else if (sizeof...(Args) > rank()) {
             EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript operator!");
         }
@@ -913,7 +913,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
 
     template <typename TOther>
     friend class RuntimeTensor;
-}; // namespace einsums
+};
 
 /**
  * @class RuntimeTensorView
@@ -921,10 +921,10 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
  * @brief Represents a view of a tensor whose properties can be determined at runtime but not compile time.
  */
 template <typename T>
-struct EINSUMS_EXPORT RuntimeTensorView : public tensor_base::CoreTensor,
-                                          public tensor_base::RuntimeTensorNoType,
-                                          public tensor_base::RuntimeTensorViewNoType,
-                                          public design_pats::Lockable<std::recursive_mutex> {
+struct RuntimeTensorView : public tensor_base::CoreTensor,
+                           public tensor_base::RuntimeTensorNoType,
+                           public tensor_base::RuntimeTensorViewNoType,
+                           public design_pats::Lockable<std::recursive_mutex> {
   public:
     /**
      * @typedef ValueType
@@ -1193,7 +1193,8 @@ struct EINSUMS_EXPORT RuntimeTensorView : public tensor_base::CoreTensor,
         }
     }
 
-    virtual ~RuntimeTensorView() = default;
+    // HIP clang doesn't like it when this is defaulted.
+    virtual ~RuntimeTensorView() {}
 
     /**
      * @brief Set all the entries in the tensor to zero.
@@ -2232,15 +2233,17 @@ void println(AType const &A, einsums::TensorPrintOptions options = {}) {
     fprintln(std::cout, A, options);
 }
 
-// EINSUMS_EXPORT extern template class RuntimeTensor<float>;
-// EINSUMS_EXPORT extern template class RuntimeTensor<double>;
-// EINSUMS_EXPORT extern template class RuntimeTensor<std::complex<float>>;
-// EINSUMS_EXPORT extern template class RuntimeTensor<std::complex<double>>;
+#endif
 
-// EINSUMS_EXPORT extern template class RuntimeTensorView<float>;
-// EINSUMS_EXPORT extern template class RuntimeTensorView<double>;
-// EINSUMS_EXPORT extern template class RuntimeTensorView<std::complex<float>>;
-// EINSUMS_EXPORT extern template class RuntimeTensorView<std::complex<double>>;
+#if !defined(EINSUMS_WINDOWS) && !defined(DOXYGEN)
+extern template class EINSUMS_EXPORT RuntimeTensor<float>;
+extern template class EINSUMS_EXPORT RuntimeTensor<double>;
+extern template class EINSUMS_EXPORT RuntimeTensor<std::complex<float>>;
+extern template class EINSUMS_EXPORT RuntimeTensor<std::complex<double>>;
 
+extern template class EINSUMS_EXPORT RuntimeTensorView<float>;
+extern template class EINSUMS_EXPORT RuntimeTensorView<double>;
+extern template class EINSUMS_EXPORT RuntimeTensorView<std::complex<float>>;
+extern template class EINSUMS_EXPORT RuntimeTensorView<std::complex<double>>;
 #endif
 } // namespace einsums

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -708,8 +708,9 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             }                                                                                                                              \
             T            *this_data = this->data();                                                                                        \
             const TOther *b_data    = b.data();                                                                                            \
+            size_t        elements  = size();                                                                                              \
             EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
-            for (size_t sentinel = 0; sentinel < size(); sentinel++) {                                                                     \
+            for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                                   \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
                     this->_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                       \
                 } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                               \
@@ -731,8 +732,9 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                 EINSUMS_THROW_EXCEPTION(dimension_error,                                                                                   \
                                         "Can not perform the operation with runtime tensor and view of different dimensions!");            \
             }                                                                                                                              \
+            size_t elements = size();                                                                                                      \
             EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
-            for (size_t sentinel = 0; sentinel < size(); sentinel++) {                                                                     \
+            for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                                   \
                 thread_local std::vector<size_t> index(rank());                                                                            \
                 sentinel_to_indices(sentinel, this->_strides, index);                                                                      \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -712,11 +712,11 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
             for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                                   \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
-                    this->_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                       \
+                    this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                         \
                 } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                               \
-                    this->_data[sentinel] OP(T) b_data[sentinel].real();                                                                   \
+                    this_data[sentinel] OP(T) b_data[sentinel].real();                                                                     \
                 } else {                                                                                                                   \
-                    this->_data[sentinel] OP(T) b_data[sentinel];                                                                          \
+                    this_data[sentinel] OP(T) b_data[sentinel];                                                                            \
                 }                                                                                                                          \
             }                                                                                                                              \
             return *this;                                                                                                                  \
@@ -733,7 +733,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                                         "Can not perform the operation with runtime tensor and view of different dimensions!");            \
             }                                                                                                                              \
             size_t elements = size();                                                                                                      \
-            EINSUMS_OMP_PARALLEL_FOR                                                                                                  \
+            EINSUMS_OMP_PARALLEL_FOR                                                                                                       \
             for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                                   \
                 thread_local std::vector<size_t> index(rank());                                                                            \
                 sentinel_to_indices(sentinel, this->_strides, index);                                                                      \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -695,12 +695,13 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                     this_data[i] OP(T)(RemoveComplexT<T>) b;                                                                               \
                 }                                                                                                                          \
             } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                                   \
+                T const b_real = (T)b.real();                                                                                              \
                 EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
                 for (size_t i = 0; i < elements; i++) {                                                                                    \
-                    this_data[i] OP(T) b.real();                                                                                           \
+                    this_data[i] OP b_real;                                                                                                \
                 }                                                                                                                          \
             } else {                                                                                                                       \
-                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
+                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
                 for (size_t i = 0; i < elements; i++) {                                                                                    \
                     this_data[i] OP(T) b;                                                                                                  \
                 }                                                                                                                          \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -720,7 +720,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                     this_data[sentinel] OP(T) b_data[sentinel].real();                                                                     \
                 }                                                                                                                          \
             } else {                                                                                                                       \
-                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
+                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
                 for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
                     if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                    \
                         this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                     \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -152,7 +152,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
 
         _data.resize(size);
 
-        EINSUMS_OMP_PARALLEL_FOR
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
         for (size_t sentinel = 0; sentinel < this->size(); sentinel++) {
             size_t hold = sentinel, ord = 0;
             for (int i = 0; i < Rank; i++) {
@@ -511,7 +511,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             _data.resize(other.size());
         }
 
-        EINSUMS_OMP_PARALLEL_FOR
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
         for (size_t i = 0; i < _data.size(); i++) {
             _data[i] = (T)other.data()[i];
         }
@@ -570,7 +570,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             _data.resize(other.size());
         }
 
-        EINSUMS_OMP_PARALLEL_FOR
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
         for (size_t sentinel = 0; sentinel < _data.size(); sentinel++) {
             _data[sentinel] = other.data()[sentinel];
         }
@@ -633,7 +633,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             _data.resize(other.size());
         }
 
-        EINSUMS_OMP_PARALLEL_FOR
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
         for (size_t sentinel = 0; sentinel < _data.size(); sentinel++) {
             _data[sentinel] = other.data()[sentinel];
         }
@@ -711,7 +711,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             }                                                                                                                              \
             T            *this_data = this->data();                                                                                        \
             const TOther *b_data    = b.data();                                                                                            \
-            EINSUMS_OMP_PARALLEL_FOR                                                                                                       \
+            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
             for (size_t sentinel = 0; sentinel < size(); sentinel++) {                                                                     \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
                     this->_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                       \
@@ -734,7 +734,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                 EINSUMS_THROW_EXCEPTION(dimension_error,                                                                                   \
                                         "Can not perform the operation with runtime tensor and view of different dimensions!");            \
             }                                                                                                                              \
-            EINSUMS_OMP_PARALLEL_FOR                                                                                                       \
+            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
             for (size_t sentinel = 0; sentinel < size(); sentinel++) {                                                                     \
                 thread_local std::vector<size_t> index(rank());                                                                            \
                 sentinel_to_indices(sentinel, this->_strides, index);                                                                      \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -695,7 +695,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                     this_data[i] OP(T)(RemoveComplexT<T>) b;                                                                               \
                 }                                                                                                                          \
             } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                                   \
-                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
+                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
                 for (size_t i = 0; i < elements; i++) {                                                                                    \
                     this_data[i] OP(T) b.real();                                                                                           \
                 }                                                                                                                          \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -695,10 +695,9 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                     this_data[i] OP(T)(RemoveComplexT<T>) b;                                                                               \
                 }                                                                                                                          \
             } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                                   \
-                T const b_real = (T)b.real();                                                                                              \
-                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
+                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
                 for (size_t i = 0; i < elements; i++) {                                                                                    \
-                    this_data[i] OP b_real;                                                                                                \
+                    this_data[i] OP(T) b.real();                                                                                           \
                 }                                                                                                                          \
             } else {                                                                                                                       \
                 EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -689,7 +689,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
         auto operator OP(const TOther &b)->RuntimeTensor<T> & {                                                                            \
             size_t elements = _data.size();                                                                                                \
             auto  *data     = _data.data();                                                                                                \
-            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
+            EINSUMS_OMP_PARALLEL_FOR                                                                                                       \
             for (size_t i = 0; i < elements; i++) {                                                                                        \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
                     data[i] OP(T)(RemoveComplexT<T>) b;                                                                                    \
@@ -709,7 +709,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             T            *this_data = this->data();                                                                                        \
             const TOther *b_data    = b.data();                                                                                            \
             size_t        elements  = size();                                                                                              \
-            EINSUMS_OMP_PARALLEL_FOR                                                                                                       \
+            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
             for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                                   \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
                     this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                         \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -700,7 +700,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                     this_data[i] OP(T) b.real();                                                                                           \
                 }                                                                                                                          \
             } else {                                                                                                                       \
-                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
+                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
                 for (size_t i = 0; i < elements; i++) {                                                                                    \
                     this_data[i] OP(T) b;                                                                                                  \
                 }                                                                                                                          \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -709,7 +709,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             T            *this_data = this->data();                                                                                        \
             const TOther *b_data    = b.data();                                                                                            \
             size_t        elements  = size();                                                                                              \
-            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
+            EINSUMS_OMP_PARALLEL_FOR                                                                                                       \
             for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                                   \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
                     this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                         \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -687,9 +687,9 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
 #    define OPERATOR(OP, NAME)                                                                                                             \
         template <typename TOther>                                                                                                         \
         auto operator OP(const TOther &b)->RuntimeTensor<T> & {                                                                            \
-            size_t elements = _data.size();                                                                                                \
-            auto  *data     = _data.data();                                                                                                \
-            EINSUMS_OMP_PARALLEL_FOR                                                                                                       \
+            size_t elements = size();                                                                                                      \
+            T     *data     = data();                                                                                                      \
+            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
             for (size_t i = 0; i < elements; i++) {                                                                                        \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
                     data[i] OP(T)(RemoveComplexT<T>) b;                                                                                    \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -725,7 +725,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                     this_data[sentinel] OP(T) b_data[sentinel].real();                                                                     \
                 }                                                                                                                          \
             } else {                                                                                                                       \
-                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
+                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
                 for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
                     this_data[sentinel] OP(T) b_data[sentinel];                                                                            \
                 }                                                                                                                          \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -733,7 +733,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                                         "Can not perform the operation with runtime tensor and view of different dimensions!");            \
             }                                                                                                                              \
             size_t elements = size();                                                                                                      \
-            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
+            EINSUMS_OMP_PARALLEL_FOR                                                                                                  \
             for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                                   \
                 thread_local std::vector<size_t> index(rank());                                                                            \
                 sentinel_to_indices(sentinel, this->_strides, index);                                                                      \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -720,7 +720,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                     this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                         \
                 }                                                                                                                          \
             } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                                   \
-                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
+                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
                 for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
                     this_data[sentinel] OP(T) b_data[sentinel].real();                                                                     \
                 }                                                                                                                          \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -689,14 +689,19 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
         auto operator OP(const TOther &b)->RuntimeTensor<T> & {                                                                            \
             size_t elements  = size();                                                                                                     \
             T     *this_data = data();                                                                                                     \
-            EINSUMS_OMP_PARALLEL_FOR                                                                                                  \
-            for (size_t i = 0; i < elements; i++) {                                                                                        \
-                if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
-                    this_data[i] OP(T)(RemoveComplexT<T>) b;                                                                               \
-                } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                               \
+            if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                                          \
+                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
+                for (size_t i = 0; i < elements; i++) {                                                                                    \
                     this_data[i] OP(T) b.real();                                                                                           \
-                } else {                                                                                                                   \
-                    this_data[i] OP(T) b;                                                                                                  \
+                }                                                                                                                          \
+            } else {                                                                                                                       \
+                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
+                for (size_t i = 0; i < elements; i++) {                                                                                    \
+                    if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                    \
+                        this_data[i] OP(T)(RemoveComplexT<T>) b;                                                                           \
+                    } else {                                                                                                               \
+                        this_data[i] OP(T) b;                                                                                              \
+                    }                                                                                                                      \
                 }                                                                                                                          \
             }                                                                                                                              \
             return *this;                                                                                                                  \
@@ -709,16 +714,22 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             T            *this_data = this->data();                                                                                        \
             const TOther *b_data    = b.data();                                                                                            \
             size_t        elements  = size();                                                                                              \
-            EINSUMS_OMP_PARALLEL_FOR                                                                                                  \
-            for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                                   \
-                if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
-                    this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                         \
-                } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                               \
+            if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                                          \
+                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
+                for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
                     this_data[sentinel] OP(T) b_data[sentinel].real();                                                                     \
-                } else {                                                                                                                   \
-                    this_data[sentinel] OP(T) b_data[sentinel];                                                                            \
+                }                                                                                                                          \
+            } else {                                                                                                                       \
+                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
+                for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
+                    if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                    \
+                        this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                     \
+                    } else {                                                                                                               \
+                        this_data[sentinel] OP(T) b_data[sentinel];                                                                        \
+                    }                                                                                                                      \
                 }                                                                                                                          \
             }                                                                                                                              \
+                                                                                                                                           \
             return *this;                                                                                                                  \
         }                                                                                                                                  \
                                                                                                                                            \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -689,7 +689,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
         auto operator OP(const TOther &b)->RuntimeTensor<T> & {                                                                            \
             size_t elements  = size();                                                                                                     \
             T     *this_data = data();                                                                                                     \
-            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
+            EINSUMS_OMP_PARALLEL_FOR                                                                                                  \
             for (size_t i = 0; i < elements; i++) {                                                                                        \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
                     this_data[i] OP(T)(RemoveComplexT<T>) b;                                                                               \
@@ -709,7 +709,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             T            *this_data = this->data();                                                                                        \
             const TOther *b_data    = b.data();                                                                                            \
             size_t        elements  = size();                                                                                              \
-            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
+            EINSUMS_OMP_PARALLEL_FOR                                                                                                  \
             for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                                   \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
                     this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                         \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -695,7 +695,7 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
                     this_data[i] OP(T) b.real();                                                                                           \
                 }                                                                                                                          \
             } else {                                                                                                                       \
-                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
+                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
                 for (size_t i = 0; i < elements; i++) {                                                                                    \
                     if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                    \
                         this_data[i] OP(T)(RemoveComplexT<T>) b;                                                                           \
@@ -714,19 +714,20 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
             T            *this_data = this->data();                                                                                        \
             const TOther *b_data    = b.data();                                                                                            \
             size_t        elements  = size();                                                                                              \
-            if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                                          \
+            if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                            \
+                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
+                for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
+                    this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                         \
+                }                                                                                                                          \
+            } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                                   \
                 EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
                 for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
                     this_data[sentinel] OP(T) b_data[sentinel].real();                                                                     \
                 }                                                                                                                          \
             } else {                                                                                                                       \
-                EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                              \
+                EINSUMS_OMP_PARALLEL_FOR                                                                                                   \
                 for (size_t sentinel = 0; sentinel < elements; sentinel++) {                                                               \
-                    if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                    \
-                        this_data[sentinel] OP(T)(RemoveComplexT<T>) b_data[sentinel];                                                     \
-                    } else {                                                                                                               \
-                        this_data[sentinel] OP(T) b_data[sentinel];                                                                        \
-                    }                                                                                                                      \
+                    this_data[sentinel] OP(T) b_data[sentinel];                                                                            \
                 }                                                                                                                          \
             }                                                                                                                              \
                                                                                                                                            \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/RuntimeTensor.hpp
@@ -687,16 +687,16 @@ struct EINSUMS_EXPORT RuntimeTensor : public tensor_base::CoreTensor,
 #    define OPERATOR(OP, NAME)                                                                                                             \
         template <typename TOther>                                                                                                         \
         auto operator OP(const TOther &b)->RuntimeTensor<T> & {                                                                            \
-            size_t elements = size();                                                                                                      \
-            T     *data     = data();                                                                                                      \
+            size_t elements  = size();                                                                                                     \
+            T     *this_data = data();                                                                                                     \
             EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
             for (size_t i = 0; i < elements; i++) {                                                                                        \
                 if constexpr (IsComplexV<T> && !IsComplexV<TOther> && !std::is_same_v<RemoveComplexT<T>, TOther>) {                        \
-                    data[i] OP(T)(RemoveComplexT<T>) b;                                                                                    \
+                    this_data[i] OP(T)(RemoveComplexT<T>) b;                                                                               \
                 } else if constexpr (!IsComplexV<T> && IsComplexV<TOther>) {                                                               \
-                    data[i] OP(T) b.real();                                                                                                \
+                    this_data[i] OP(T) b.real();                                                                                           \
                 } else {                                                                                                                   \
-                    data[i] OP(T) b;                                                                                                       \
+                    this_data[i] OP(T) b;                                                                                                  \
                 }                                                                                                                          \
             }                                                                                                                              \
             return *this;                                                                                                                  \

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/Tensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/Tensor.hpp
@@ -714,7 +714,7 @@ struct Tensor : tensor_base::CoreTensor, design_pats::Lockable<std::recursive_mu
 
         size_t size = this->size();
 
-        EINSUMS_OMP_PARALLEL_FOR
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
         for (size_t sentinel = 0; sentinel < size; sentinel++) {
             _data[sentinel] = other.data()[sentinel];
         }

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/Tensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/Tensor.hpp
@@ -1348,6 +1348,8 @@ struct TensorView final : tensor_base::CoreTensor, design_pats::Lockable<std::re
         return *this;
     }
 
+    void zero() { *this = T{0.0}; }
+
 #ifndef DOXYGEN
 #    if defined(OPERATOR)
 #        undef OPERATOR

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/TensorForward.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/TensorForward.hpp
@@ -54,19 +54,28 @@ struct BlockTensor;
 template <typename T, size_t Rank>
 struct TiledTensor;
 
-#if defined(EINSUMS_COMPUTE_CODE)
+#    if defined(EINSUMS_COMPUTE_CODE)
 template <typename T, size_t Rank>
 struct DeviceTensor;
+
+template <typename T, size_t Rank>
+struct DeviceTensorView;
 
 template <typename T, size_t Rank>
 struct BlockDeviceTensor;
 
 template <typename T, size_t Rank>
 struct TiledDeviceTensor;
-#endif
+
+template <typename T, size_t Rank>
+struct TiledDeviceTensorView;
+#    endif
 
 template <typename T, size_t Rank>
 struct TensorView;
+
+template <typename T, size_t Rank>
+struct TiledTensorView;
 
 template <typename T, size_t ViewRank, size_t Rank>
 struct DiskView;
@@ -74,10 +83,10 @@ struct DiskView;
 template <typename T, size_t Rank>
 struct DiskTensor;
 
-template<typename T>
+template <typename T>
 struct RuntimeTensor;
 
-template<typename T>
+template <typename T>
 struct RuntimeTensorView;
 
 template <typename T>
@@ -96,7 +105,7 @@ using VectorData = std::vector<T>;
  * @param type The type held by that tensor.
  * @param rank The rank of the tensor.
  */
-#define TENSOR_EXPORT_TR(tensortype, type, rank) extern template class EINSUMS_EXPORT tensortype<type, rank>;
+#    define TENSOR_EXPORT_TR(tensortype, type, rank) extern template class EINSUMS_EXPORT tensortype<type, rank>;
 
 /**
  * @def TENSOR_EXPORT_RANK
@@ -107,11 +116,11 @@ using VectorData = std::vector<T>;
  * @param tensortype The type of tensor to declare.
  * @param rank The rank of the tensor.
  */
-#define TENSOR_EXPORT_RANK(tensortype, rank)                                                                                               \
-    TENSOR_EXPORT_TR(tensortype, float, rank)                                                                                              \
-    TENSOR_EXPORT_TR(tensortype, double, rank)                                                                                             \
-    TENSOR_EXPORT_TR(tensortype, std::complex<float>, rank)                                                                                \
-    TENSOR_EXPORT_TR(tensortype, std::complex<double>, rank)
+#    define TENSOR_EXPORT_RANK(tensortype, rank)                                                                                           \
+        TENSOR_EXPORT_TR(tensortype, float, rank)                                                                                          \
+        TENSOR_EXPORT_TR(tensortype, double, rank)                                                                                         \
+        TENSOR_EXPORT_TR(tensortype, std::complex<float>, rank)                                                                            \
+        TENSOR_EXPORT_TR(tensortype, std::complex<double>, rank)
 
 /**
  * @def TENSOR_EXPORT
@@ -121,11 +130,11 @@ using VectorData = std::vector<T>;
  *
  * @param tensortype The type of tensor to declare.
  */
-#define TENSOR_EXPORT(tensortype)                                                                                                          \
-    TENSOR_EXPORT_RANK(tensortype, 1)                                                                                                      \
-    TENSOR_EXPORT_RANK(tensortype, 2)                                                                                                      \
-    TENSOR_EXPORT_RANK(tensortype, 3)                                                                                                      \
-    TENSOR_EXPORT_RANK(tensortype, 4)
+#    define TENSOR_EXPORT(tensortype)                                                                                                      \
+        TENSOR_EXPORT_RANK(tensortype, 1)                                                                                                  \
+        TENSOR_EXPORT_RANK(tensortype, 2)                                                                                                  \
+        TENSOR_EXPORT_RANK(tensortype, 3)                                                                                                  \
+        TENSOR_EXPORT_RANK(tensortype, 4)
 
 /**
  * @def TENSOR_DEFINE_TR
@@ -136,7 +145,7 @@ using VectorData = std::vector<T>;
  * @param type The type held by that tensor.
  * @param rank The rank of the tensor.
  */
-#define TENSOR_DEFINE_TR(tensortype, type, rank) template class tensortype<type, rank>;
+#    define TENSOR_DEFINE_TR(tensortype, type, rank) template class tensortype<type, rank>;
 
 /**
  * @def TENSOR_DEFINE_RANK
@@ -147,11 +156,11 @@ using VectorData = std::vector<T>;
  * @param tensortype The type of tensor to define.
  * @param rank The rank of the tensor.
  */
-#define TENSOR_DEFINE_RANK(tensortype, rank)                                                                                               \
-    TENSOR_DEFINE_TR(tensortype, float, rank)                                                                                              \
-    TENSOR_DEFINE_TR(tensortype, double, rank)                                                                                             \
-    TENSOR_DEFINE_TR(tensortype, std::complex<float>, rank)                                                                                \
-    TENSOR_DEFINE_TR(tensortype, std::complex<double>, rank)
+#    define TENSOR_DEFINE_RANK(tensortype, rank)                                                                                           \
+        TENSOR_DEFINE_TR(tensortype, float, rank)                                                                                          \
+        TENSOR_DEFINE_TR(tensortype, double, rank)                                                                                         \
+        TENSOR_DEFINE_TR(tensortype, std::complex<float>, rank)                                                                            \
+        TENSOR_DEFINE_TR(tensortype, std::complex<double>, rank)
 
 /**
  * @def TENSOR_DEFINE
@@ -161,11 +170,11 @@ using VectorData = std::vector<T>;
  *
  * @param tensortype The type of tensor to define.
  */
-#define TENSOR_DEFINE(tensortype)                                                                                                          \
-    TENSOR_DEFINE_RANK(tensortype, 1)                                                                                                      \
-    TENSOR_DEFINE_RANK(tensortype, 2)                                                                                                      \
-    TENSOR_DEFINE_RANK(tensortype, 3)                                                                                                      \
-    TENSOR_DEFINE_RANK(tensortype, 4)
+#    define TENSOR_DEFINE(tensortype)                                                                                                      \
+        TENSOR_DEFINE_RANK(tensortype, 1)                                                                                                  \
+        TENSOR_DEFINE_RANK(tensortype, 2)                                                                                                  \
+        TENSOR_DEFINE_RANK(tensortype, 3)                                                                                                  \
+        TENSOR_DEFINE_RANK(tensortype, 4)
 
 /**
  * @def TENSOR_EXPORT_TR_DISK_VIEW
@@ -177,7 +186,8 @@ using VectorData = std::vector<T>;
  * @param view_rank The rank of the view.
  * @param rank The rank of the base tensor.
  */
-#define TENSOR_EXPORT_TR_DISK_VIEW(tensortype, type, view_rank, rank) extern template class EINSUMS_EXPORT tensortype<type, view_rank, rank>;
+#    define TENSOR_EXPORT_TR_DISK_VIEW(tensortype, type, view_rank, rank)                                                                  \
+        extern template class EINSUMS_EXPORT tensortype<type, view_rank, rank>;
 
 /**
  * @def TENSOR_EXPORT_RANK_DISK_VIEW
@@ -189,11 +199,11 @@ using VectorData = std::vector<T>;
  * @param view_rank The rank of the view.
  * @param rank The rank of the base tensor.
  */
-#define TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, view_rank, rank)                                                                          \
-    TENSOR_EXPORT_TR_DISK_VIEW(tensortype, float, view_rank, rank)                                                                         \
-    TENSOR_EXPORT_TR_DISK_VIEW(tensortype, double, view_rank, rank)                                                                        \
-    TENSOR_EXPORT_TR_DISK_VIEW(tensortype, std::complex<float>, view_rank, rank)                                                           \
-    TENSOR_EXPORT_TR_DISK_VIEW(tensortype, std::complex<double>, view_rank, rank)
+#    define TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, view_rank, rank)                                                                      \
+        TENSOR_EXPORT_TR_DISK_VIEW(tensortype, float, view_rank, rank)                                                                     \
+        TENSOR_EXPORT_TR_DISK_VIEW(tensortype, double, view_rank, rank)                                                                    \
+        TENSOR_EXPORT_TR_DISK_VIEW(tensortype, std::complex<float>, view_rank, rank)                                                       \
+        TENSOR_EXPORT_TR_DISK_VIEW(tensortype, std::complex<double>, view_rank, rank)
 
 /**
  * @def TENSOR_EXPORT_RANK2_DISK_VIEW
@@ -204,11 +214,11 @@ using VectorData = std::vector<T>;
  * @param tensortype The type of tensor to declare.
  * @param rank The rank of the base tensor.
  */
-#define TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, rank)                                                                                    \
-    TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, 1, rank)                                                                                      \
-    TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, 2, rank)                                                                                      \
-    TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, 3, rank)                                                                                      \
-    TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, 4, rank)
+#    define TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, rank)                                                                                \
+        TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, 1, rank)                                                                                  \
+        TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, 2, rank)                                                                                  \
+        TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, 3, rank)                                                                                  \
+        TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, 4, rank)
 
 /**
  * @def TENSOR_EXPORT_DISK_VIEW
@@ -218,11 +228,11 @@ using VectorData = std::vector<T>;
  *
  * @param tensortype The type of tensor to declare.
  */
-#define TENSOR_EXPORT_DISK_VIEW(tensortype)                                                                                                \
-    TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, 1)                                                                                           \
-    TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, 2)                                                                                           \
-    TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, 3)                                                                                           \
-    TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, 4)
+#    define TENSOR_EXPORT_DISK_VIEW(tensortype)                                                                                            \
+        TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, 1)                                                                                       \
+        TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, 2)                                                                                       \
+        TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, 3)                                                                                       \
+        TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, 4)
 
 /**
  * @def TENSOR_DEFINE_TR_DISK_VIEW
@@ -234,7 +244,7 @@ using VectorData = std::vector<T>;
  * @param view_rank The rank of the view
  * @param rank The rank of the tensor.
  */
-#define TENSOR_DEFINE_TR_DISK_VIEW(tensortype, type, view_rank, rank) template class tensortype<type, view_rank, rank>;
+#    define TENSOR_DEFINE_TR_DISK_VIEW(tensortype, type, view_rank, rank) template class tensortype<type, view_rank, rank>;
 
 /**
  * @def TENSOR_DEFINE_RANK_DISK_VIEW
@@ -246,11 +256,11 @@ using VectorData = std::vector<T>;
  * @param view_rank The rank of the view.
  * @param rank The rank of the base tensor.
  */
-#define TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, view_rank, rank)                                                                          \
-    TENSOR_DEFINE_TR_DISK_VIEW(tensortype, float, view_rank, rank)                                                                         \
-    TENSOR_DEFINE_TR_DISK_VIEW(tensortype, double, view_rank, rank)                                                                        \
-    TENSOR_DEFINE_TR_DISK_VIEW(tensortype, std::complex<float>, view_rank, rank)                                                           \
-    TENSOR_DEFINE_TR_DISK_VIEW(tensortype, std::complex<double>, view_rank, rank)
+#    define TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, view_rank, rank)                                                                      \
+        TENSOR_DEFINE_TR_DISK_VIEW(tensortype, float, view_rank, rank)                                                                     \
+        TENSOR_DEFINE_TR_DISK_VIEW(tensortype, double, view_rank, rank)                                                                    \
+        TENSOR_DEFINE_TR_DISK_VIEW(tensortype, std::complex<float>, view_rank, rank)                                                       \
+        TENSOR_DEFINE_TR_DISK_VIEW(tensortype, std::complex<double>, view_rank, rank)
 
 /**
  * @def TENSOR_DEFINE_RANK2_DISK_VIEW
@@ -261,11 +271,11 @@ using VectorData = std::vector<T>;
  * @param tensortype The type of tensor to define.
  * @param rank The rank of the base tensor.
  */
-#define TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, rank)                                                                                    \
-    TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, 1, rank)                                                                                      \
-    TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, 2, rank)                                                                                      \
-    TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, 3, rank)                                                                                      \
-    TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, 4, rank)
+#    define TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, rank)                                                                                \
+        TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, 1, rank)                                                                                  \
+        TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, 2, rank)                                                                                  \
+        TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, 3, rank)                                                                                  \
+        TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, 4, rank)
 
 /**
  * @def TENSOR_DEFINE_DISK_VIEW
@@ -275,27 +285,27 @@ using VectorData = std::vector<T>;
  *
  * @param tensortype The type of tensor to define.
  */
-#define TENSOR_DEFINE_DISK_VIEW(tensortype)                                                                                                \
-    TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, 1)                                                                                           \
-    TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, 2)                                                                                           \
-    TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, 3)                                                                                           \
-    TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, 4)
+#    define TENSOR_DEFINE_DISK_VIEW(tensortype)                                                                                            \
+        TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, 1)                                                                                       \
+        TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, 2)                                                                                       \
+        TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, 3)                                                                                       \
+        TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, 4)
 
 #else
 
-#define TENSOR_EXPORT_TR(tensortype, type, rank)
-#define TENSOR_EXPORT_RANK(tensortype, rank)
-#define TENSOR_EXPORT(tensortype)
-#define TENSOR_DEFINE_TR(tensortype, type, rank)
-#define TENSOR_DEFINE_RANK(tensortype, rank)
-#define TENSOR_DEFINE(tensortype)
-#define TENSOR_EXPORT_TR_DISK_VIEW(tensortype, type, view_rank, rank)
-#define TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, view_rank, rank)
-#define TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, rank)
-#define TENSOR_EXPORT_DISK_VIEW(tensortype)
-#define TENSOR_DEFINE_TR_DISK_VIEW(tensortype, type, view_rank, rank)
-#define TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, view_rank, rank)
-#define TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, rank)
-#define TENSOR_DEFINE_DISK_VIEW(tensortype)
+#    define TENSOR_EXPORT_TR(tensortype, type, rank)
+#    define TENSOR_EXPORT_RANK(tensortype, rank)
+#    define TENSOR_EXPORT(tensortype)
+#    define TENSOR_DEFINE_TR(tensortype, type, rank)
+#    define TENSOR_DEFINE_RANK(tensortype, rank)
+#    define TENSOR_DEFINE(tensortype)
+#    define TENSOR_EXPORT_TR_DISK_VIEW(tensortype, type, view_rank, rank)
+#    define TENSOR_EXPORT_RANK_DISK_VIEW(tensortype, view_rank, rank)
+#    define TENSOR_EXPORT_RANK2_DISK_VIEW(tensortype, rank)
+#    define TENSOR_EXPORT_DISK_VIEW(tensortype)
+#    define TENSOR_DEFINE_TR_DISK_VIEW(tensortype, type, view_rank, rank)
+#    define TENSOR_DEFINE_RANK_DISK_VIEW(tensortype, view_rank, rank)
+#    define TENSOR_DEFINE_RANK2_DISK_VIEW(tensortype, rank)
+#    define TENSOR_DEFINE_DISK_VIEW(tensortype)
 
 #endif

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/TiledTensor.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/TiledTensor.hpp
@@ -7,6 +7,7 @@
 
 #include <Einsums/Config.hpp>
 
+#include <Einsums/Concepts/NamedRequirements.hpp>
 #include <Einsums/Concepts/SubscriptChooser.hpp>
 #include <Einsums/Concepts/TensorConcepts.hpp>
 #include <Einsums/Errors/Error.hpp>
@@ -15,10 +16,9 @@
 #include <Einsums/Tensor/TensorForward.hpp>
 #include <Einsums/TensorBase/HashFunctions.hpp>
 #include <Einsums/TensorBase/TensorBase.hpp>
+#include <Einsums/TypeSupport/Lockable.hpp>
 
 #include <string>
-
-#include <Einsums/TypeSupport/Lockable.hpp>
 
 #ifdef EINSUMS_COMPUTE_CODE
 #    include <Einsums/Tensor/DeviceTensor.hpp>
@@ -61,63 +61,6 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      */
     constexpr static size_t Rank = rank;
 
-  protected:
-    /**
-     * @property _tile_offsets
-     *
-     * @brief A list containing the positions along the axes that each tile starts.
-     */
-    /**
-     * @property _tile_sizes
-     *
-     * @brief A list of the lengths of the tiles along the axes.
-     */
-    std::array<std::vector<int>, Rank> _tile_offsets, _tile_sizes;
-
-    /**
-     * @property _tiles
-     *
-     * @brief The map containing the tiles.
-     */
-    map_type _tiles;
-
-    /**
-     * @property _dims
-     *
-     * @brief The overall dimensions of the tensor.
-     */
-    Dim<Rank> _dims;
-
-    /**
-     * @property _size
-     *
-     * @brief The total number of elements in the tensor, including the ignored zeros.
-     */
-    /**
-     * @property _grid_size
-     *
-     * @brief The number of possible tile positions within the grid.
-     */
-    size_t _size, _grid_size;
-
-    /**
-     * @property _name
-     *
-     * @brief The name of the tensor.
-     */
-    std::string _name{"(unnamed)"};
-
-    /**
-     * Add a tile using the underlying type's preferred method. Also gives it a name.
-     *
-     * @param pos The position in the grid to place the tile.
-     */
-    virtual void add_tile(std::array<int, Rank> pos) = 0;
-
-    template <typename TOther, size_t RankOther, typename TensorTypeOther>
-    friend struct TiledTensorBase;
-
-  public:
     /**
      * @typedef ValueType
      *
@@ -144,21 +87,32 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @param name The name of the tensor.
      * @param sizes The grids to apply.
      */
-    template <typename... Sizes>
-        requires(!std::is_same_v<std::array<std::vector<int>, Rank>, Sizes> && ... && true)
-    TiledTensor(std::string name, Sizes... sizes) : _name(name), _tile_offsets(), _tile_sizes(), _tiles(), _size(0), _dims{} {
-        static_assert(sizeof...(Sizes) == Rank || sizeof...(Sizes) == 1);
+    template <ContainerOrInitializer... Sizes>
+        requires(!ContainerOrInitializer<typename Sizes::value_type> && ... && true)
+    TiledTensor(std::string name, Sizes const &...sizes) : _name(name), _tile_offsets(), _tile_sizes(), _tiles(), _size(0), _dims{} {
+        static_assert(sizeof...(Sizes) == rank || sizeof...(Sizes) == 1);
 
         _size = 1;
-        if constexpr (sizeof...(Sizes) == Rank &&
-                      !std::is_same_v<std::array<std::vector<int>, Rank>, decltype(std::get<0>(std::tuple(sizes...)))>) {
-            _tile_sizes = std::array<std::vector<int>, Rank>{std::vector<int>(sizes.begin(), sizes.end())...};
+        if constexpr (sizeof...(Sizes) == rank) {
+            auto size_tuple = std::make_tuple(std::forward<Sizes>(sizes)...);
+            for_sequence<rank>([&](auto i) {
+                auto &size = std::get<i>(size_tuple);
+
+                this->_tile_sizes[(int)i] = std::vector<int>(size.size());
+                for (int j = 0; j < size.size(); j++) {
+                    this->_tile_sizes[(int)i][j] = size[j];
+                }
+            });
         } else {
-            for (int i = 0; i < Rank; i++) {
-                _tile_sizes[i] = std::vector<int>(sizes.begin()..., sizes.end()...);
+            for (int i = 0; i < rank; i++) {
+                _tile_sizes[i] = std::vector<int>(sizes.size()...);
+
+                for (int j = 0; j < _tile_sizes[i].size(); j++) {
+                    _tile_sizes[i][j] = (sizes[j] + ...);
+                }
             }
         }
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             _tile_offsets[i] = std::vector<int>();
             _tile_offsets[i].reserve(_tile_sizes[i].size());
 
@@ -173,7 +127,7 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
 
         _grid_size = 1;
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             _grid_size *= _tile_offsets[i].size();
         }
     }
@@ -184,10 +138,21 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @param name The name of the tensor.
      * @param sizes The grids to apply.
      */
-    TiledTensor(std::string name, std::array<std::vector<int>, Rank> const &sizes)
-        : _name(name), _tile_offsets(), _tile_sizes(sizes), _tiles(), _size(0), _dims{} {
+    template <Container ContainerType>
+        requires(Container<typename ContainerType::value_type> && std::is_integral_v<typename ContainerType::value_type::value_type>)
+    TiledTensor(std::string name, ContainerType const &sizes) : _name(name), _tile_offsets(), _tile_sizes(), _tiles(), _size(0), _dims{} {
+        if (sizes.size() != rank) {
+            EINSUMS_THROW_EXCEPTION(num_argument_error, "Wrong number of grid sizes passed to TiledTensor constructor!");
+        }
+        for (int i = 0; i < rank; i++) {
+            _tile_sizes[i] = std::vector<int>(sizes[i].size());
+
+            for (int j = 0; j < sizes[i].size(); j++) {
+                _tile_sizes[i][j] = sizes[i][j];
+            }
+        }
         _size = 1;
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             _tile_offsets[i] = std::vector<int>();
             _tile_offsets[i].reserve(_tile_sizes[i].size());
             int sum = 0;
@@ -201,7 +166,7 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
 
         _grid_size = 1;
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             _grid_size *= _tile_offsets[i].size();
         }
     }
@@ -211,11 +176,11 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      *
      * @param other The tensor to be copied.
      */
-    TiledTensor(TiledTensor<T, Rank, TensorType> const &other)
+    TiledTensor(TiledTensor<T, rank, TensorType> const &other)
         : _tile_offsets(other._tile_offsets), _tile_sizes(other._tile_sizes), _name(other._name), _size(other._size), _tiles(),
           _dims{other._dims}, _grid_size{other._grid_size} {
         for (auto &pair : other._tiles) {
-            _tiles[pair.first] = TensorType(pair.second);
+            _tiles.insert_or_assign(pair.first, pair.second);
         }
     }
 
@@ -224,16 +189,16 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      *
      * @param other The tensor to be copied and converted.
      */
-    template <TRTensorConcept<Rank, T> OtherTensor>
-    TiledTensor(TiledTensor<T, Rank, OtherTensor> const &other)
+    template <TRTensorConcept<rank, T> OtherTensor>
+    TiledTensor(TiledTensor<T, rank, OtherTensor> const &other)
         : _tile_offsets(other._tile_offsets), _tile_sizes(other._tile_sizes), _name(other._name), _size(other._size), _tiles(),
           _dims{other._dims}, _grid_size{other._grid_size} {
         for (auto &pair : other._tiles) {
-            _tiles[pair.first] = TensorType(pair.second);
+            _tiles.insert_or_assign(pair.first, pair.second);
         }
     }
 
-    ~TiledTensor() = default;
+    virtual ~TiledTensor() = default;
 
     /**
      * Returns the tile with given coordinates. If the tile is not filled, it will be created.
@@ -242,11 +207,11 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @return The tile at the given index.
      */
     template <std::integral... MultiIndex>
-        requires(sizeof...(MultiIndex) == Rank)
+        requires(sizeof...(MultiIndex) == rank)
     TensorType &tile(MultiIndex... index) {
-        std::array<int, Rank> arr_index{static_cast<int>(index)...};
+        std::array<int, rank> arr_index{static_cast<int>(index)...};
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (arr_index[i] < 0) {
                 arr_index[i] += _tile_sizes[i].size();
             }
@@ -255,9 +220,9 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
         }
 
         if (!has_tile(arr_index)) {
-            Dim<Rank> dims{};
+            Dim<rank> dims{};
 
-            for (int i = 0; i < Rank; i++) {
+            for (int i = 0; i < rank; i++) {
                 dims[i] = _tile_sizes[i].at(arr_index[i]);
             }
 
@@ -274,11 +239,11 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @return The tile at the given index.
      */
     template <std::integral... MultiIndex>
-        requires(sizeof...(MultiIndex) == Rank)
+        requires(sizeof...(MultiIndex) == rank)
     const TensorType &tile(MultiIndex... index) const {
-        std::array<int, Rank> arr_index{static_cast<int>(index)...};
+        std::array<int, rank> arr_index{static_cast<int>(index)...};
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (arr_index[i] < 0) {
                 arr_index[i] += _tile_sizes[i].size();
             }
@@ -298,9 +263,9 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
     template <typename Storage>
         requires(!std::integral<Storage>)
     const TensorType &tile(Storage index) const {
-        std::array<int, Rank> arr_index;
+        std::array<int, rank> arr_index;
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             arr_index[i] = static_cast<int>(index[i]);
             if (arr_index[i] < 0) {
                 arr_index[i] += _tile_sizes[i].size();
@@ -321,9 +286,9 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
     template <typename Storage>
         requires(!std::integral<Storage>)
     TensorType &tile(Storage index) {
-        std::array<int, Rank> arr_index{index};
+        std::array<int, rank> arr_index{index};
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (arr_index[i] < 0) {
                 arr_index[i] += _tile_sizes[i].size();
             }
@@ -332,9 +297,9 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
         }
 
         if (!has_tile(arr_index)) {
-            Dim<Rank> dims{};
+            Dim<rank> dims{};
 
-            for (int i = 0; i < Rank; i++) {
+            for (int i = 0; i < rank; i++) {
                 dims[i] = _tile_sizes[i].at(arr_index[i]);
             }
             add_tile(arr_index);
@@ -350,11 +315,11 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @return True if there is a tile and it is initialized at this position. False if there is no tile or it is not initialized.
      */
     template <std::integral... MultiIndex>
-        requires(sizeof...(MultiIndex) == Rank)
+        requires(sizeof...(MultiIndex) == rank)
     bool has_tile(MultiIndex... index) const {
-        std::array<int, Rank> arr_index{static_cast<int>(index)...};
+        std::array<int, rank> arr_index{static_cast<int>(index)...};
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (arr_index[i] < 0) {
                 arr_index[i] += _tile_sizes[i].size();
             }
@@ -374,12 +339,12 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @return The coordinates of the tile.
      */
     template <std::integral... MultiIndex>
-        requires(sizeof...(MultiIndex) == Rank)
-    std::array<int, Rank> tile_of(MultiIndex... index) const {
-        std::array<int, Rank> arr_index{static_cast<int>(index)...};
-        std::array<int, Rank> out{0};
+        requires(sizeof...(MultiIndex) == rank)
+    std::array<int, rank> tile_of(MultiIndex... index) const {
+        std::array<int, rank> arr_index{static_cast<int>(index)...};
+        std::array<int, rank> out{0};
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (arr_index[i] < 0) {
                 arr_index[i] += _dims[i];
             }
@@ -411,9 +376,9 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
     template <typename Storage>
         requires(!std::integral<Storage>)
     bool has_tile(Storage index) const {
-        std::array<int, Rank> arr_index;
+        std::array<int, rank> arr_index;
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             arr_index[i] = static_cast<int>(index[i]);
             if (arr_index[i] < 0) {
                 index[i] += _tile_sizes[i].size();
@@ -435,11 +400,11 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      */
     template <typename Storage>
         requires(!std::integral<Storage>)
-    std::array<int, Rank> tile_of(Storage index) const {
-        std::array<int, Rank> arr_index;
-        std::array<int, Rank> out{0};
+    std::array<int, rank> tile_of(Storage index) const {
+        std::array<int, rank> arr_index;
+        std::array<int, rank> out{0};
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             arr_index[i] = static_cast<int>(index[i]);
             if (arr_index[i] < 0) {
                 arr_index[i] += _dims[i];
@@ -470,14 +435,14 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @return The value at the position.
      */
     template <std::integral... MultiIndex>
-        requires(sizeof...(MultiIndex) == Rank)
+        requires(sizeof...(MultiIndex) == rank)
     T operator()(MultiIndex... index) const {
         auto coords = tile_of(index...);
 
-        auto array_ind = std::array<int64_t, Rank>{static_cast<int64_t>(index)...};
+        auto array_ind = std::array<int64_t, rank>{static_cast<int64_t>(index)...};
 
         // Find the index in the tile.
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (array_ind[i] < 0) {
                 array_ind[i] += _dims[i];
             }
@@ -498,14 +463,14 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @return A reference to the position.
      */
     template <std::integral... MultiIndex>
-        requires(sizeof...(MultiIndex) == Rank)
+        requires(sizeof...(MultiIndex) == rank)
     T &operator()(MultiIndex... index) {
         auto coords = tile_of(index...);
 
-        auto array_ind = std::array<int64_t, Rank>{static_cast<int64_t>(index)...};
+        auto array_ind = std::array<int64_t, rank>{static_cast<int64_t>(index)...};
 
         // Find the index in the tile.
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (array_ind[i] < 0) {
                 array_ind[i] += _dims[i];
             }
@@ -522,30 +487,30 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @param index The index to evaluate.
      * @return The value at the position.
      */
-    template <typename Container>
+    template <typename ContainerType>
         requires requires {
-            requires !std::is_integral_v<Container>;
-            requires !std::is_same_v<Container, Dim<Rank>>;
-            requires !std::is_same_v<Container, Stride<Rank>>;
-            requires !std::is_same_v<Container, Offset<Rank>>;
-            requires !std::is_same_v<Container, Range>;
+            requires !std::is_integral_v<ContainerType>;
+            requires !std::is_same_v<ContainerType, Dim<rank>>;
+            requires !std::is_same_v<ContainerType, Stride<rank>>;
+            requires !std::is_same_v<ContainerType, Offset<rank>>;
+            requires !std::is_same_v<ContainerType, Range>;
         }
-    T operator()(Container const &index) const {
-        if (index.size() < Rank) {
+    T operator()(ContainerType const &index) const {
+        if (index.size() < rank) {
             [[unlikely]] EINSUMS_THROW_EXCEPTION(std::out_of_range, "Not enough indices passed to Tensor!");
-        } else if (index.size() > Rank) {
+        } else if (index.size() > rank) {
             [[unlikely]] EINSUMS_THROW_EXCEPTION(std::out_of_range, "Too many indices passed to Tensor!");
         }
         auto coords = tile_of(index);
 
-        std::array<std::int64_t, Rank> array_ind;
+        std::array<std::int64_t, rank> array_ind;
 
-        for (size_t i = 0; i < Rank; i++) {
+        for (size_t i = 0; i < rank; i++) {
             array_ind[i] = index[i];
         }
 
         // Find the index in the tile.
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (array_ind[i] < 0) {
                 array_ind[i] += _dims[i];
             }
@@ -565,30 +530,30 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @param index The index to evaluate.
      * @return A reference to the position.
      */
-    template <typename Container>
+    template <typename ContainerType>
         requires requires {
-            requires !std::is_integral_v<Container>;
-            requires !std::is_same_v<Container, Dim<Rank>>;
-            requires !std::is_same_v<Container, Stride<Rank>>;
-            requires !std::is_same_v<Container, Offset<Rank>>;
-            requires !std::is_same_v<Container, Range>;
+            requires !std::is_integral_v<ContainerType>;
+            requires !std::is_same_v<ContainerType, Dim<rank>>;
+            requires !std::is_same_v<ContainerType, Stride<rank>>;
+            requires !std::is_same_v<ContainerType, Offset<rank>>;
+            requires !std::is_same_v<ContainerType, Range>;
         }
-    T &operator()(Container const &index) {
-        if (index.size() < Rank) {
+    T &operator()(ContainerType const &index) {
+        if (index.size() < rank) {
             EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to Tensor!");
-        } else if (index.size() > Rank) {
+        } else if (index.size() > rank) {
             EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to Tensor!");
         }
         auto coords = tile_of(index);
 
-        std::array<std::int64_t, Rank> array_ind;
+        std::array<std::int64_t, rank> array_ind;
 
-        for (size_t i = 0; i < Rank; i++) {
+        for (size_t i = 0; i < rank; i++) {
             array_ind[i] = index[i];
         }
 
         // Find the index in the tile.
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (array_ind[i] < 0) {
                 array_ind[i] += _dims[i];
             }
@@ -627,17 +592,17 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
 
         // Find the number of tiles.
         long num_tiles = 1;
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             num_tiles *= _tile_offsets[i].size();
         }
 
         EINSUMS_OMP_PARALLEL_FOR
         for (long i = 0; i < num_tiles; i++) {
-            std::array<int, Rank> tile_index{};
+            std::array<int, rank> tile_index{};
             long                  remaining = i;
 
             // Turn sentinel into an index.
-            for (int j = 0; j < Rank; j++) {
+            for (int j = 0; j < rank; j++) {
                 tile_index[j] = remaining % _tile_offsets[j].size();
                 remaining /= _tile_offsets[j].size();
             }
@@ -663,7 +628,7 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      *
      * @param copy The tensor to copy.
      */
-    TiledTensor<T, Rank, TensorType> &operator=(TiledTensor<T, Rank, TensorType> const &copy) {
+    TiledTensor<T, rank, TensorType> &operator=(TiledTensor<T, rank, TensorType> const &copy) {
         zero();
         _tile_sizes   = copy._tile_sizes;
         _tile_offsets = copy._tile_offsets;
@@ -686,8 +651,8 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @param copy The tensor to copy.
      */
     template <TiledTensorConcept TensorOther>
-        requires(SameUnderlyingAndRank<TiledTensor<T, Rank, TensorType>, TensorOther>)
-    TiledTensor<T, Rank, TensorType> &operator=(TensorOther const &copy) {
+        requires(SameUnderlyingAndRank<TiledTensor<T, rank, TensorType>, TensorOther>)
+    TiledTensor<T, rank, TensorType> &operator=(TensorOther const &copy) {
         zero();
         _tile_sizes   = copy._tile_sizes;
         _tile_offsets = copy._tile_offsets;
@@ -726,17 +691,17 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
 
         // Find the number of tiles.
         long num_tiles = 1;
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             num_tiles *= _tile_offsets[i].size();
         }
 
         EINSUMS_OMP_PARALLEL_FOR
         for (long i = 0; i < num_tiles; i++) {
-            std::array<int, Rank> tile_index{};
+            std::array<int, rank> tile_index{};
             long                  remaining = i;
 
             // Turn sentinel into an index.
-            for (int j = 0; j < Rank; j++) {
+            for (int j = 0; j < rank; j++) {
                 tile_index[j] = remaining % _tile_offsets[j].size();
                 remaining /= _tile_offsets[j].size();
             }
@@ -759,17 +724,17 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
 
         // Find the number of tiles.
         long num_tiles = 1;
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             num_tiles *= _tile_offsets[i].size();
         }
 
         EINSUMS_OMP_PARALLEL_FOR
         for (long i = 0; i < num_tiles; i++) {
-            std::array<int, Rank> tile_index{};
+            std::array<int, rank> tile_index{};
             long                  remaining = i;
 
             // Turn sentinel into an index.
-            for (int j = 0; j < Rank; j++) {
+            for (int j = 0; j < rank; j++) {
                 tile_index[j] = remaining % _tile_offsets[j].size();
                 remaining /= _tile_offsets[j].size();
             }
@@ -901,7 +866,7 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
     /**
      * Returns the tile offsets.
      */
-    std::array<std::vector<int>, Rank> tile_offsets() const { return _tile_offsets; }
+    std::array<std::vector<int>, rank> tile_offsets() const { return _tile_offsets; }
 
     /**
      * Returns the tile offsets along a given dimension.
@@ -914,7 +879,7 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
     /**
      * Returns the tile sizes.
      */
-    std::array<std::vector<int>, Rank> tile_sizes() const { return _tile_sizes; }
+    std::array<std::vector<int>, rank> tile_sizes() const { return _tile_sizes; }
 
     /**
      * Returns the tile sizes along a given dimension.
@@ -981,7 +946,7 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
     /**
      * @brief Get the dimensions
      */
-    Dim<Rank> dims() const { return _dims; }
+    Dim<rank> dims() const { return _dims; }
 
     /**
      * Check to see if the given tile has zero size.
@@ -990,11 +955,11 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
      * @return True if the tile has at least one dimension of zero, leading to a size of zero, or false if there are no zero dimensions.
      */
     template <std::integral... Index>
-        requires(sizeof...(Index) == Rank)
+        requires(sizeof...(Index) == rank)
     bool has_zero_size(Index... index) const {
-        std::array<int, Rank> arr_index{static_cast<int>(index)...};
+        std::array<int, rank> arr_index{static_cast<int>(index)...};
 
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (_tile_sizes[i].at(arr_index[i]) == 0) {
                 return true;
             }
@@ -1012,7 +977,7 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
     template <typename Storage>
         requires(!std::integral<Storage>)
     bool has_zero_size(Storage const &index) const {
-        for (int i = 0; i < Rank; i++) {
+        for (int i = 0; i < rank; i++) {
             if (_tile_sizes[i].at(index[i]) == 0) {
                 return true;
             }
@@ -1028,17 +993,17 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
         TensorType out(_dims);
         out.set_name(name());
 
-        Stride<Rank> tile_strides;
+        Stride<rank> tile_strides;
 
         size_t tiles = 1;
 
-        for (ptrdiff_t i = Rank - 1; i >= 0; i--) {
+        for (ptrdiff_t i = rank - 1; i >= 0; i--) {
             tile_strides[i] = tiles;
             tiles *= grid_size(i);
         }
 
         for (size_t tile = 0; tile < tiles; tile++) {
-            std::array<int64_t, Rank> tile_index;
+            std::array<int64_t, rank> tile_index;
 
             sentinel_to_indices(tile, tile_strides, tile_index);
 
@@ -1046,9 +1011,9 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
                 continue;
             } else {
                 // Calculate the view ranges.
-                thread_local std::array<Range, Rank> ranges;
+                thread_local std::array<Range, rank> ranges;
 
-                for (size_t i = 0; i < Rank; i++) {
+                for (size_t i = 0; i < rank; i++) {
                     ranges[i] =
                         Range{this->tile_offset(i)[tile_index[i]], this->tile_offset(i)[tile_index[i]] + this->tile_size(i)[tile_index[i]]};
                 }
@@ -1063,6 +1028,62 @@ struct TiledTensor : public TiledTensorNoExtra, design_pats::Lockable<std::recur
 
         return out;
     }
+
+  protected:
+    /**
+     * @property _tile_offsets
+     *
+     * @brief A list containing the positions along the axes that each tile starts.
+     */
+    /**
+     * @property _tile_sizes
+     *
+     * @brief A list of the lengths of the tiles along the axes.
+     */
+    std::array<std::vector<int>, rank> _tile_offsets, _tile_sizes;
+
+    /**
+     * @property _tiles
+     *
+     * @brief The map containing the tiles.
+     */
+    map_type _tiles;
+
+    /**
+     * @property _dims
+     *
+     * @brief The overall dimensions of the tensor.
+     */
+    Dim<rank> _dims;
+
+    /**
+     * @property _size
+     *
+     * @brief The total number of elements in the tensor, including the ignored zeros.
+     */
+    /**
+     * @property _grid_size
+     *
+     * @brief The number of possible tile positions within the grid.
+     */
+    size_t _size, _grid_size;
+
+    /**
+     * @property _name
+     *
+     * @brief The name of the tensor.
+     */
+    std::string _name{"(unnamed)"};
+
+    /**
+     * Add a tile using the underlying type's preferred method. Also gives it a name.
+     *
+     * @param pos The position in the grid to place the tile.
+     */
+    virtual void add_tile(std::array<int, rank> const &pos) = 0;
+
+    template <typename TOther, size_t RankOther, typename TensorTypeOther>
+    friend struct TiledTensorBase;
 };
 
 } // namespace tensor_base
@@ -1082,7 +1103,7 @@ struct TiledTensor final : public tensor_base::TiledTensor<T, Rank, einsums::Ten
      *
      * @param pos The position of the tile to create.
      */
-    void add_tile(std::array<int, Rank> pos) override {
+    void add_tile(std::array<int, Rank> const &pos) override {
         std::string tile_name = this->_name + " - (";
         Dim<Rank>   dims{};
 
@@ -1116,18 +1137,8 @@ struct TiledTensor final : public tensor_base::TiledTensor<T, Rank, einsums::Ten
      * @param sizes The grids for the axes. There must either only be one, or the number must be the same as the rank.
      */
     template <typename... Sizes>
-    TiledTensor(std::string name, Sizes... sizes) : tensor_base::TiledTensor<T, Rank, Tensor<T, Rank>>(name, sizes...) {}
-
-    /**
-     * @brief Create a new tiled tensor with the given name and grid specification.
-     *
-     * The grid passed to this constructor will be applied to all of the axes equally. The resulting tensor will
-     * be square, and all of the diagonal tiles will also be square.
-     *
-     * @param name The name for the tensor.
-     * @param init The grid for the tensor.
-     */
-    TiledTensor(std::string name, std::initializer_list<int> init) : tensor_base::TiledTensor<T, Rank, Tensor<T, Rank>>(name, init) {}
+    TiledTensor(std::string name, Sizes &&...sizes)
+        : tensor_base::TiledTensor<T, Rank, Tensor<T, Rank>>(name, std::forward<Sizes>(sizes)...) {}
 
     /**
      * @brief Copy constructor.
@@ -1182,6 +1193,9 @@ struct TiledTensor final : public tensor_base::TiledTensor<T, Rank, einsums::Ten
  * @struct TiledTensorView
  *
  * @brief Tensors of this class hold views of the tiles of a tiled tensor.
+ *
+ * Since views of block tensors are not guaranteed to be truly block diagonal, TiledTensorViews also hold
+ * views of BlockTensors when the view is not hypersquare.
  */
 template <typename T, size_t Rank>
 struct TiledTensorView final : public tensor_base::TiledTensor<T, Rank, einsums::TensorView<T, Rank>>, tensor_base::CoreTensor {
@@ -1200,7 +1214,9 @@ struct TiledTensorView final : public tensor_base::TiledTensor<T, Rank, einsums:
      * not allowed. This is because currently, TiledTensorViews are kind of scuffed in that
      * their structure is desynchronized from the tensor they view. This may change in the future.
      */
-    void add_tile(std::array<int, Rank>) override { EINSUMS_THROW_EXCEPTION(std::logic_error, "Can't add a tile to a TiledTensorView!"); }
+    void add_tile(std::array<int, Rank> const &) override {
+        EINSUMS_THROW_EXCEPTION(std::logic_error, "Can't add a tile to a TiledTensorView!");
+    }
 
   public:
     /**
@@ -1225,7 +1241,8 @@ struct TiledTensorView final : public tensor_base::TiledTensor<T, Rank, einsums:
      * @param sizes The grids for the axes. There must either only be one, or the number must be the same as the rank.
      */
     template <typename... Sizes>
-    TiledTensorView(std::string name, Sizes... sizes) : tensor_base::TiledTensor<T, Rank, einsums::TensorView<T, Rank>>(name, sizes...) {}
+    TiledTensorView(std::string name, Sizes &&...sizes)
+        : tensor_base::TiledTensor<T, Rank, einsums::TensorView<T, Rank>>(name, std::forward<Sizes>(sizes)...) {}
 
     /**
      * @brief Copy constructor.
@@ -1251,7 +1268,7 @@ struct TiledTensorView final : public tensor_base::TiledTensor<T, Rank, einsums:
      */
     void insert_tile(std::array<int, Rank> pos, einsums::TensorView<T, Rank> &&view) {
         std::lock_guard lock(*this);
-        this->_tiles.emplace(pos, std::move(view));
+        this->_tiles.emplace(pos, view);
     }
 };
 
@@ -1271,7 +1288,7 @@ struct TiledDeviceTensor final : public tensor_base::TiledTensor<T, Rank, einsum
      *
      * @param pos The position to put the new tensor.
      */
-    void add_tile(std::array<int, Rank> pos) override {
+    void add_tile(std::array<int, Rank> const &pos) override {
         std::lock_guard(*this);
         std::string tile_name = this->_name + " - (";
         Dim<Rank>   dims{};
@@ -1308,8 +1325,8 @@ struct TiledDeviceTensor final : public tensor_base::TiledTensor<T, Rank, einsum
      */
     template <typename... Sizes>
         requires(!(std::is_same_v<Sizes, detail::HostToDeviceMode> || ...))
-    TiledDeviceTensor(std::string name, detail::HostToDeviceMode mode, Sizes... sizes)
-        : _mode{mode}, tensor_base::TiledTensor<T, Rank, einsums::DeviceTensor<T, Rank>>(name, sizes...) {}
+    TiledDeviceTensor(std::string name, detail::HostToDeviceMode mode, Sizes &&...sizes)
+        : _mode{mode}, tensor_base::TiledTensor<T, Rank, einsums::DeviceTensor<T, Rank>>(name, std::forward<Sizes>(sizes)...) {}
 
     /**
      * @brief Create a new tiled tensor with the given name and grid specification.
@@ -1325,8 +1342,8 @@ struct TiledDeviceTensor final : public tensor_base::TiledTensor<T, Rank, einsum
      */
     template <typename... Sizes>
         requires(!(std::is_same_v<Sizes, detail::HostToDeviceMode> || ...))
-    TiledDeviceTensor(std::string name, Sizes... sizes)
-        : tensor_base::TiledTensor<T, Rank, einsums::DeviceTensor<T, Rank>>(name, sizes...) {}
+    TiledDeviceTensor(std::string name, Sizes &&...sizes)
+        : tensor_base::TiledTensor<T, Rank, einsums::DeviceTensor<T, Rank>>(name, std::forward<Sizes>(sizes)...) {}
 
     /**
      * @brief Copy constructor.
@@ -1460,32 +1477,6 @@ struct TiledDeviceTensor final : public tensor_base::TiledTensor<T, Rank, einsum
 
 template <typename T, size_t Rank>
 struct TiledDeviceTensorView final : public tensor_base::TiledTensor<T, Rank, DeviceTensorView<T, Rank>>, tensor_base::DeviceTensorBase {
-  private:
-    /**
-     * @property _full_view_of_underlying
-     *
-     * @brief Indicates whether the view can see all of the elements of the underlying tensor.
-     */
-    bool _full_view_of_underlying{false};
-
-    /**
-     * @property _mode
-     *
-     * @brief The storage mode of the tiles.
-     */
-    detail::HostToDeviceMode _mode{detail::DEV_ONLY};
-
-    /**
-     * @brief Tries to add a tile to the tensor, but it can't.
-     *
-     * As of the current version, modification of the underlying structure of a TiledTensorView is
-     * not allowed. This is because currently, TiledTensorViews are kind of scuffed in that
-     * their structure is desynchronized from the tensor they view. This may change in the future.
-     */
-    void add_tile(std::array<int, Rank> pos) override {
-        EINSUMS_THROW_EXCEPTION(std::logic_error, "Can't add a tile to a TiledDeviceTensorView!");
-    }
-
   public:
     /**
      * @typedef underlying_type
@@ -1511,8 +1502,26 @@ struct TiledDeviceTensorView final : public tensor_base::TiledTensor<T, Rank, De
      */
     template <typename... Sizes>
         requires(!(std::is_same_v<Sizes, detail::HostToDeviceMode> || ...))
-    TiledDeviceTensorView(std::string name, detail::HostToDeviceMode mode, Sizes... sizes)
-        : _mode{mode}, tensor_base::TiledTensor<T, Rank, DeviceTensorView<T, Rank>>(name, sizes...) {}
+    TiledDeviceTensorView(std::string name, detail::HostToDeviceMode mode, Sizes &&...sizes)
+        : tensor_base::TiledTensor<T, Rank, DeviceTensorView<T, Rank>>(name, std::forward<Sizes>(sizes)...) {}
+
+    /**
+     * @brief Construct a new tensor view with the given name, storage mode, and grid specification.
+     *
+     * The sizes should be collections of integers. There should either be only one collection, or there should be
+     * as many collections as the rank of the tensor. If there are as many collections as the rank of the tensor,
+     * then each collection will be used to split up the respective axis as a grid. If there is only one collection, then
+     * it will be applied to all of the axes, making a square tensor whose diagonal tiles are square as well. Obviously,
+     * if the tensor is only one-dimensional, these two behaviors are the same.
+     *
+     * @param name The name of the tensor.
+     * @param mode The storage mode for the tensors.
+     * @param sizes The grids for the axes. There must either only be one, or the number must be the same as the rank.
+     */
+    template <typename... Sizes>
+        requires(!(std::is_same_v<Sizes, detail::HostToDeviceMode> || ...))
+    TiledDeviceTensorView(std::string name, Sizes &&...sizes)
+        : tensor_base::TiledTensor<T, Rank, DeviceTensorView<T, Rank>>(name, std::forward<Sizes>(sizes)...) {}
 
     /**
      * @brief Copy constructor.
@@ -1550,8 +1559,8 @@ struct TiledDeviceTensorView final : public tensor_base::TiledTensor<T, Rank, De
      * @param view The view to add to the tensor.
      */
     void insert_tile(std::array<int, Rank> pos, DeviceTensorView<T, Rank> &&view) {
-        std::lock_guard(*this);
-        this->_tiles[pos].emplace(pos, std::move(view));
+        std::lock_guard lock(*this);
+        this->_tiles.emplace(pos, view);
     }
 
     /**
@@ -1629,6 +1638,25 @@ struct TiledDeviceTensorView final : public tensor_base::TiledTensor<T, Rank, De
         requires(std::is_integral_v<int_type>)
     auto operator()(std::array<int_type, Rank> const &index) -> HostDevReference<T> {
         return std::apply(*this, index);
+    }
+
+  private:
+    /**
+     * @property _full_view_of_underlying
+     *
+     * @brief Indicates whether the view can see all of the elements of the underlying tensor.
+     */
+    bool _full_view_of_underlying{false};
+
+    /**
+     * @brief Tries to add a tile to the tensor, but it can't.
+     *
+     * As of the current version, modification of the underlying structure of a TiledTensorView is
+     * not allowed. This is because currently, TiledTensorViews are kind of scuffed in that
+     * their structure is desynchronized from the tensor they view. This may change in the future.
+     */
+    void add_tile(std::array<int, Rank> const &pos) override {
+        EINSUMS_THROW_EXCEPTION(std::logic_error, "Can't add a tile to a TiledDeviceTensorView!");
     }
 };
 

--- a/libs/Einsums/Tensor/src/TensorDefs.cpp
+++ b/libs/Einsums/Tensor/src/TensorDefs.cpp
@@ -20,17 +20,6 @@
 
 namespace einsums {
 
-
-// template class RuntimeTensor<float>;
-// template class RuntimeTensor<double>;
-// template class RuntimeTensor<std::complex<float>>;
-// template class RuntimeTensor<std::complex<double>>;
-
-// template class RuntimeTensorView<float>;
-// template class RuntimeTensorView<double>;
-// template class RuntimeTensorView<std::complex<float>>;
-// template class RuntimeTensorView<std::complex<double>>;
-
 TENSOR_DEFINE_RANK(BlockTensor, 2)
 TENSOR_DEFINE_RANK(BlockTensor, 3)
 TENSOR_DEFINE_RANK(BlockTensor, 4)
@@ -44,5 +33,17 @@ TENSOR_DEFINE(TensorView)
 
 TENSOR_DEFINE(TiledTensor)
 TENSOR_DEFINE(TiledTensorView)
+
+#ifndef EINSUMS_WINDOWS
+template class RuntimeTensor<float>;
+template class RuntimeTensor<double>;
+template class RuntimeTensor<std::complex<float>>;
+template class RuntimeTensor<std::complex<double>>;
+
+template class RuntimeTensorView<float>;
+template class RuntimeTensorView<double>;
+template class RuntimeTensorView<std::complex<float>>;
+template class RuntimeTensorView<std::complex<double>>;
+#endif
 
 } // namespace einsums

--- a/libs/Einsums/Tensor/src/TensorDefs.hip
+++ b/libs/Einsums/Tensor/src/TensorDefs.hip
@@ -13,4 +13,7 @@ TENSOR_DEFINE_RANK(DeviceTensor, 0)
 TENSOR_DEFINE(DeviceTensor)
 TENSOR_DEFINE(DeviceTensorView)
 
+TENSOR_DEFINE(TiledDeviceTensor)
+TENSOR_DEFINE(TiledDeviceTensorView)
+
 }

--- a/libs/Einsums/Tensor/tests/unit/TensorView.cpp
+++ b/libs/Einsums/Tensor/tests/unit/TensorView.cpp
@@ -16,8 +16,8 @@ TEMPLATE_TEST_CASE("Subset TensorView", "[tensor]", float, double, std::complex<
         size_t const size = 7;
         size_t const row  = 1;
 
-        Tensor     I_original = create_random_tensor("Original", size, size);
-        TensorView I_view     = I_original(row, All);
+        auto I_original = create_random_tensor<TestType>("Original", size, size);
+        auto I_view     = I_original(row, All);
 
         for (size_t i = 0; i < size; i++) {
             REQUIRE(I_original(row, i) == I_view(i));
@@ -28,8 +28,8 @@ TEMPLATE_TEST_CASE("Subset TensorView", "[tensor]", float, double, std::complex<
         size_t const size = 7;
         size_t const d1   = 4;
 
-        Tensor     I_original = create_random_tensor("Original", size, size, size);
-        TensorView I_view     = I_original(d1, All, All);
+        auto I_original = create_random_tensor<TestType>("Original", size, size, size);
+        auto I_view     = I_original(d1, All, All);
 
         for (size_t i = 0; i < size; i++) {
             for (size_t j = 0; j < size; j++) {
@@ -43,8 +43,8 @@ TEMPLATE_TEST_CASE("Subset TensorView", "[tensor]", float, double, std::complex<
         size_t const d1   = 4;
         size_t const d2   = 3;
 
-        Tensor     I_original = create_random_tensor("Original", size, size, size);
-        TensorView I_view     = I_original(d1, d2, All);
+        auto I_original = create_random_tensor<TestType>("Original", size, size, size);
+        auto I_view     = I_original(d1, d2, All);
 
         for (size_t i = 0; i < size; i++) {
             REQUIRE(I_original(d1, d2, i) == I_view(i));
@@ -57,16 +57,16 @@ TEMPLATE_TEST_CASE("Block tensor views", "[tensor]", float, double, std::complex
 
     BlockTensor<TestType, 2> test("Test", 3, 4, 5);
 
-    test[0] = create_random_tensor("1", 3, 3);
-    test[2] = create_random_tensor("2", 4, 4);
-    test[3] = create_random_tensor("3", 5, 5);
+    test[0] = create_random_tensor<TestType>("1", 3, 3);
+    test[1] = create_random_tensor<TestType>("2", 4, 4);
+    test[2] = create_random_tensor<TestType>("3", 5, 5);
 
     SECTION("non-const") {
         auto test_view = (TiledTensorView<TestType, 2>)test;
 
         for (int i = 0; i < 12; i++) {
             for (int j = 0; j < 12; j++) {
-                REQUIRE(test(i, j) == test_view(i, j));
+                REQUIRE(test(i, j) == test_view.at(i, j));
             }
         }
     }

--- a/libs/Einsums/Tensor/tests/unit/TensorView.cpp
+++ b/libs/Einsums/Tensor/tests/unit/TensorView.cpp
@@ -3,6 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 //--------------------------------------------------------------------------------------------
 
+#include <Einsums/Tensor/BlockTensor.hpp>
 #include <Einsums/Tensor/Tensor.hpp>
 #include <Einsums/TensorUtilities/CreateRandomTensor.hpp>
 
@@ -47,6 +48,36 @@ TEMPLATE_TEST_CASE("Subset TensorView", "[tensor]", float, double, std::complex<
 
         for (size_t i = 0; i < size; i++) {
             REQUIRE(I_original(d1, d2, i) == I_view(i));
+        }
+    }
+}
+
+TEMPLATE_TEST_CASE("Block tensor views", "[tensor]", float, double, std::complex<float>, std::complex<double>) {
+    using namespace einsums;
+
+    BlockTensor<TestType, 2> test("Test", 3, 4, 5);
+
+    test[0] = create_random_tensor("1", 3, 3);
+    test[2] = create_random_tensor("2", 4, 4);
+    test[3] = create_random_tensor("3", 5, 5);
+
+    SECTION("non-const") {
+        auto test_view = (TiledTensorView<TestType, 2>)test;
+
+        for (int i = 0; i < 12; i++) {
+            for (int j = 0; j < 12; j++) {
+                REQUIRE(test(i, j) == test_view(i, j));
+            }
+        }
+    }
+
+    SECTION("const") {
+        auto const test_view = (TiledTensorView<TestType, 2> const)test;
+
+        for (int i = 0; i < 12; i++) {
+            for (int j = 0; j < 12; j++) {
+                REQUIRE(test(i, j) == test_view(i, j));
+            }
         }
     }
 }

--- a/libs/Einsums/TensorAlgebra/include/Einsums/TensorAlgebra/Backends/ElementTransform.hpp
+++ b/libs/Einsums/TensorAlgebra/include/Einsums/TensorAlgebra/Backends/ElementTransform.hpp
@@ -35,7 +35,7 @@ auto element_transform(CType *C, UnaryOperator unary_opt) -> void {
     Stride<Rank> index_strides;
     size_t       elements = dims_to_strides(C->dims(), index_strides);
 
-    // EINSUMS_OMP_PARALLEL_FOR
+    EINSUMS_OMP_PARALLEL_FOR
     for (size_t item = 0; item < elements; item++) {
         size_t offset;
         sentinel_to_sentinels(item, index_strides, C->strides(), offset);
@@ -91,7 +91,7 @@ auto element(MultiOperator multi_opt, CType<T, Rank> *C, MultiTensors<T, Rank> &
     Stride<Rank> index_strides;
     size_t       elements = dims_to_strides(C->dims(), index_strides);
 
-    // EINSUMS_OMP_PARALLEL_FOR
+    EINSUMS_OMP_PARALLEL_FOR
     for (size_t item = 0; item < elements; item++) {
         thread_local std::array<int64_t, Rank> index;
 

--- a/libs/Einsums/TensorAlgebra/include/Einsums/TensorAlgebra/Backends/GenericAlgorithm.hpp
+++ b/libs/Einsums/TensorAlgebra/include/Einsums/TensorAlgebra/Backends/GenericAlgorithm.hpp
@@ -81,7 +81,7 @@ void einsum_generic_algorithm(std::tuple<CUniqueIndices...> const &C_unique, std
         Stride<sizeof...(LinkDims)> link_index_strides;
         size_t                      link_elements = dims_to_strides(link_dims, link_index_strides);
 
-        //        EINSUMS_OMP_PARALLEL_FOR
+        EINSUMS_OMP_PARALLEL_FOR
         for (size_t item = 0; item < target_elements; item++) {
             thread_local std::array<int64_t, sizeof...(TargetDims)> target_combination;
             sentinel_to_indices(item, target_index_strides, target_combination);

--- a/libs/Einsums/TensorBase/include/Einsums/TensorBase/TensorBase.hpp
+++ b/libs/Einsums/TensorBase/include/Einsums/TensorBase/TensorBase.hpp
@@ -62,7 +62,7 @@ struct DeviceTypedTensor {
  *
  * @brief Represents a tensor only available to the core.
  */
-struct CoreTensor {
+struct EINSUMS_EXPORT CoreTensor {
 
 };
 
@@ -72,7 +72,7 @@ struct CoreTensor {
  *
  * @brief Represents a tensor available to graphics hardware.
  */
-struct DeviceTensorBase {
+struct EINSUMS_EXPORT DeviceTensorBase {
 
 };
 #endif
@@ -82,7 +82,7 @@ struct DeviceTensorBase {
  *
  * @brief Represents a tensor stored on disk.
  */
-struct DiskTensor {
+struct EINSUMS_EXPORT DiskTensor {
 
 };
 
@@ -115,7 +115,7 @@ struct TiledTensor;
  * Specifies that a tensor is a block tensor without needing template parameters. Internal use only.
  * Use BlockTensorBase in your code.
  */
-struct BlockTensorNoExtra {
+struct EINSUMS_EXPORT BlockTensorNoExtra {
 
 };
 
@@ -128,12 +128,12 @@ struct BlockTensor;
  *
  * @brief Specifies that the tensor type can be used by einsum to select different routines other than the generic algorithm.
  */
-struct AlgebraOptimizedTensor {
+struct EINSUMS_EXPORT AlgebraOptimizedTensor {
 
 };
 
-class RuntimeTensorNoType {};
+class EINSUMS_EXPORT RuntimeTensorNoType {};
 
-class RuntimeTensorViewNoType {};
+class EINSUMS_EXPORT RuntimeTensorViewNoType {};
 
 } // namespace einsums::tensor_base

--- a/libs/Einsums/TensorUtilities/include/Einsums/TensorUtilities/BlockViews.hpp
+++ b/libs/Einsums/TensorUtilities/include/Einsums/TensorUtilities/BlockViews.hpp
@@ -12,6 +12,24 @@
 
 namespace einsums {
 
+/**
+ * @brief Create a view of a block tensor where each member has a different view.
+ *
+ * This function takes in a vector of ranges and applies the ranges to each dimension of each block. For instance:
+
+ * @code
+ * BlockTensor<double, 2> tensor("tensor", 5, 5);
+ * apply_view(tensor, std::vector<Range>{Range{0, 3}, Range{1, 4}});
+ * @endcode
+ * 
+ * This will create a view where the first block has been restricted to the top-left 3x3 block and the second has
+ * been restricted to the middle 3x3 block.
+ *
+ * @param tensor The tensor to view.
+ * @param spec A vector of ranges that will be passed to the internal tensors to construct the view.
+ *
+ * @return A TiledTensorView that contains the resulting views.
+ */
 template <CoreBlockTensorConcept TensorType>
 auto apply_view(TensorType const &tensor, std::vector<Range> const &spec) {
     if (spec.size() > tensor.num_blocks()) {
@@ -47,6 +65,24 @@ auto apply_view(TensorType const &tensor, std::vector<Range> const &spec) {
     return out;
 }
 
+/**
+ * @brief Create a view of a block tensor where each member has a different view.
+ *
+ * This function takes in several vectors of ranges and applies the ranges to the respective dimension of each block. For instance:
+
+ * @code
+ * BlockTensor<double, 2> tensor("tensor", 5, 5);
+ * apply_view(tensor, std::vector<Range>{Range{0, 3}, Range{1, 4}}, std::vector<Range>{Range{1, 4}, Range{0, 3}});
+ * @endcode
+ * 
+ * This will create a view where the first block has been restricted to the first three rows and middle three columns,
+ * and the second block has been restricted to the middle three rows and the first three columns.
+ *
+ * @param tensor The tensor to view.
+ * @param spec Several vectors of ranges that will be passed to the internal tensors to construct the view.
+ *
+ * @return A TiledTensorView that contains the resulting views.
+ */
 template <CoreBlockTensorConcept TensorType, typename... ViewSpec>
     requires requires {
         requires sizeof...(ViewSpec) == TensorType::Rank;
@@ -94,6 +130,27 @@ auto apply_view(TensorType const &tensor, ViewSpec &&...spec) {
     return out;
 }
 
+/**
+ * @brief Create a view of a tiled tensor where each member has a different view.
+ *
+ * This function takes in several vectors of ranges and applies the ranges to the respective dimension of each tile. For instance:
+
+ * @code
+ * TiledTensor<double, 2> tensor("tensor", std::array{5, 5});
+ * apply_view(tensor, std::vector<Range>{Range{0, 3}, Range{1, 4}}, std::vector<Range>{Range{1, 4}, Range{0, 3}});
+ * @endcode
+ * 
+ * This will create a view where:
+ * - The (0,0) tile is restricted to the first three rows and middle three columns.
+ * - The (0,1) tile is restricted to the top left 3x3 block.
+ * - The (1,0) tile is restricted to the middle 3x3 block.
+ * - The (1,1) tile is restricted to the middle three columns and first three rows.
+ *
+ * @param tensor The tensor to view.
+ * @param spec Several vectors of ranges that will be passed to the internal tensors to construct the view.
+ *
+ * @return A TiledTensorView that contains the resulting views.
+ */
 template <CoreTiledTensorConcept TensorType, typename... ViewSpec>
     requires requires {
         requires sizeof...(ViewSpec) == TensorType::Rank;

--- a/libs/Einsums/TensorUtilities/include/Einsums/TensorUtilities/BlockViews.hpp
+++ b/libs/Einsums/TensorUtilities/include/Einsums/TensorUtilities/BlockViews.hpp
@@ -197,7 +197,7 @@ auto apply_view(TensorType const &tensor, ViewSpec &&...spec) {
     return out;
 }
 
-#ifdef EINSUMS_COMPUTE_CODE
+#if defined(EINSUMS_COMPUTE_CODE) && !defined(DOXYGEN)
 
 /**
  * @brief Create a view of a block tensor where each member has a different view.

--- a/libs/Einsums/TensorUtilities/include/Einsums/TensorUtilities/BlockViews.hpp
+++ b/libs/Einsums/TensorUtilities/include/Einsums/TensorUtilities/BlockViews.hpp
@@ -1,0 +1,143 @@
+//--------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//--------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <Einsums/Tensor/BlockTensor.hpp>
+#include <Einsums/Tensor/TiledTensor.hpp>
+
+#include "Einsums/Errors/Error.hpp"
+
+namespace einsums {
+
+template <CoreBlockTensorConcept TensorType>
+auto apply_view(TensorType const &tensor, std::vector<Range> const &spec) {
+    if (spec.size() > tensor.num_blocks()) {
+        EINSUMS_THROW_EXCEPTION(num_argument_error, "Can not apply view specification to block tensor. Incorrect number of indices given.");
+    }
+
+    std::vector<int64_t> sizes(spec.size());
+
+    for (int i = 0; i < spec.size(); i++) {
+        if (spec[i][1] < 0 && tensor.block_dim(i) != 0) {
+            sizes[i] = tensor.block_dim(i) + spec[i][1] - spec[i][0];
+        } else if (tensor.block_dim(i) == 0) {
+            sizes[i] = 0;
+        } else {
+            sizes[i] = spec[i][1] - spec[i][0];
+        }
+    }
+
+    auto out = TiledTensorView<typename TensorType::ValueType, TensorType::Rank>("unnamed view", sizes);
+
+    std::array<int, TensorType::Rank> position;
+
+    auto index = std::array<Range, TensorType::Rank>();
+
+    for (int i = 0; i < spec.size(); i++) {
+        position.fill((int)i);
+
+        index.fill(spec.at(i));
+
+        out.insert_tile(position, std::apply(tensor[i], index));
+    }
+
+    return out;
+}
+
+template <CoreBlockTensorConcept TensorType, typename... ViewSpec>
+    requires requires {
+        requires sizeof...(ViewSpec) == TensorType::Rank;
+        requires sizeof...(ViewSpec) > 1;
+        requires(std::is_same_v<ViewSpec, std::vector<Range>> && ...);
+    }
+auto apply_view(TensorType const &tensor, ViewSpec &&...spec) {
+    if (((spec.size() > tensor.num_blocks()) || ...)) {
+        EINSUMS_THROW_EXCEPTION(num_argument_error, "Can not apply view specification to block tensor. Incorrect number of indices given.");
+    }
+
+    auto spec_array = std::array{std::forward<ViewSpec>(spec)...};
+
+    std::array<std::vector<int>, TensorType::Rank> sizes;
+
+    for (int i = 0; i < spec_array.size(); i++) {
+        sizes[i].resize(spec_array[i].size());
+        for (int j = 0; j < spec_array[i].size(); j++) {
+            if (spec_array[i][j][1] < 0 && tensor.block_dim(j) != 0) {
+                sizes[i][j] = tensor.block_dim(j) + spec_array[i][j][1] - spec_array[i][j][0];
+            } else if (tensor.block_dim(j) == 0) {
+                sizes[i][j] = 0;
+            } else {
+                sizes[i][j] = spec_array[i][j][1] - spec_array[i][j][0];
+            }
+        }
+    }
+
+    auto out = TiledTensorView<typename TensorType::ValueType, TensorType::Rank>("unnamed view", sizes);
+
+    std::array<int, TensorType::Rank> position;
+
+    auto index = std::array<Range, TensorType::Rank>();
+
+    for (int i = 0; i < tensor.num_blocks(); i++) {
+        position.fill((int)i);
+
+        for (int j = 0; j < index.size(); j++) {
+            index[j] = spec_array[j][i];
+        }
+
+        out.insert_tile(position, std::apply(tensor[i], index));
+    }
+
+    return out;
+}
+
+template <CoreTiledTensorConcept TensorType, typename... ViewSpec>
+    requires requires {
+        requires sizeof...(ViewSpec) == TensorType::Rank;
+        requires sizeof...(ViewSpec) > 1;
+        requires(std::is_same_v<ViewSpec, std::vector<Range>> && ...);
+    }
+auto apply_view(TensorType const &tensor, ViewSpec &&...spec) {
+    auto spec_array = std::array{std::forward<ViewSpec>(spec)...};
+
+    for(int i = 0; i < TensorType::Rank; i++) {
+        if (spec_array[i].size() > tensor.grid_size(i)) {
+            EINSUMS_THROW_EXCEPTION(num_argument_error, "Can not apply view specification to tiled tensor. Incorrect number of indices given.");
+        }
+    }
+    
+    std::array<std::vector<int>, TensorType::Rank> sizes;
+
+    for (int i = 0; i < spec_array.size(); i++) {
+        sizes[i].resize(spec_array[i].size());
+        for (int j = 0; j < spec_array[i].size(); j++) {
+            if (spec_array[i][j][1] < 0 && tensor.tile_size(i)[j] != 0) {
+                sizes[i][j] = tensor.tile_size(i)[j] + spec_array[i][j][1] - spec_array[i][j][0];
+            } else if (tensor.tile_size(i)[j] == 0) {
+                sizes[i][j] = 0;
+            } else {
+                sizes[i][j] = spec_array[i][j][1] - spec_array[i][j][0];
+            }
+        }
+    }
+
+    auto out = TiledTensorView<typename TensorType::ValueType, TensorType::Rank>("unnamed view", sizes);
+
+    auto index = std::array<Range, TensorType::Rank>();
+
+    for (auto const &pair : tensor.tiles()) {
+
+        for (int j = 0; j < index.size(); j++) {
+            index[j] = spec_array[j][pair.first[j]];
+        }
+
+        out.insert_tile(pair.first, std::apply(pair.second, index));
+    }
+
+    return out;
+}
+
+} // namespace einsums

--- a/libs/Einsums/TensorUtilities/include/Einsums/TensorUtilities/BlockViews.hpp
+++ b/libs/Einsums/TensorUtilities/include/Einsums/TensorUtilities/BlockViews.hpp
@@ -197,4 +197,193 @@ auto apply_view(TensorType const &tensor, ViewSpec &&...spec) {
     return out;
 }
 
+#ifdef EINSUMS_COMPUTE_CODE
+
+/**
+ * @brief Create a view of a block tensor where each member has a different view.
+ *
+ * This function takes in a vector of ranges and applies the ranges to each dimension of each block. For instance:
+
+ * @code
+ * BlockTensor<double, 2> tensor("tensor", 5, 5);
+ * apply_view(tensor, std::vector<Range>{Range{0, 3}, Range{1, 4}});
+ * @endcode
+ * 
+ * This will create a view where the first block has been restricted to the top-left 3x3 block and the second has
+ * been restricted to the middle 3x3 block.
+ *
+ * @param tensor The tensor to view.
+ * @param spec A vector of ranges that will be passed to the internal tensors to construct the view.
+ *
+ * @return A TiledTensorView that contains the resulting views.
+ */
+ template <DeviceBlockTensorConcept TensorType>
+ auto apply_view(TensorType const &tensor, std::vector<Range> const &spec) {
+     if (spec.size() > tensor.num_blocks()) {
+         EINSUMS_THROW_EXCEPTION(num_argument_error, "Can not apply view specification to block tensor. Incorrect number of indices given.");
+     }
+ 
+     std::vector<int64_t> sizes(spec.size());
+ 
+     for (int i = 0; i < spec.size(); i++) {
+         if (spec[i][1] < 0 && tensor.block_dim(i) != 0) {
+             sizes[i] = tensor.block_dim(i) + spec[i][1] - spec[i][0];
+         } else if (tensor.block_dim(i) == 0) {
+             sizes[i] = 0;
+         } else {
+             sizes[i] = spec[i][1] - spec[i][0];
+         }
+     }
+ 
+     auto out = TiledDeviceTensorView<typename TensorType::ValueType, TensorType::Rank>("unnamed view", sizes);
+ 
+     std::array<int, TensorType::Rank> position;
+ 
+     auto index = std::array<Range, TensorType::Rank>();
+ 
+     for (int i = 0; i < spec.size(); i++) {
+         position.fill((int)i);
+ 
+         index.fill(spec.at(i));
+ 
+         out.insert_tile(position, std::apply(tensor[i], index));
+     }
+ 
+     return out;
+ }
+ 
+ /**
+  * @brief Create a view of a block tensor where each member has a different view.
+  *
+  * This function takes in several vectors of ranges and applies the ranges to the respective dimension of each block. For instance:
+ 
+  * @code
+  * BlockTensor<double, 2> tensor("tensor", 5, 5);
+  * apply_view(tensor, std::vector<Range>{Range{0, 3}, Range{1, 4}}, std::vector<Range>{Range{1, 4}, Range{0, 3}});
+  * @endcode
+  * 
+  * This will create a view where the first block has been restricted to the first three rows and middle three columns,
+  * and the second block has been restricted to the middle three rows and the first three columns.
+  *
+  * @param tensor The tensor to view.
+  * @param spec Several vectors of ranges that will be passed to the internal tensors to construct the view.
+  *
+  * @return A TiledTensorView that contains the resulting views.
+  */
+ template <DeviceBlockTensorConcept TensorType, typename... ViewSpec>
+     requires requires {
+         requires sizeof...(ViewSpec) == TensorType::Rank;
+         requires sizeof...(ViewSpec) > 1;
+         requires(std::is_same_v<ViewSpec, std::vector<Range>> && ...);
+     }
+ auto apply_view(TensorType const &tensor, ViewSpec &&...spec) {
+     if (((spec.size() > tensor.num_blocks()) || ...)) {
+         EINSUMS_THROW_EXCEPTION(num_argument_error, "Can not apply view specification to block tensor. Incorrect number of indices given.");
+     }
+ 
+     auto spec_array = std::array{std::forward<ViewSpec>(spec)...};
+ 
+     std::array<std::vector<int>, TensorType::Rank> sizes;
+ 
+     for (int i = 0; i < spec_array.size(); i++) {
+         sizes[i].resize(spec_array[i].size());
+         for (int j = 0; j < spec_array[i].size(); j++) {
+             if (spec_array[i][j][1] < 0 && tensor.block_dim(j) != 0) {
+                 sizes[i][j] = tensor.block_dim(j) + spec_array[i][j][1] - spec_array[i][j][0];
+             } else if (tensor.block_dim(j) == 0) {
+                 sizes[i][j] = 0;
+             } else {
+                 sizes[i][j] = spec_array[i][j][1] - spec_array[i][j][0];
+             }
+         }
+     }
+ 
+     auto out = TiledDeviceTensorView<typename TensorType::ValueType, TensorType::Rank>("unnamed view", sizes);
+ 
+     std::array<int, TensorType::Rank> position;
+ 
+     auto index = std::array<Range, TensorType::Rank>();
+ 
+     for (int i = 0; i < tensor.num_blocks(); i++) {
+         position.fill((int)i);
+ 
+         for (int j = 0; j < index.size(); j++) {
+             index[j] = spec_array[j][i];
+         }
+ 
+         out.insert_tile(position, std::apply(tensor[i], index));
+     }
+ 
+     return out;
+ }
+ 
+ /**
+  * @brief Create a view of a tiled tensor where each member has a different view.
+  *
+  * This function takes in several vectors of ranges and applies the ranges to the respective dimension of each tile. For instance:
+ 
+  * @code
+  * TiledTensor<double, 2> tensor("tensor", std::array{5, 5});
+  * apply_view(tensor, std::vector<Range>{Range{0, 3}, Range{1, 4}}, std::vector<Range>{Range{1, 4}, Range{0, 3}});
+  * @endcode
+  * 
+  * This will create a view where:
+  * - The (0,0) tile is restricted to the first three rows and middle three columns.
+  * - The (0,1) tile is restricted to the top left 3x3 block.
+  * - The (1,0) tile is restricted to the middle 3x3 block.
+  * - The (1,1) tile is restricted to the middle three columns and first three rows.
+  *
+  * @param tensor The tensor to view.
+  * @param spec Several vectors of ranges that will be passed to the internal tensors to construct the view.
+  *
+  * @return A TiledTensorView that contains the resulting views.
+  */
+ template <DeviceTiledTensorConcept TensorType, typename... ViewSpec>
+     requires requires {
+         requires sizeof...(ViewSpec) == TensorType::Rank;
+         requires sizeof...(ViewSpec) > 1;
+         requires(std::is_same_v<ViewSpec, std::vector<Range>> && ...);
+     }
+ auto apply_view(TensorType const &tensor, ViewSpec &&...spec) {
+     auto spec_array = std::array{std::forward<ViewSpec>(spec)...};
+ 
+     for(int i = 0; i < TensorType::Rank; i++) {
+         if (spec_array[i].size() > tensor.grid_size(i)) {
+             EINSUMS_THROW_EXCEPTION(num_argument_error, "Can not apply view specification to tiled tensor. Incorrect number of indices given.");
+         }
+     }
+     
+     std::array<std::vector<int>, TensorType::Rank> sizes;
+ 
+     for (int i = 0; i < spec_array.size(); i++) {
+         sizes[i].resize(spec_array[i].size());
+         for (int j = 0; j < spec_array[i].size(); j++) {
+             if (spec_array[i][j][1] < 0 && tensor.tile_size(i)[j] != 0) {
+                 sizes[i][j] = tensor.tile_size(i)[j] + spec_array[i][j][1] - spec_array[i][j][0];
+             } else if (tensor.tile_size(i)[j] == 0) {
+                 sizes[i][j] = 0;
+             } else {
+                 sizes[i][j] = spec_array[i][j][1] - spec_array[i][j][0];
+             }
+         }
+     }
+ 
+     auto out = TiledDeviceTensorView<typename TensorType::ValueType, TensorType::Rank>("unnamed view", sizes);
+ 
+     auto index = std::array<Range, TensorType::Rank>();
+ 
+     for (auto const &pair : tensor.tiles()) {
+ 
+         for (int j = 0; j < index.size(); j++) {
+             index[j] = spec_array[j][pair.first[j]];
+         }
+ 
+         out.insert_tile(pair.first, std::apply(pair.second, index));
+     }
+ 
+     return out;
+ }
+
+#endif
+
 } // namespace einsums

--- a/libs/Einsums/TensorUtilities/tests/unit/BlockViews.cpp
+++ b/libs/Einsums/TensorUtilities/tests/unit/BlockViews.cpp
@@ -1,0 +1,169 @@
+//--------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//--------------------------------------------------------------------------------------------
+
+#include <Einsums/Testing.hpp>
+#include <Einsums/Tensor/BlockTensor.hpp>
+#include <Einsums/Tensor/TiledTensor.hpp>
+#include <Einsums/TensorUtilities/BlockViews.hpp>
+#include <Einsums/TensorUtilities/CreateRandomTensor.hpp>
+
+
+TEMPLATE_TEST_CASE("Block tensor views", "[tensor]", float, double, std::complex<float>, std::complex<double>) {
+
+    using namespace einsums;
+
+    SECTION("10x10 all same") {
+
+        auto A = BlockTensor<TestType, 2>("Test tensor", 5, 5);
+
+        for(int i = 0; i < 5; i++) {
+            for(int j = 0; j < 5; j++) {
+                A(i, j) = i + 5 * j + 1;
+                A(i + 5, j + 5) = i + 5 * j + 26;
+            }
+        }
+
+        auto A_view = apply_view(A, std::vector<Range>{Range{0, 3}, Range{1, 4}});
+
+        for(int i = 0; i < 3; i++) {
+            for(int j = 0; j < 3; j++) {
+                REQUIRE(A(i, j) == A_view(i, j));
+                REQUIRE(A(i + 6, j + 6) == A_view(i + 3, j + 3));
+            }
+        }
+
+        // Modify.
+        auto B = A;
+
+        for(int i = 0; i < 3; i++) {
+            for(int j = 0; j < 3; j++) {
+                A_view(i, j) = 0;
+                A_view(i + 3, j + 3) = 0;
+            }
+        }
+
+        for(int i = 0; i < 5; i++) {
+            for(int j = 0; j < 5; j++) {
+                if(i < 3 && j < 3) {
+                    REQUIRE(A(i, j) == TestType{0.0});
+                    REQUIRE(A(i, j) != B(i, j));
+                } else {
+                    REQUIRE(A(i, j) != TestType{0.0});
+                    REQUIRE(A(i, j) == B(i, j));
+                }
+
+                if(0 < i && i < 4 && 0 < j && j < 4) {
+                    REQUIRE(A(i + 5, j + 5) == TestType{0.0});
+                    REQUIRE(A(i + 5, j + 5) != B(i + 5, j + 5));
+                } else {
+                    REQUIRE(A(i + 5, j + 5) != TestType{0.0});
+                    REQUIRE(A(i + 5, j + 5) == B(i + 5, j + 5));
+                }
+            }
+        }
+    }
+
+    SECTION("STO-3G water coefficients") {
+        BlockTensor<TestType, 2> C_matrix{"Overlap", 4, 0, 1, 2};
+
+        C_matrix[0] = create_random_tensor<TestType>("A1", 4, 4);
+        C_matrix[1].set_name("A2");
+        C_matrix[2] = create_random_tensor<TestType>("B1", 1, 1);
+        C_matrix[3] = create_random_tensor<TestType>("B2", 2, 2);
+
+        auto C_occ = apply_view(C_matrix, std::vector<Range>{Range{0, 4}, Range{0, 0}, Range{0, 1}, Range{0, 2}}, std::vector<Range>{Range{0, 3}, Range{0, 0}, Range{0, 1}, Range{0, 1}});
+
+        for(int i = 0; i < 4; i++) {
+            for(int j = 0; j < 3; j++) {
+                REQUIRE(C_matrix[0](i, j) == C_occ.tile(0, 0)(i, j));
+            }
+        }
+
+        for(int i = 0; i < 1; i++) {
+            for(int j = 0; j < 1; j++) {
+                REQUIRE(C_matrix[2](i, j) == C_occ.tile(2, 2)(i, j));
+            }
+        }
+
+        for(int i = 0; i < 2; i++) {
+            for(int j = 0; j < 1; j++) {
+                REQUIRE(C_matrix[3](i, j) == C_occ.tile(3, 3)(i, j));
+            }
+        }
+
+        C_occ.zero_no_clear();
+
+        for(int i = 0; i < 4; i++) {
+            for(int j = 0; j < 3; j++) {
+                REQUIRE(C_matrix[0](i, j) == TestType{0.0});
+            }
+            REQUIRE(C_matrix[0](i, 3) != TestType{0.0});
+        }
+
+        for(int i = 0; i < 1; i++) {
+            for(int j = 0; j < 1; j++) {
+                REQUIRE(C_matrix[2](i, j) == TestType{0.0});
+            }
+        }
+
+        for(int i = 0; i < 2; i++) {
+            for(int j = 0; j < 1; j++) {
+                REQUIRE(C_matrix[3](i, j) == TestType{0.0});
+            }
+            REQUIRE(C_matrix[3](i, 1) != TestType{0.0});
+        }
+    }
+
+    SECTION("STO-3G water but tiled") {
+        TiledTensor<TestType, 2> C_matrix{"Overlap", std::array{4, 0, 1, 2}};
+
+        C_matrix.tile(0, 0) = create_random_tensor<TestType>("A1", 4, 4);
+        C_matrix.tile(1, 1).set_name("A2");
+        C_matrix.tile(2, 2) = create_random_tensor<TestType>("B1", 1, 1);
+        C_matrix.tile(3, 3) = create_random_tensor<TestType>("B2", 2, 2);
+
+        auto C_occ = apply_view(C_matrix, std::vector<Range>{Range{0, 4}, Range{0, 0}, Range{0, 1}, Range{0, 2}}, std::vector<Range>{Range{0, 3}, Range{0, 0}, Range{0, 1}, Range{0, 1}});
+
+        for(int i = 0; i < 4; i++) {
+            for(int j = 0; j < 3; j++) {
+                REQUIRE(C_matrix.tile(0, 0)(i, j) == C_occ.tile(0, 0)(i, j));
+            }
+        }
+
+        for(int i = 0; i < 1; i++) {
+            for(int j = 0; j < 1; j++) {
+                REQUIRE(C_matrix.tile(2, 2)(i, j) == C_occ.tile(2, 2)(i, j));
+            }
+        }
+
+        for(int i = 0; i < 2; i++) {
+            for(int j = 0; j < 1; j++) {
+                REQUIRE(C_matrix.tile(3, 3)(i, j) == C_occ.tile(3, 3)(i, j));
+            }
+        }
+
+        C_occ.zero_no_clear();
+
+        for(int i = 0; i < 4; i++) {
+            for(int j = 0; j < 3; j++) {
+                REQUIRE(C_matrix.tile(0, 0)(i, j) == TestType{0.0});
+            }
+            REQUIRE(C_matrix.tile(0, 0)(i, 3) != TestType{0.0});
+        }
+
+        for(int i = 0; i < 1; i++) {
+            for(int j = 0; j < 1; j++) {
+                REQUIRE(C_matrix.tile(2, 2)(i, j) == TestType{0.0});
+            }
+        }
+
+        for(int i = 0; i < 2; i++) {
+            for(int j = 0; j < 1; j++) {
+                REQUIRE(C_matrix.tile(3, 3)(i, j) == TestType{0.0});
+            }
+            REQUIRE(C_matrix.tile(3, 3)(i, 1) != TestType{0.0});
+        }
+    }
+}

--- a/libs/Einsums/TensorUtilities/tests/unit/CMakeLists.txt
+++ b/libs/Einsums/TensorUtilities/tests/unit/CMakeLists.txt
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 #----------------------------------------------------------------------------------------------
 
-set(TensorUtilitiesTests Identity)
+set(TensorUtilitiesTests Identity BlockViews)
 
 foreach(test ${TensorUtilitiesTests})
   set(sources ${test}.cpp)

--- a/libs/EinsumsPy/Tensor/include/EinsumsPy/Tensor/PyTensor.hpp
+++ b/libs/EinsumsPy/Tensor/include/EinsumsPy/Tensor/PyTensor.hpp
@@ -75,14 +75,14 @@ class EINSUMS_EXPORT PyTensorIterator {
      *
      * @brief Holds the number of elements this iterator will need to cycle through.
      */
-    size_t               _curr_index, _elements;
+    size_t _curr_index, _elements;
 
     /**
      * @property _index_strides
      *
      * @brief Holds information to be able to turn _curr_index into a list of indices that can be passed to the underlying tensor.
      */
-    std::vector<size_t>  _index_strides;
+    std::vector<size_t> _index_strides;
 
     /**
      * @property _tensor
@@ -90,7 +90,7 @@ class EINSUMS_EXPORT PyTensorIterator {
      * @brief The tensor this iterator will iterate over.
      */
     RuntimeTensorView<T> _tensor;
-    
+
     /**
      * @property _stop
      *
@@ -101,10 +101,9 @@ class EINSUMS_EXPORT PyTensorIterator {
      *
      * @brief Indicates whether the iterator is a forward iterator or a reverse iterator.
      */
-    bool                 _stop{false}, _reverse{false};
+    bool _stop{false}, _reverse{false};
 
   public:
-
     /**
      * @brief Copy constructor with optional direction modification.
      *
@@ -760,7 +759,7 @@ class PyTensor : public RuntimeTensor<T> {
                 }                                                                                                                          \
             }                                                                                                                              \
         } else {                                                                                                                           \
-            EINSUMS_OMP_PARALLEL_FOR                                                                                                       \
+            EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                                  \
             for (size_t sentinel = 0; sentinel < this->size(); sentinel++) {                                                               \
                 if constexpr (std::is_base_of_v<pybind11::object, TOther>) {                                                               \
                     this->_data[sentinel] OP pybind11::cast<T>((TOther)buffer_data[sentinel]);                                             \
@@ -919,7 +918,7 @@ class PyTensor : public RuntimeTensor<T> {
                         this->_data[sentinel] OP buffer_data[buffer_sent];                                                                 \
                     }                                                                                                                      \
                 } else {                                                                                                                   \
-                    EINSUMS_OMP_PARALLEL_FOR                                                                                               \
+                    EINSUMS_OMP_PARALLEL_FOR_SIMD                                                                                          \
                     for (size_t sentinel = 0; sentinel < this->size(); sentinel++) {                                                       \
                         this->_data[sentinel] OP buffer_data[sentinel];                                                                    \
                     }                                                                                                                      \
@@ -983,7 +982,7 @@ class PyTensor : public RuntimeTensor<T> {
 
     /**
      * @brief Check whether the tensor can see all of the data it stores.
-     * 
+     *
      * This function should return true for this kind of tensor.
      */
     bool full_view_of_underlying() const noexcept override { PYBIND11_OVERRIDE(bool, RuntimeTensor<T>, full_view_of_underlying); }
@@ -1198,7 +1197,6 @@ class PyTensorView : public RuntimeTensorView<T> {
     }
 
   public:
-
     /**
      * @brief Subscript into the tensor.
      *
@@ -1603,7 +1601,6 @@ class PyTensorView : public RuntimeTensorView<T> {
 #undef COPY_CAST_OP
 
   public:
-
     /**
      * @brief Copy the data from a buffer into the view.
      *

--- a/libs/EinsumsPy/TensorAlgebra/include/EinsumsPy/TensorAlgebra/PyTensorAlgebra.hpp
+++ b/libs/EinsumsPy/TensorAlgebra/include/EinsumsPy/TensorAlgebra/PyTensorAlgebra.hpp
@@ -920,7 +920,7 @@ class EINSUMS_EXPORT PyEinsumGerPlan : public PyEinsumGenericPlan {
             if (C_prefactor == T{0.0}) {
                 std::memset(C_data, 0, C_info.shape[0] * C_info.strides[0]);
             } else if (C_prefactor != T{1.0}) {
-                EINSUMS_OMP_PARALLEL_FOR
+                EINSUMS_OMP_PARALLEL_FOR_SIMD
                 for (size_t i = 0; i < C_info.shape[0] * C_info.strides[0]; i++) {
                     C_data[i] *= C_prefactor;
                 }


### PR DESCRIPTION
This PR adds facilities to create views from block and tiled tensors where each member is viewed with a different range. This is intended to be used for doing `<pq|rs> -> <ia|jb>` transformations, where some indices are restricted in one way, and others in a different way.