### PR TITLE
CreateModuleSkeleton: Fix error in template and restructure it.

### DIFF
--- a/libs/create_module_skeleton/ExportAll.cpp.in.fstring
+++ b/libs/create_module_skeleton/ExportAll.cpp.in.fstring
@@ -3,8 +3,9 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 //--------------------------------------------------------------------------------------------
 
-#include <pybind11/pybind11.h>
 #include <Einsums/Config.hpp>
+
+#include <pybind11/pybind11.h>
 
 namespace py = pybind11;
 

--- a/libs/create_module_skeleton/build_structure.py
+++ b/libs/create_module_skeleton/build_structure.py
@@ -18,7 +18,7 @@ def parse_template(filename, output_file, **kwargs):
 def build_layer(input_dir, output_dir, **kwargs):
     for item in os.listdir(input_dir):
         # Skip exports if we don't need them.
-        if item in ["Export.cpp"] and not kwargs["python"]:
+        if item in ["Export.cpp.fstring"] and not kwargs["python"]:
             continue
         item_out = kwargs.get(item, item)
 

--- a/libs/create_module_skeleton/template_top/CMakeLists.txt.fstring
+++ b/libs/create_module_skeleton/template_top/CMakeLists.txt.fstring
@@ -6,9 +6,9 @@
 {gpu_head}
 list(APPEND CMAKE_MODULE_PATH "${{CMAKE_CURRENT_SOURCE_DIR}}/cmake")
 
-set({module_name}Headers {lib_name}/{module_name}/InitModule.hpp {lib_name}/{module_name}/ModuleVars.hpp)
+set({module_name}Headers )
 
-set({module_name}Sources {export_source} InitModule.cpp /ModuleVars.cpp)
+set({module_name}Sources {export_source} InitModule.hpp ModuleVars.hpp InitModule.cpp ModuleVars.cpp)
 
 include(Einsums_AddModule)
 einsums_add_module(

--- a/libs/create_module_skeleton/template_top/src/InitModule.cpp.fstring
+++ b/libs/create_module_skeleton/template_top/src/InitModule.cpp.fstring
@@ -3,9 +3,11 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 //--------------------------------------------------------------------------------------------
 
-#include <{lib_name}/{module_name}/InitModule.hpp>
 #include <Einsums/Runtime.hpp>
+
 #include <argparse/argparse.hpp>
+
+#include "InitModule.hpp"
 
 namespace einsums {{
     
@@ -26,9 +28,9 @@ int setup_{lib_name}_{module_name}() {{
     static bool is_initialized = false;
 
     if(!is_initialized) {{
-        einsums::register_arguments(einsums::add_{lib_name}_{module_name}_arguments);
-        einsums::register_startup_function(einsums::initialize_{lib_name}_{module_name});
-        einsums::register_shutdown_function(einsums::finalize_{lib_name}_{module_name});
+        register_arguments(add_{lib_name}_{module_name}_arguments);
+        register_startup_function(initialize_{lib_name}_{module_name});
+        register_shutdown_function(finalize_{lib_name}_{module_name});
 
         is_initialized = true;
     }}
@@ -48,8 +50,6 @@ EINSUMS_EXPORT void add_{lib_name}_{module_name}_arguments(argparse::ArgumentPar
     auto &global_double = global_config.get_double_map()->get_value();
     auto &global_int = global_config.get_int_map()->get_value();
     auto &global_bool = global_config.get_bool_map()->get_value();
-
-    auto lock = std::lock_guard(global_string, global_double, global_int, global_bool);
 
     /* Examples:
      * String argument: 

--- a/libs/create_module_skeleton/template_top/src/InitModule.hpp.fstring
+++ b/libs/create_module_skeleton/template_top/src/InitModule.hpp.fstring
@@ -5,7 +5,6 @@
 
 #pragma once
 
-#include <Einsums/Config.hpp>
 #include <argparse/argparse.hpp>
 
 /*
@@ -22,16 +21,15 @@
 
 namespace einsums {{
 
-EINSUMS_EXPORT int setup_{lib_name}_{module_name}();
+int setup_{lib_name}_{module_name}();
 
-EINSUMS_EXPORT void add_{lib_name}_{module_name}_arguments(argparse::ArgumentParser &);
-EINSUMS_EXPORT void initialize_{lib_name}_{module_name}();
-EINSUMS_EXPORT void finalize_{lib_name}_{module_name}();
+void add_{lib_name}_{module_name}_arguments(argparse::ArgumentParser &);
+void initialize_{lib_name}_{module_name}();
+void finalize_{lib_name}_{module_name}();
 
 namespace detail {{
 
 static int initialize_module_{lib_name}_{module_name} = setup_{lib_name}_{module_name}();
 
 }}
-
 }}

--- a/libs/create_module_skeleton/template_top/src/ModuleVars.cpp.fstring
+++ b/libs/create_module_skeleton/template_top/src/ModuleVars.cpp.fstring
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 //--------------------------------------------------------------------------------------------
 
-#include <{lib_name}/{module_name}/ModuleVars.hpp>
+#include "ModuleVars.hpp"
 
 namespace einsums::detail {{
 

--- a/libs/create_module_skeleton/template_top/src/ModuleVars.hpp.fstring
+++ b/libs/create_module_skeleton/template_top/src/ModuleVars.hpp.fstring
@@ -5,26 +5,25 @@
 
 #pragma once
 
-#include <{lib_name}/{module_name}/InitModule.hpp>
+#include <Einsums/Config.hpp>
+
 #include <Einsums/TypeSupport/Singleton.hpp>
 #include <Einsums/TypeSupport/Lockable.hpp>
-#include <Einsums/Config.hpp>
+
+#include "InitModule.hpp"
 
 namespace einsums {{
 namespace detail {{
 
 /// @todo This class can be freely changed. It is provided as a starting point for your convenience. If not needed, it may be removed.
 
-class EINSUMS_EXPORT {lib_name}_{module_name}_vars final : public design_pats::Lockable<std::recursive_mutex> {{
+struct EINSUMS_EXPORT {lib_name}_{module_name}_vars final : design_pats::Lockable<std::recursive_mutex> {{
     EINSUMS_SINGLETON_DEF({lib_name}_{module_name}_vars)
 
-public:
     // Put module-global variables here.
-
 
 private:
     explicit {lib_name}_{module_name}_vars() = default;
-
 }};
 
 }}


### PR DESCRIPTION
Fixes errors in the templates and in the build_struct.py file.

I also moved the InitModule.hpp and ModuleVars.hpp out of the public API headers into the private src directory. If it needs to be in the public API location then that can be handled on a case by case basis. But nothing in these headers are anything a user needs to use.