### PR TITLE
Make Indices only accept indices.

### DIFF
--- a/libs/Einsums/TensorAlgebra/include/Einsums/TensorAlgebra/Detail/Index.hpp
+++ b/libs/Einsums/TensorAlgebra/include/Einsums/TensorAlgebra/Detail/Index.hpp
@@ -190,6 +190,10 @@ constexpr auto list = std::make_tuple(i, j, k, l, m, n, a, b, c, d, e, f, p, q, 
  *
  * @brief Identifier for providing index labels to the the einsum function.
  *
+ * If a variable name is passed to this class, it will raise a compiler error. If this is the case,
+ * please double check that you don't have any name clashes. Try to prefix the indices with @c einsums::index
+ * to see if that fixes your issues.
+ *
  * @tparam Args The indices to pass.
  */
 template <typename... Args>

--- a/libs/Einsums/TensorAlgebra/include/Einsums/TensorAlgebra/Detail/Index.hpp
+++ b/libs/Einsums/TensorAlgebra/include/Einsums/TensorAlgebra/Detail/Index.hpp
@@ -193,6 +193,7 @@ constexpr auto list = std::make_tuple(i, j, k, l, m, n, a, b, c, d, e, f, p, q, 
  * @tparam Args The indices to pass.
  */
 template <typename... Args>
+requires(std::is_base_of_v<index::LabelBase, Args> && ... && true)
 struct Indices : std::tuple<Args...> {
     /**
      * Construct a new Indices object using the given indices.

--- a/libs/Einsums/TensorAlgebra/tests/unit/Sort.cpp
+++ b/libs/Einsums/TensorAlgebra/tests/unit/Sort.cpp
@@ -46,15 +46,7 @@ TEMPLATE_TEST_CASE("permute2", "[tensor]", float, double, std::complex<float>, s
             }
         }
     }
-
-    SECTION("Index with tensor name") {
-        constexpr bool same_name_compiles = requires(Tensor<double, 2> A, Tensor<double, 2> C) {
-            permute(einsums::Indices{A, C}, &C, einsums::Indices{C, A}, A);
-        };
-
-        REQUIRES(!same_name_compiles);
-    }
-
+    
     SECTION("Rank 2 - axpy (2)") {
         Tensor A = create_incremented_tensor("A", 3, 3);
         Tensor C0{"C", 3, 3};

--- a/libs/Einsums/TensorAlgebra/tests/unit/Sort.cpp
+++ b/libs/Einsums/TensorAlgebra/tests/unit/Sort.cpp
@@ -47,6 +47,14 @@ TEMPLATE_TEST_CASE("permute2", "[tensor]", float, double, std::complex<float>, s
         }
     }
 
+    SECTION("Index with tensor name") {
+        constexpr bool same_name_compiles = requires(Tensor<double, 2> A, Tensor<double, 2> C) {
+            permute(einsums::Indices{A, C}, &C, einsums::Indices{C, A}, A);
+        };
+
+        REQUIRES(!same_name_compiles);
+    }
+
     SECTION("Rank 2 - axpy (2)") {
         Tensor A = create_incremented_tensor("A", 3, 3);
         Tensor C0{"C", 3, 3};


### PR DESCRIPTION
Some users have had issues where they may unintentionally create a tensor with the same name as an index. This change will make it so that an error is thrown when users try to pass a tensor to the indices object.