### PR TITLE
Updates cpptrace dependency.

### DIFF
--- a/cmake/Einsums_SetupCppTrace.cmake
+++ b/cmake/Einsums_SetupCppTrace.cmake
@@ -7,8 +7,7 @@ include(FetchContent)
 fetchcontent_declare(
   cpptrace
   GIT_REPOSITORY https://github.com/jeremy-rifkin/cpptrace.git
-  GIT_TAG v0.7.3 # <HASH or TAG>
-  FIND_PACKAGE_ARGS
-  0.7
+  GIT_TAG v1.0.1 # <HASH or TAG>
+  FIND_PACKAGE_ARGS 1.0
 )
 fetchcontent_makeavailable(cpptrace)

--- a/cmake/templates/EinsumsConfig.cmake.in
+++ b/cmake/templates/EinsumsConfig.cmake.in
@@ -67,7 +67,7 @@ einsums_find_package(TargetHDF5 REQUIRED)
 einsums_find_package(OpenMP MODULE COMPONENTS CXX)
 
 if (@EINSUMS_WITH_BACKTRACES@)
-  einsums_find_package(cpptrace 0.7 REQUIRED)
+  einsums_find_package(cpptrace 1.0 REQUIRED)
 endif ()
 
 if (NOT TARGET tgt::lapack)

--- a/devtools/conda-envs/merge_yml.py
+++ b/devtools/conda-envs/merge_yml.py
@@ -8,7 +8,6 @@ import argparse
 
 packages_to_filter = [
     'cpptrace' if platform.system() == 'Windows' else None,
-    'cpptrace' if platform.system() == 'Darwin' and platform.machine() == 'arm64' else None,
 ]
 
 dir_path = os.path.dirname(os.path.realpath(__file__))
@@ -84,7 +83,7 @@ if __name__ == "__main__":
         args.blas = "mkl"
 
     snippets = ["snippets/common.yml", f"snippets/compiler/{args.compiler}.yml",
-                f"snippets/blas/{args.blas}.yml"]
+                f"snippets/blas/{args.blas}.yml", f"snippets/os/{platform.system()}.yml"]
     if args.docs:
         snippets.append("snippets/docs.yml")
 

--- a/devtools/conda-envs/snippets/common.yml
+++ b/devtools/conda-envs/snippets/common.yml
@@ -16,6 +16,7 @@ dependencies:
   - fftw
   - fmt
   - cpptrace
+  - spdlog
   # HDF5
   # * zlib brings headers; hdf5 package only bring libzlib
   - hdf5

--- a/devtools/conda-envs/snippets/os/Darwin.yml
+++ b/devtools/conda-envs/snippets/os/Darwin.yml
@@ -1,0 +1,6 @@
+name: einsums-dev
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:
+  - clang-tools

--- a/devtools/conda-envs/snippets/os/Linux.yml
+++ b/devtools/conda-envs/snippets/os/Linux.yml
@@ -1,0 +1,5 @@
+name: einsums-dev
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:

--- a/devtools/conda-envs/snippets/os/Linux.yml
+++ b/devtools/conda-envs/snippets/os/Linux.yml
@@ -2,4 +2,3 @@ name: einsums-dev
 channels:
   - conda-forge
   - nodefaults
-dependencies:

--- a/devtools/conda-envs/snippets/os/Windows.yml
+++ b/devtools/conda-envs/snippets/os/Windows.yml
@@ -1,0 +1,5 @@
+name: einsums-dev
+channels:
+  - conda-forge
+  - nodefaults
+dependencies:

--- a/devtools/conda-envs/snippets/os/Windows.yml
+++ b/devtools/conda-envs/snippets/os/Windows.yml
@@ -2,4 +2,3 @@ name: einsums-dev
 channels:
   - conda-forge
   - nodefaults
-dependencies:

--- a/libs/Einsums/StringUtil/tests/unit/CMakeLists.txt
+++ b/libs/Einsums/StringUtil/tests/unit/CMakeLists.txt
@@ -19,7 +19,6 @@ foreach(test ${StringUtilTests})
   get_filename_component(TestName ${test} NAME_WE)
   # Extract extension of the test Example1.cpp -> .cpp, Example.2.hip -> .2.hip
   get_filename_component(Extension ${test} EXT)
-  message("Test name ${TestName}")
 
   # Remove the leading dot and replace any periods with underscores
   string(SUBSTRING ${Extension} 1 -1 EXT_NO_DOT) # Remove the leading dot


### PR DESCRIPTION
Updates the Cpptrace dependency to the v1 release. Separately, I got macOS ARM conda builds of Cpptrace and its dependency libdwarf approved. This also updates the `devtool/conda-env` scripts.