### PR TITLE
Tensor rework ideas

### DIFF
--- a/libs/Einsums/BLASVendor/src/Common.hpp
+++ b/libs/Einsums/BLASVendor/src/Common.hpp
@@ -47,34 +47,34 @@ void transpose(int_t m, int_t n, T const *in, int_t ldin, T *out, int_t ldout) {
     EINSUMS_ASSERT(m >= 0);
     EINSUMS_ASSERT(n >= 0);
 
-    std::vector<int>    perm{1, 0};
-    std::vector<size_t> size_in{static_cast<unsigned long>(m), static_cast<unsigned long>(n)}, outer_size_in, outer_size_out;
+    std::array<int, 2>    perm{1, 0};
+    std::array<size_t, 2> size_in{static_cast<unsigned long>(m), static_cast<unsigned long>(n)}, outer_size_in, outer_size_out;
     if constexpr (Order == OrderMajor::Row) {
-        outer_size_in = std::move(std::vector<size_t>{static_cast<unsigned long>(m), static_cast<unsigned long>(ldin)});
-        outer_size_out = std::move(std::vector<size_t>{static_cast<unsigned long>(n), static_cast<unsigned long>(ldout)});
+        outer_size_in  = std::move(std::array<size_t, 2>{static_cast<unsigned long>(m), static_cast<unsigned long>(ldin)});
+        outer_size_out = std::move(std::array<size_t, 2>{static_cast<unsigned long>(n), static_cast<unsigned long>(ldout)});
     } else {
-        outer_size_in = std::move(std::vector<size_t>{static_cast<unsigned long>(ldin), static_cast<unsigned long>(n)});
-        outer_size_out = std::move(std::vector<size_t>{static_cast<unsigned long>(ldout), static_cast<unsigned long>(m)});
+        outer_size_in  = std::move(std::array<size_t, 2>{static_cast<unsigned long>(ldin), static_cast<unsigned long>(n)});
+        outer_size_out = std::move(std::array<size_t, 2>{static_cast<unsigned long>(ldout), static_cast<unsigned long>(m)});
     }
 
-    auto plan = hptt::create_plan(perm, 2, T{1.0}, in, size_in, outer_size_in, T{0.0}, out, outer_size_out, hptt::ESTIMATE,
+    auto plan = hptt::create_plan(perm.data(), 2, T{1.0}, in, size_in.data(), outer_size_in.data(), T{0.0}, out, outer_size_out.data(), hptt::ESTIMATE,
                                   omp_get_max_threads(), {}, Order == OrderMajor::Row);
 
     plan->execute();
 }
 
-template <OrderMajor Order, typename T>
-void transpose(int_t m, int_t n, std::vector<T> const &in, int_t ldin, T *out, int_t ldout) {
+template <OrderMajor Order, typename T, typename Alloc>
+void transpose(int_t m, int_t n, std::vector<T, Alloc> const &in, int_t ldin, T *out, int_t ldout) {
     transpose<Order>(m, n, in.data(), ldin, out, ldout);
 }
 
-template <OrderMajor Order, typename T>
-void transpose(int_t m, int_t n, T const *in, int_t ldin, std::vector<T> &out, int_t ldout) {
+template <OrderMajor Order, typename T, typename Alloc>
+void transpose(int_t m, int_t n, T const *in, int_t ldin, std::vector<T, Alloc> &out, int_t ldout) {
     transpose<Order>(m, n, in, ldin, out.data(), ldout);
 }
 
-template <OrderMajor Order, typename T>
-void transpose(int_t m, int_t n, std::vector<T> const &in, int_t ldin, std::vector<T> &out, int_t ldout) {
+template <OrderMajor Order, typename T, typename Alloc1, typename Alloc2>
+void transpose(int_t m, int_t n, std::vector<T, Alloc1> const &in, int_t ldin, std::vector<T, Alloc2> &out, int_t ldout) {
     transpose<Order>(m, n, in.data(), ldin, out.data(), ldout);
 }
 } // namespace einsums::blas::vendor

--- a/libs/Einsums/BufferAllocator/include/Einsums/BufferAllocator/BufferAllocator.hpp
+++ b/libs/Einsums/BufferAllocator/include/Einsums/BufferAllocator/BufferAllocator.hpp
@@ -12,8 +12,11 @@
 #include <Einsums/StringUtil/MemoryString.hpp>
 
 #include <complex>
+#include <deque>
+#include <forward_list>
 #include <source_location>
 #include <type_traits>
+#include <unordered_set>
 
 namespace einsums {
 
@@ -223,5 +226,42 @@ extern template struct EINSUMS_EXPORT BufferAllocator<std::complex<float>>;
 extern template struct EINSUMS_EXPORT BufferAllocator<std::complex<double>>;
 
 #endif
+
+// Container overloads.
+template <class T>
+using BufferVector = std::vector<T, BufferAllocator<T>>;
+
+template <class T>
+using BufferDeque = std::deque<T, BufferAllocator<T>>;
+
+template <class T>
+using BufferForwardList = std::forward_list<T, BufferAllocator<T>>;
+
+template <class T>
+using BufferList = std::list<T, BufferAllocator<T>>;
+
+template <class T, class Compare = std::less<T>>
+using BufferSet = std::set<T, Compare, BufferAllocator<T>>;
+
+template <class Key, class T, class Compare = std::less<Key>>
+using BufferMap = std::map<Key, T, Compare, BufferAllocator<std::pair<Key const, T>>>;
+
+template <class Key, class Compare = std::less<Key>>
+using BufferMultiset = std::multiset<Key, Compare, BufferAllocator<Key>>;
+
+template <class Key, class T, class Compare = std::less<Key>>
+using BufferMultimap = std::multimap<Key, T, Compare, BufferAllocator<std::pair<Key const, T>>>;
+
+template <class Key, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>>
+using BufferUnorderedSet = std::unordered_set<Key, Hash, KeyEqual, BufferAllocator<Key>>;
+
+template <class Key, class T, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>>
+using BufferUnorderedMap = std::unordered_map<Key, T, Hash, KeyEqual, BufferAllocator<std::pair<const Key, T>>>;
+
+template <class Key, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>>
+using BufferUnorderedMultiset = std::unordered_multiset<Key, Hash, KeyEqual, BufferAllocator<Key>>;
+
+template <class Key, class T, class Hash = std::hash<Key>, class KeyEqual = std::equal_to<Key>>
+using BufferUnorderedMultimap = std::unordered_multimap<Key, T, Hash, KeyEqual, BufferAllocator<std::pair<const Key, T>>>;
 
 } // namespace einsums

--- a/libs/Einsums/CMakeLists.txt
+++ b/libs/Einsums/CMakeLists.txt
@@ -39,6 +39,7 @@ set(_Einsums_modules
   TypeSupport
   Utilities
   Version
+  hipBLAS
   )
 # cmake-format: on
 
@@ -49,3 +50,4 @@ foreach(module ${_Einsums_modules})
   einsums_info("    ${module}")
   add_subdirectory(${module})
 endforeach()
+

--- a/libs/Einsums/Config/include/Einsums/Config/CompilerSpecific.hpp
+++ b/libs/Einsums/Config/include/Einsums/Config/CompilerSpecific.hpp
@@ -29,6 +29,8 @@
 #    define EINSUMS_OMP_CRITICAL   _Pragma("omp critical")
 #endif
 
+#define EINSUMS_PRAGMA(X) _Pragma(#X)
+
 #ifdef __GNUC__
 
 // gcc does not have reductions for complex values.

--- a/libs/Einsums/GPUMemory/CMakeLists.txt
+++ b/libs/Einsums/GPUMemory/CMakeLists.txt
@@ -8,9 +8,10 @@ if(EINSUMS_WITH_GPU_SUPPORT)
 
   set(GPUMemoryHeaders Einsums/GPUMemory/GPUAllocator.hpp Einsums/GPUMemory/InitModule.hpp
                        Einsums/GPUMemory/ModuleVars.hpp Einsums/GPUMemory/GPUPointer.hpp
+                       Einsums/GPUMemory/GPUMemoryTracker.hpp
   )
 
-  set(GPUMemorySources InitModule.cpp ModuleVars.cpp)
+  set(GPUMemorySources InitModule.hip ModuleVars.cpp GPUMemoryTracker.cpp)
 
   include(Einsums_AddModule)
   einsums_add_module(

--- a/libs/Einsums/GPUMemory/include/Einsums/GPUMemory/GPUAllocator.hpp
+++ b/libs/Einsums/GPUMemory/include/Einsums/GPUMemory/GPUAllocator.hpp
@@ -21,6 +21,8 @@
 #include <source_location>
 #include <type_traits>
 
+#include "Einsums/TypeSupport/SizeOf.hpp"
+
 namespace einsums {
 
 namespace gpu {
@@ -31,51 +33,169 @@ struct GPUAllocator {
     /**
      * @typedef dev_datatype
      *
-     * @brief The data type stored on the device. This is only different if T is complex.
+     * @brief The data type stored on the device. This is only different if @c T is complex or @c void.
+     *
+     * When @c T is complex, this will give the translation from the C++ @c std::complex type to the appropriate
+     * HIP complex type. When @c T is void, this will give @c uint8_t in order to give good sizes.
      */
-    using dev_datatype = std::conditional_t<
-        std::is_same_v<std::remove_cv_t<T>, std::complex<float>>, hipFloatComplex,
-        std::conditional_t<std::is_same_v<std::remove_cv_t<T>, std::complex<double>>, hipDoubleComplex, std::remove_cv_t<T>>>;
-    using pointer            = GPUPointer<T>;
-    using const_pointer      = GPUPointer<T const>;
-    using void_pointer       = GPUPointer<void>;
-    using const_void_pointer = GPUPointer<void const>;
-    using value_type         = dev_datatype;
-    using size_type          = size_t;
-    using difference_type    = ptrdiff_t;
+    using dev_datatype = SwitchT<std::remove_cv_t<T>, Case<uint8_t, void>, Case<hipFloatComplex, std::complex<float>>,
+                                 Case<hipDoubleComplex, std::complex<double>>, Default<T>>;
 
+    /**
+     * @typedef host_datatype
+     *
+     * @brief Exposes the template parameter to the programmer while handling @c void cases.
+     *
+     * When @c T is void, this will give @c uint8_t in order to give good sizes. Otherwise, it
+     * will simply be @c T with const and volatile removed.
+     */
+    using host_datatype = std::conditional_t<std::is_void_v<std::remove_cv_t<T>>, uint8_t, std::remove_cv_t<T>>;
+
+    /**
+     * @typedef pointer
+     *
+     * @brief The kinds of pointers returned by this allocator.
+     *
+     * This allocator returns GPUPointer<T>, which are smart pointers that wrap pointers on the GPU.
+     */
+    using pointer = GPUPointer<T>;
+
+    /**
+     * @typedef const_pointer
+     *
+     * @brief The kinds of pointers returned by this allocator but const.
+     *
+     * This allocator returns a const form of GPUPointer<T>, which are smart pointers that wrap pointers on the GPU.
+     */
+    using const_pointer = GPUPointer<std::add_const_t<T>>;
+
+    /**
+     * @typedef void_pointer
+     *
+     * @brief The kinds of pointers returned by this allocator but typeless.
+     *
+     * This allocator returns GPUPointer<void> or GPUPointer<void const>, which are smart pointers that wrap pointers on the GPU.
+     */
+    using void_pointer = std::conditional_t<std::is_const_v<T>, GPUPointer<void const>, GPUPointer<void>>;
+
+    /**
+     * @typedef const_void_pointer
+     *
+     * @brief The kinds of pointers returned by this allocator but typeless.
+     *
+     * This allocator returns GPUPointer<void const>, which are smart pointers that wrap pointers on the GPU.
+     */
+    using const_void_pointer = GPUPointer<void const>;
+
+    /**
+     * @typedef value_type
+     *
+     * @brief The type of data stored by the pointers.
+     *
+     * This is the data type on the device, not the host. Complex values are transformed to the device equivalents.
+     */
+    using value_type = dev_datatype;
+
+    /**
+     * @typedef size_type
+     *
+     * @brief The type representing the sizes of pointers.
+     *
+     * It's @c size_t .
+     */
+    using size_type = size_t;
+
+    /**
+     * @typedef difference_type
+     *
+     * @brief The type representing differences between pointers.
+     *
+     * It's @c ptrdiff_t .
+     */
+    using difference_type = ptrdiff_t;
+
+    /**
+     * @property itemsize
+     *
+     * @brief The size of an individual element.
+     *
+     * This is provided since @c sizeof(void) is not a valid statement, but we still need to find the size of
+     * elements contained in void pointers, which is 1 byte. When the data type is not void, then this just
+     * gives the size of that data type.
+     */
+    constexpr static size_t itemsize = SizeOfV<T>;
+
+    /**
+     * @brief Allocate a number of elements.
+     *
+     * The total allocation size in bytes will be equal to the number of requested elements times the size in bytes of the element type.
+     * If the data type is void, then the number of bytes will be the number of elements.
+     *
+     * @param n The number of elements to allocate.
+     *
+     * @return A pointer to the allocated memory.
+     *
+     * @throws std::runtime_errror if the allocator can not reserve enough memory.
+     */
     pointer allocate(size_t n) {
         T *out;
 
         auto &vars = detail::Einsums_GPUMemory_vars::get_singleton();
 
-        if (!vars.try_allocate(n * sizeof(T))) {
+        if (!vars.try_allocate(n * itemsize)) {
             EINSUMS_THROW_EXCEPTION(std::runtime_error, "Could not allocate enough memory on the GPU device. Requested {} bytes.",
-                                    n * sizeof(T));
+                                    n * itemsize);
         }
 
-        hip_catch(hipMalloc((void **)&out, n * sizeof(T)));
+        hip_catch(hipMalloc((void **)&out, n * itemsize));
 
         return pointer(out);
     }
 
+    /**
+     * @brief Try to allocate a number of elements.
+     *
+     * The total allocation size in bytes will be equal to the number of requested elements times the size in bytes of the element type.
+     * If the data type is void, then the number of bytes will be the number of elements.
+     *
+     * @param n The number of elements to allocate.
+     *
+     * @return A pointer to the allocated memory. If memory could not be allocated, this will be the null pointer.
+     */
+    pointer try_allocate(size_t n) {
+        T *out;
+
+        auto &vars = detail::Einsums_GPUMemory_vars::get_singleton();
+
+        if (!vars.try_allocate(n * itemsize)) {
+            return pointer(nullptr);
+        }
+
+        hip_catch(hipMalloc((void **)&out, n * itemsize));
+
+        return pointer(out);
+    }
+
+    /**
+     * @brief Deallocate a pointer that points to a number of elements.
+     *
+     * @param p The pointer to deallocate.
+     * @param n The number of elements the pointer pointed to.
+     */
     void deallocate(pointer p, size_t n) {
         auto &vars = detail::Einsums_GPUMemory_vars::get_singleton();
 
-        vars.deallocate(n * sizeof(T));
+        vars.deallocate(n * itemsize);
 
         hip_catch(hipFree((void *)p));
     }
 
-    void construct(pointer xp, T const &value) {
-        hip_catch(hipMemcpy((void *)xp, (void const *)&value, sizeof(value), hipMemcpyHostToDevice));
-    }
-
-    void destroy(pointer xp) {
-        ; // Do nothing.
-    }
-
-    size_type max_size() const { return detail::Einsums_GPUMemory_vars::get_singleton().get_max_size() / sizeof(T); }
+    /**
+     * @brief Get the max allocation size in elements.
+     *
+     * This is based on the command line arguments passed into Einsums.
+     */
+    size_type max_size() const { return detail::Einsums_GPUMemory_vars::get_singleton().get_max_size() / itemsize; }
 };
 
 template <typename T>
@@ -108,11 +228,6 @@ struct MappedAllocator {
     void deallocate(pointer p, size_t n) {
         hip_catch(hipHostUnregister(static_cast<void *>(p)));
         delete[] p;
-    }
-
-    template <typename... Args>
-    void construct(pointer xp, Args &&...args) {
-        *xp = T(std::forward<Args>(args)...);
     }
 };
 

--- a/libs/Einsums/GPUMemory/include/Einsums/GPUMemory/GPUMemoryTracker.hpp
+++ b/libs/Einsums/GPUMemory/include/Einsums/GPUMemory/GPUMemoryTracker.hpp
@@ -18,6 +18,8 @@ namespace gpu {
 struct GPUMemoryTracker final : design_pats::Lockable<std::recursive_mutex> {
     EINSUMS_SINGLETON_DEF(GPUMemoryTracker)
 
+    ~GPUMemoryTracker();
+
     /**
      * @brief Finds memory that can be deallocated and deallocates it.
      *
@@ -134,8 +136,6 @@ struct GPUMemoryTracker final : design_pats::Lockable<std::recursive_mutex> {
 
   private:
     GPUMemoryTracker() = default;
-
-    ~GPUMemoryTracker();
 
     struct MemoryData {
         size_t  handle;

--- a/libs/Einsums/GPUMemory/include/Einsums/GPUMemory/GPUMemoryTracker.hpp
+++ b/libs/Einsums/GPUMemory/include/Einsums/GPUMemory/GPUMemoryTracker.hpp
@@ -1,0 +1,173 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <Einsums/GPUMemory/GPUAllocator.hpp>
+#include <Einsums/GPUMemory/GPUPointer.hpp>
+#include <Einsums/TypeSupport/Lockable.hpp>
+#include <Einsums/TypeSupport/Singleton.hpp>
+
+#include <list>
+#include <mutex>
+namespace einsums {
+namespace gpu {
+
+struct GPUMemoryTracker final : design_pats::Lockable<std::recursive_mutex> {
+    EINSUMS_SINGLETON_DEF(GPUMemoryTracker)
+
+    /**
+     * @brief Finds memory that can be deallocated and deallocates it.
+     *
+     * This goes through the list of allocations, oldest first, and checks if
+     * it can be deleted. Then, it deletes them.
+     *
+     * @param until The amount of memory we are trying to free. If we free more than this,
+     * then this function will exit early.
+     *
+     * @return The amount of memory we freed.
+     */
+    size_t cleanup_allocations(size_t until = std::numeric_limits<size_t>::max());
+
+    /**
+     * @brief Checks to see if all the memory allocations are sticky.
+     *
+     * This is important to check, since having a bunch of sticky allocations can cause
+     * issues when allocating temporary buffers.
+     */
+    bool is_all_sticky();
+
+    /**
+     * @brief Searches for a handle or any of its parents.
+     *
+     * If the pointer does not exist, return nullptr.
+     */
+    GPUPointer<void> get_pointer_for_handle_no_alloc(size_t handle);
+
+    /**
+     * @brief Get the pointer associated with the given handle.
+     *
+     * If the pointer does not exist, then reallocate it. If the handle is a view of another handle,
+     * then this will look for parents of the view as well.
+     *
+     * @param handle The handle to query.
+     * @param nelems The number of elements to allocate if needed.
+     *
+     * @returns The pointer associated with the handle and whether the pointer needed to be allocated.
+     */
+    template <typename T>
+    std::tuple<GPUPointer<T>, bool> get_pointer(size_t handle, size_t nelems) {
+        auto out = get_pointer_for_handle_no_alloc(handle);
+
+        if (!out) {
+            // We couldn't find the pointer or any parent, so we need to allocate the pointer.
+            auto data = allocate_pointer(nelems, false, handle);
+
+            return {GPUPointer<T>(data.ptr), true};
+        } else {
+            // We found the pointer, return it.
+            return {GPUPointer<T>(out), false};
+        }
+    }
+
+    /**
+     * @brief Allocates a sticky pointer.
+     *
+     * A sticky pointer is one that won't go away until it is explicitly freed.
+     *
+     * @return The handle for the pointer and the pointer itself.
+     */
+    template <typename T>
+    std::tuple<size_t, GPUPointer<T>> create_sticky_pointer(size_t nelems) {
+        size_t handle = create_handle();
+
+        auto data = allocate_pointer(nelems, true, handle);
+
+        return {handle, GPUPointer<T>(data.ptr)};
+    }
+
+    /**
+     * @brief Creates a new handle.
+     *
+     * This does not allocate any memory. It just creates the handle. Pass this into get_pointer to actually
+     * allocate the memory.
+     */
+    size_t create_handle();
+
+    /**
+     * @brief Tells the tracker that a handle is a contiguous view of another.
+     *
+     * @param handle The view handle.
+     * @param parent The handle of the view's parent.
+     * @param offset The position in the buffer that the view starts.
+     */
+    void handle_view(size_t handle, size_t parent, size_t offset);
+
+    /**
+     * @brief Remove a view from the view list.
+     */
+    void remove_view(size_t handle);
+
+    /**
+     * @brief Releases a hold on a handle.
+     *
+     * No memory is actually freed when this is called. If the use count for a handle goes to zero,
+     * the memory still remains. If the handle is acquired again, the pointer will be the same.
+     * However, if the use count of the handle goes to zero, then the memory associated with that
+     * handle may be freed to make way for other buffers. In this case, the pointer returned by get_pointer
+     * will not necessarily be the same as what it was. If the handle is sticky, this function will not
+     * mark that handle as not sticky unless it is told to do so. A sticky handle is not freed during
+     * clean up operations. By default, this does not remove the sticky property.
+     *
+     * @param handle The handle to release.
+     * @param remove_sticky If true, sets a sticky handle to be not sticky, allowing it to be removed
+     * during clean up operations.
+     */
+    void release_handle(size_t handle, bool remove_sticky = false);
+
+    /**
+     * @brief Check to see if a handle already has a pointer allocated.
+     */
+    bool handle_is_allocated(size_t handle);
+
+  private:
+    GPUMemoryTracker() = default;
+
+    ~GPUMemoryTracker();
+
+    struct MemoryData {
+        size_t  handle;
+        void   *ptr;
+        size_t  size;
+        int32_t use_count;
+        int32_t is_sticky;
+    };
+
+    struct HandleRelations {
+        size_t handle;
+        size_t offset;
+        size_t contiguous_parent_handle;
+    };
+
+    MemoryData allocate_pointer(size_t nelems, bool sticky, size_t handle);
+
+    GPUAllocator<void> alloc_;
+
+    std::list<MemoryData> memory_list_;
+
+    std::list<HandleRelations> view_list_;
+
+    /**
+     * @var serialize_
+     *
+     * @brief Holds a value to help generate unique handles.
+     *
+     * These start at 1 so that uninitialized handles can be zero.
+     */
+    size_t serialize_{1};
+};
+
+} // namespace gpu
+} // namespace einsums

--- a/libs/Einsums/GPUMemory/include/Einsums/GPUMemory/GPUPointer.hpp
+++ b/libs/Einsums/GPUMemory/include/Einsums/GPUMemory/GPUPointer.hpp
@@ -169,6 +169,8 @@ struct GPUPointer final {
         return static_cast<U *>(gpu_ptr_);
     }
 
+    constexpr operator bool() const noexcept { return gpu_ptr_ == nullptr; }
+
     static pointer pointer_to(element_type &other) { return pointer(&other); }
 
   private:
@@ -307,6 +309,8 @@ struct GPUPointer<T const> final {
     constexpr operator U const *() const {
         return gpu_ptr_;
     }
+
+    constexpr operator bool() const { return gpu_ptr_ == nullptr; }
 
   private:
     dev_datatype const *gpu_ptr_{nullptr};

--- a/libs/Einsums/GPUMemory/include/Einsums/GPUMemory/ModuleVars.hpp
+++ b/libs/Einsums/GPUMemory/include/Einsums/GPUMemory/ModuleVars.hpp
@@ -11,8 +11,17 @@
 #include <Einsums/TypeSupport/Lockable.hpp>
 #include <Einsums/TypeSupport/Singleton.hpp>
 
+#include <hip/driver_types.h>
+#include <hip/hip_common.h>
+#include <hip/hip_complex.h>
+#include <hip/hip_runtime_api.h>
+
 namespace einsums {
 namespace gpu {
+
+extern EINSUMS_EXPORT __constant__ float float_constants[6];
+extern EINSUMS_EXPORT  __constant__ double double_constants[6];
+
 namespace detail {
 
 /// @todo This class can be freely changed. It is provided as a starting point for your convenience. If not needed, it may be removed.
@@ -44,6 +53,62 @@ class EINSUMS_EXPORT Einsums_GPUMemory_vars final : public design_pats::Lockable
     void deallocate(size_t bytes);
 
     size_t get_max_size() const;
+
+    float *get_const(float val) {
+      if(val == 0.0f) {
+        return float_constants;
+      } else if(val == 1.0f) {
+        return float_constants + 1;
+      } else if(val == -1.0f) {
+        return float_constants + 3;
+      } else {
+        return nullptr;
+      }
+    }
+
+    double *get_const(double val) {
+      if(val == 0.0) {
+        return double_constants;
+      } else if(val == 1.0) {
+        return double_constants + 1;
+      } else if(val == -1.0) {
+        return double_constants + 3;
+      } else {
+        return nullptr;
+      }
+    }
+
+    hipFloatComplex *get_const(std::complex<float> val) {
+      if(val == 0.0f) {
+        return (hipFloatComplex *) (float_constants + 4);
+      } else if(val == 1.0f) {
+        return (hipFloatComplex *) (float_constants + 1);
+      } else if(val == -1.0f) {
+        return (hipFloatComplex *) (float_constants + 3);
+      } else if(val == std::complex<float>{0.0f, 1.0f}) {
+        return (hipFloatComplex *) (float_constants);
+      } else if(val == std::complex<float>{0.0f, -1.0f}) {
+        return (hipFloatComplex *) (float_constants + 2);
+      } else {
+        return nullptr;
+      }
+    }
+
+    hipDoubleComplex *get_const(std::complex<double> val) {
+      if(val == 0.0) {
+        return (hipDoubleComplex *) (double_constants + 4);
+      } else if(val == 1.0) {
+        return (hipDoubleComplex *) (double_constants + 1);
+      } else if(val == -1.0) {
+        return (hipDoubleComplex *) (double_constants + 3);
+      } else if(val == std::complex<double>{0.0, 1.0}) {
+        return (hipDoubleComplex *) (double_constants);
+      } else if(val == std::complex<double>{0.0, -1.0}) {
+        return (hipDoubleComplex *) (double_constants + 2);
+      } else {
+        return nullptr;
+      }
+    }
 
   private:
     explicit Einsums_GPUMemory_vars() = default;

--- a/libs/Einsums/GPUMemory/src/GPUMemoryTracker.cpp
+++ b/libs/Einsums/GPUMemory/src/GPUMemoryTracker.cpp
@@ -1,0 +1,241 @@
+#include <Einsums/Errors/Error.hpp>
+#include <Einsums/GPUMemory/GPUMemoryTracker.hpp>
+
+namespace einsums {
+namespace gpu {
+
+EINSUMS_SINGLETON_IMPL(GPUMemoryTracker)
+
+size_t GPUMemoryTracker::cleanup_allocations(size_t until) {
+    auto   lock         = std::lock_guard(*this);
+    size_t freed_memory = 0;
+    if (memory_list_.size() == 0) {
+        return freed_memory;
+    }
+
+    auto curr_pos = memory_list_.begin();
+
+    while (curr_pos != memory_list_.end()) {
+        auto next_pos = std::next(curr_pos);
+
+        if (curr_pos->use_count <= 0 && !curr_pos->is_sticky) {
+            freed_memory += curr_pos->size;
+            alloc_.deallocate(GPUPointer<void>(curr_pos->ptr), curr_pos->size);
+            memory_list_.erase(curr_pos);
+
+            if (freed_memory >= until) {
+                return freed_memory;
+            }
+        }
+
+        curr_pos = next_pos;
+    }
+
+    return freed_memory;
+}
+
+bool GPUMemoryTracker::is_all_sticky() {
+    auto lock = std::lock_guard(*this);
+
+    for (auto &elem : memory_list_) {
+        if (!elem.is_sticky) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+GPUMemoryTracker::~GPUMemoryTracker() {
+    for (auto &element : memory_list_) {
+        alloc_.deallocate(GPUPointer<void>(element.ptr), element.size);
+    }
+
+    memory_list_.clear();
+}
+
+GPUMemoryTracker::MemoryData GPUMemoryTracker::allocate_pointer(size_t nelems, bool sticky, size_t handle) {
+    if (handle == 0) {
+        EINSUMS_THROW_EXCEPTION(
+            uninitialized_error,
+            "The handle used to request an allocation was 0. This means that it is uninitialized. Please acquire a handle first.");
+    }
+    // No pointer found. Create a new pointer with this handle.
+    // First, check to see if we can allocate that many elements at all.
+    if (nelems > alloc_.max_size()) {
+        EINSUMS_THROW_EXCEPTION(std::runtime_error,
+                                "Requested allocation size is bigger than the total allowed buffer size! Got {}, maximum size is {}.",
+                                nelems, alloc_.max_size());
+    }
+
+    // Now, try to allocate until we can.
+    GPUPointer<void> out = alloc_.try_allocate(nelems);
+    MemoryData       data;
+
+    if (out != nullptr) {
+        auto lock      = std::lock_guard(*this);
+        data.handle    = handle;
+        data.is_sticky = sticky;
+        data.ptr       = (void *)out;
+        data.size      = nelems;
+        data.use_count = 1;
+
+        memory_list_.push_back(data);
+
+        return data;
+    }
+
+    // While we can't allocate, we need to clean up the memory list and check to see if there are too many
+    // sticky allocations.
+    int tries = 0;
+    while (!out && tries < 100) {
+        if (is_all_sticky()) {
+            EINSUMS_THROW_EXCEPTION(std::runtime_error, "Could not allocate GPU memory! Too many permanent allocations are clogging up "
+                                                        "the pipeline. Fix your code to remove some of these permanent allocations.");
+        }
+
+        size_t freed = cleanup_allocations(nelems);
+
+        if (freed >= nelems) {
+            auto             lock = std::lock_guard(*this);
+            GPUPointer<void> out  = alloc_.try_allocate(nelems);
+
+            if (out != nullptr) {
+                data.handle    = handle;
+                data.is_sticky = sticky;
+                data.ptr       = (void *)out;
+                data.size      = nelems;
+                data.use_count = 1;
+
+                memory_list_.push_back(data);
+            }
+        }
+
+        tries++;
+
+        // Wait a bit. Maybe some memory will be freed.
+        std::this_thread::yield();
+    }
+
+    if (!out) {
+        EINSUMS_THROW_EXCEPTION(std::runtime_error,
+                                "Could not allocate GPU memory! Something is using too much memory and not giving it back. Check to "
+                                "see that you are not allocating large buffers in the same thread as this call before this call.");
+    }
+
+    return data;
+}
+
+size_t GPUMemoryTracker::create_handle() {
+    auto lock = std::lock_guard(*this);
+
+    size_t out = serialize_;
+    serialize_++;
+
+    return out;
+}
+
+void GPUMemoryTracker::release_handle(size_t handle, bool remove_sticky) {
+    auto lock = std::lock_guard(*this);
+
+    for (auto elem : memory_list_) {
+
+        if (elem.handle == handle) {
+            elem.use_count--;
+
+            if (remove_sticky) {
+                elem.is_sticky = false;
+            }
+
+            return;
+        }
+    }
+}
+
+void GPUMemoryTracker::handle_view(size_t handle, size_t parent, size_t offset) {
+    auto lock = std::lock_guard(*this);
+    view_list_.emplace_back(HandleRelations{handle, offset, parent});
+}
+
+void GPUMemoryTracker::remove_view(size_t handle) {
+    auto lock = std::lock_guard(*this);
+
+    // First, find the item that matches this handle.
+    HandleRelations relation;
+    bool            found = false;
+
+    for (auto it = view_list_.begin(); it != view_list_.end(); it++) {
+        if (it->handle == handle) {
+            found    = true;
+            relation = *it;
+            view_list_.erase(it);
+            break;
+        }
+    }
+
+    // If not found, then search through and look for children. Delete them, which will mark them as top-level.
+    if (!found) {
+        auto curr_pos = view_list_.begin();
+        while (curr_pos != view_list_.end()) {
+            auto next_pos = std::next(curr_pos);
+
+            if (curr_pos->contiguous_parent_handle == handle) {
+                view_list_.erase(curr_pos);
+            }
+
+            curr_pos = next_pos;
+        }
+    } else {
+        // Otherwise, search through for all this handle's children and set their parents to this handle's parent.
+        for (auto &elem : view_list_) {
+            if (elem.contiguous_parent_handle == handle) {
+                elem.contiguous_parent_handle = relation.contiguous_parent_handle;
+            }
+        }
+    }
+}
+
+GPUPointer<void> GPUMemoryTracker::get_pointer_for_handle_no_alloc(size_t handle) {
+    auto lock = std::lock_guard(*this);
+
+    for (auto it = memory_list_.begin(); it != memory_list_.end(); it++) {
+        if (it->handle == handle) {
+            // Move the item to the end of the list. This will mean it is checked last when looking
+            // for memory to free.
+            MemoryData temp = *it;
+            temp.use_count++;
+
+            memory_list_.erase(it);
+
+            memory_list_.push_back(temp);
+
+            return GPUPointer<void>(temp.ptr);
+        }
+    }
+
+    // Look for the parent.
+    for (auto relation : view_list_) {
+        if (relation.handle == handle) {
+            // Look for the parent pointer
+            auto ptr = get_pointer_for_handle_no_alloc(relation.contiguous_parent_handle);
+
+            // No parent pointer.
+            if (ptr == nullptr) {
+                return ptr;
+            }
+
+            // Offset the parent pointer to get the view pointer.
+            return GPUPointer<uint8_t>((void *)ptr) + relation.offset;
+        }
+    }
+
+    // No pointer.
+    return nullptr;
+}
+
+bool GPUMemoryTracker::handle_is_allocated(size_t handle) {
+    return get_pointer_for_handle_no_alloc(handle) != nullptr;
+}
+
+} // namespace gpu
+} // namespace einsums

--- a/libs/Einsums/GPUMemory/src/InitModule.hip
+++ b/libs/Einsums/GPUMemory/src/InitModule.hip
@@ -11,6 +11,12 @@
 
 #include <argparse/argparse.hpp>
 
+extern EINSUMS_EXPORT __constant__ float float_constants[6];
+extern EINSUMS_EXPORT  __constant__ double double_constants[6];
+
+static float host_float_constants[] = {0.0f, 1.0f, 0.0f, -1.0f, 0.0f, 0.0f};
+static double host_double_constants[] = {0.0, 1.0, 0.0, -1.0, 0.0, 0.0};
+
 namespace einsums {
 
 /*
@@ -52,6 +58,9 @@ void initialize_Einsums_GPUMemory() {
     EINSUMS_LOG_TRACE("initializing Einsums/GPUMemory");
 
     gpu::detail::Einsums_GPUMemory_vars::get_singleton().reset_curr_size();
+
+    hip_catch(hipMemcpyToSymbol(float_constants, host_float_constants, 6 * sizeof(float)));
+    hip_catch(hipMemcpyToSymbol(double_constants, host_double_constants, 6 * sizeof(double)));
 }
 
 void finalize_Einsums_GPUMemory() {

--- a/libs/Einsums/Tensor/CMakeLists.txt
+++ b/libs/Einsums/Tensor/CMakeLists.txt
@@ -15,6 +15,7 @@ set(TensorHeaders
     Einsums/Tensor/FunctionTensor.hpp
     Einsums/Tensor/RuntimeTensor.hpp
     Einsums/Tensor/TiledTensor.hpp
+    Einsums/Tensor/Backends/TensorImpl.hpp
 )
 
 set(TensorSources TensorDefs.cpp Requirements.cpp)
@@ -25,7 +26,7 @@ if(EINSUMS_WITH_GPU_SUPPORT)
   list(APPEND TensorHeaders Einsums/Tensor/DeviceTensor.hpp)
   list(APPEND TensorSources TensorDefs.hip)
 
-  set(TensorGPUModules Einsums_GPUStreams)
+  set(TensorGPUModules Einsums_GPUStreams Einsums_GPUMemory Einsums_hipBLAS)
   set(TensorGPUDeps hip::host hip::device)
 
   if(EINSUMS_WITH_CUDA)
@@ -45,6 +46,8 @@ einsums_add_module(
   DEPENDENCIES Einsums::h5cpp ${TensorGPUDeps}
   MODULE_DEPENDENCIES
     Einsums_BLAS
+    Einsums_BLASVendor
+    Einsums_BufferAllocator
     Einsums_Concepts
     Einsums_Config
     Einsums_Errors

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImpl.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImpl.hpp
@@ -5,6 +5,7 @@
 
 #pragma once
 
+#include <Einsums/BLAS.hpp>
 #include <Einsums/BufferAllocator/BufferAllocator.hpp>
 #include <Einsums/Concepts/Complex.hpp>
 #include <Einsums/Concepts/NamedRequirements.hpp>
@@ -13,7 +14,6 @@
 #include <Einsums/TensorBase/Common.hpp>
 #include <Einsums/TensorBase/IndexUtilities.hpp>
 #include <Einsums/TypeSupport/Lockable.hpp>
-#include <Einsums/BLASVendor.hpp>
 
 #include <mutex>
 #include <numeric>
@@ -26,6 +26,8 @@
 #    include <Einsums/GPUMemory/GPUAllocator.hpp>
 #    include <Einsums/GPUMemory/GPUMemoryTracker.hpp>
 #    include <Einsums/GPUMemory/GPUPointer.hpp>
+#    include <Einsums/GPUStreams/GPUStreams.hpp>
+#    include <Einsums/hipBLAS.hpp>
 
 #    include <hip/hip_common.h>
 #    include <hip/hip_complex.h>
@@ -710,34 +712,57 @@ struct TensorImpl final {
         }
 
         if constexpr (std::is_same_v<TOther, T>) {
-            #ifdef EINSUMS_COMPUTE_CODE
-            auto singleton = gpu::GPUMemoryTracker::get_singleton();
-            if(singleton.handle_is_allocated(gpu_handle_) && singleton.handle_is_allocated(other.gpu_handle_)) {
-                hipblas_catch(hipblasSaxpy());
-            }
-            #endif
-            blas::vendor::axpy(size(), );
-        }
+#ifdef EINSUMS_COMPUTE_CODE
+            auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+            if (singleton.handle_is_allocated(gpu_handle_) && singleton.handle_is_allocated(other.gpu_handle_)) {
+                auto [this_ptr, test]   = singleton.get_pointer(gpu_handle_, size());
+                auto [other_ptr, test2] = singleton.get_pointer(other.gpu_handle_, size());
+                auto *one               = gpu::detail::Einsums_GPUMemory_vars::get_singleton().get_const(T{1.0});
+                hipblas_catch(hipblasSaxpy(gpu::get_blas_handle(), size(), one, other_ptr, 1, this_ptr, 1));
 
-        size_t elems = size();
+                gpu::stream_wait();
 
-        EINSUMS_OMP_PARALLEL_FOR_SIMD
-        for (size_t i = 0; i < elems; i++) {
-            if constexpr (!IsComplexV<T>) {
-                data_[i] = T{std::real(other.data_[i])};
-            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
-                auto val = other.data_[i];
-                data_[i] = T{std::real(val), std::imag(val)};
+                copy_from_gpu(this_ptr);
+
+                singleton.release_handle(gpu_handle_);
+                singleton.release_handle(other.gpu_handle_);
             } else {
-                data_[i] = T{other.data_[i]};
+#endif
+                blas::axpy(size(), T{1.0}, other.data_, 1, data_, 1);
+#ifdef EINSUMS_COMPUTE_CODE
+            }
+#endif
+        } else {
+
+            size_t elems = size();
+
+            EINSUMS_OMP_PARALLEL_FOR_SIMD
+            for (size_t i = 0; i < elems; i++) {
+                if constexpr (!IsComplexV<T>) {
+                    data_[i] += T{std::real(other.data_[i])};
+                } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                    auto val = other.data_[i];
+                    data_[i] += T{std::real(val), std::imag(val)};
+                } else {
+                    data_[i] += T{other.data_[i]};
+                }
             }
         }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
     }
 
     template <typename TOther>
     void add_assign(TensorImpl<TOther> const &other) {
         if (other.is_contiguous() && is_contiguous()) {
-            copy_from_assume_contiguous(other);
+            add_assign_both_contiguous(other);
             return;
         }
 
@@ -767,14 +792,657 @@ struct TensorImpl final {
             sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
 
             if constexpr (!IsComplexV<T>) {
-                data_[this_sentinel] = T{std::real(other.data_[other_sentinel])};
+                data_[this_sentinel] += T{std::real(other.data_[other_sentinel])};
             } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
-                auto val             = other.data_[other_sentinel];
-                data_[this_sentinel] = T{std::real(val), std::imag(val)};
+                auto val = other.data_[other_sentinel];
+                data_[this_sentinel] += T{std::real(val), std::imag(val)};
             } else {
-                data_[this_sentinel] = T{other.data_[other_sentinel]};
+                data_[this_sentinel] += T{other.data_[other_sentinel]};
             }
         }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void sub_assign_both_contiguous(TensorImpl<TOther> const &other) {
+        if (other.rank() != rank()) {
+            EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+        }
+
+        if (other.dims() != dims()) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+        }
+
+        if (other.data() == data() || data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        if constexpr (std::is_same_v<TOther, T>) {
+#ifdef EINSUMS_COMPUTE_CODE
+            auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+            if (singleton.handle_is_allocated(gpu_handle_) && singleton.handle_is_allocated(other.gpu_handle_)) {
+                auto [this_ptr, test]   = singleton.get_pointer(gpu_handle_, size());
+                auto [other_ptr, test2] = singleton.get_pointer(other.gpu_handle_, size());
+                auto *negative_one      = gpu::detail::Einsums_GPUMemory_vars::get_singleton().get_const(T{-1.0});
+                hipblas_catch(hipblasSaxpy(gpu::get_blas_handle(), size(), negative_one, other_ptr, 1, this_ptr, 1));
+
+                gpu::stream_wait();
+
+                copy_from_gpu(this_ptr);
+
+                singleton.release_handle(gpu_handle_);
+                singleton.release_handle(other.gpu_handle_);
+            } else {
+#endif
+                blas::axpy(size(), T{-1.0}, other.data_, 1, data_, 1);
+#ifdef EINSUMS_COMPUTE_CODE
+            }
+#endif
+        } else {
+
+            size_t elems = size();
+
+            EINSUMS_OMP_PARALLEL_FOR_SIMD
+            for (size_t i = 0; i < elems; i++) {
+                if constexpr (!IsComplexV<T>) {
+                    data_[i] -= T{std::real(other.data_[i])};
+                } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                    auto val = other.data_[i];
+                    data_[i] -= T{std::real(val), std::imag(val)};
+                } else {
+                    data_[i] -= T{other.data_[i]};
+                }
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void sub_assign(TensorImpl<TOther> const &other) {
+        if (other.is_contiguous() && is_contiguous()) {
+            sub_assign_both_contiguous(other);
+            return;
+        }
+
+        if (other.rank() != rank()) {
+            EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+        }
+
+        if (other.dims() != dims()) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+        }
+
+        if (other.data() == data() || data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        BufferVector<size_t> index_strides;
+
+        dims_to_strides(dims(), index_strides);
+
+        EINSUMS_OMP_PARALLEL_FOR
+        for (size_t i = 0; i < elems; i++) {
+            size_t this_sentinel, other_sentinel;
+
+            sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
+
+            if constexpr (!IsComplexV<T>) {
+                data_[this_sentinel] -= T{std::real(other.data_[other_sentinel])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val = other.data_[other_sentinel];
+                data_[this_sentinel] -= T{std::real(val), std::imag(val)};
+            } else {
+                data_[this_sentinel] -= T{other.data_[other_sentinel]};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void mul_assign_both_contiguous(TensorImpl<TOther> const &other) {
+        if (other.rank() != rank()) {
+            EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+        }
+
+        if (other.dims() != dims()) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+        }
+
+        if (other.data() == data() || data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        for (size_t i = 0; i < elems; i++) {
+            if constexpr (!IsComplexV<T>) {
+                data_[i] *= T{std::real(other.data_[i])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val = other.data_[i];
+                data_[i] *= T{std::real(val), std::imag(val)};
+            } else {
+                data_[i] *= T{other.data_[i]};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void mul_assign(TensorImpl<TOther> const &other) {
+        if (other.is_contiguous() && is_contiguous()) {
+            mul_assign_both_contiguous(other);
+            return;
+        }
+
+        if (other.rank() != rank()) {
+            EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+        }
+
+        if (other.dims() != dims()) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+        }
+
+        if (other.data() == data() || data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        BufferVector<size_t> index_strides;
+
+        dims_to_strides(dims(), index_strides);
+
+        EINSUMS_OMP_PARALLEL_FOR
+        for (size_t i = 0; i < elems; i++) {
+            size_t this_sentinel, other_sentinel;
+
+            sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
+
+            if constexpr (!IsComplexV<T>) {
+                data_[this_sentinel] *= T{std::real(other.data_[other_sentinel])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val = other.data_[other_sentinel];
+                data_[this_sentinel] *= T{std::real(val), std::imag(val)};
+            } else {
+                data_[this_sentinel] *= T{other.data_[other_sentinel]};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void div_assign_both_contiguous(TensorImpl<TOther> const &other) {
+        if (other.rank() != rank()) {
+            EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+        }
+
+        if (other.dims() != dims()) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+        }
+
+        if (other.data() == data() || data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        for (size_t i = 0; i < elems; i++) {
+            if constexpr (!IsComplexV<T>) {
+                data_[i] /= T{std::real(other.data_[i])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val = other.data_[i];
+                data_[i] /= T{std::real(val), std::imag(val)};
+            } else {
+                data_[i] /= T{other.data_[i]};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void div_assign(TensorImpl<TOther> const &other) {
+        if (other.is_contiguous() && is_contiguous()) {
+            div_assign_both_contiguous(other);
+            return;
+        }
+
+        if (other.rank() != rank()) {
+            EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+        }
+
+        if (other.dims() != dims()) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+        }
+
+        if (other.data() == data() || data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        BufferVector<size_t> index_strides;
+
+        dims_to_strides(dims(), index_strides);
+
+        EINSUMS_OMP_PARALLEL_FOR
+        for (size_t i = 0; i < elems; i++) {
+            size_t this_sentinel, other_sentinel;
+
+            sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
+
+            if constexpr (!IsComplexV<T>) {
+                data_[this_sentinel] /= T{std::real(other.data_[other_sentinel])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val = other.data_[other_sentinel];
+                data_[this_sentinel] /= T{std::real(val), std::imag(val)};
+            } else {
+                data_[this_sentinel] /= T{other.data_[other_sentinel]};
+            }
+        }
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void add_assign_scalar_contiguous(TOther value) {
+        if (data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        for (size_t i = 0; i < elems; i++) {
+            if constexpr (!IsComplexV<T>) {
+                data_[i] += T{value};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                data_[i] += T{std::real(value), std::imag(value)};
+            } else {
+                data_[i] += T{value};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void add_assign_scalar(TOther value) {
+        if (is_contiguous()) {
+            add_assign_scalar_contiguous(value);
+            return;
+        }
+
+        if (data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        BufferVector<size_t> index_strides;
+
+        dims_to_strides(dims(), index_strides);
+
+        EINSUMS_OMP_PARALLEL_FOR
+        for (size_t i = 0; i < elems; i++) {
+            size_t this_sentinel;
+
+            sentinel_to_sentinels(i, index_strides, strides(), this_sentinel);
+
+            if constexpr (!IsComplexV<T>) {
+                data_[this_sentinel] += T{value};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                data_[this_sentinel] += T{std::real(value), std::imag(value)};
+            } else {
+                data_[this_sentinel] += T{value};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void sub_assign_scalar_contiguous(TOther value) {
+        if (data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        for (size_t i = 0; i < elems; i++) {
+            if constexpr (!IsComplexV<T>) {
+                data_[i] -= T{value};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                data_[i] -= T{std::real(value), std::imag(value)};
+            } else {
+                data_[i] -= T{value};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void sub_assign_scalar(TOther value) {
+        if (is_contiguous()) {
+            sub_assign_scalar_contiguous(value);
+            return;
+        }
+
+        if (data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        BufferVector<size_t> index_strides;
+
+        dims_to_strides(dims(), index_strides);
+
+        EINSUMS_OMP_PARALLEL_FOR
+        for (size_t i = 0; i < elems; i++) {
+            size_t this_sentinel;
+
+            sentinel_to_sentinels(i, index_strides, strides(), this_sentinel);
+
+            if constexpr (!IsComplexV<T>) {
+                data_[this_sentinel] -= T{value};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                data_[this_sentinel] -= T{std::real(value), std::imag(value)};
+            } else {
+                data_[this_sentinel] -= T{value};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void mul_assign_scalar_contiguous(TOther value) {
+        if (data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+        if constexpr (std::is_same_v<T, TOther>) {
+#ifdef EINSUMS_COMPUTE_CODE
+            auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+            if (singleton.handle_is_allocated(gpu_handle_)) {
+                size_t             value_handle = singleton.create_handle();
+                gpu::GPUPointer<T> value_ptr    = singleton.get_pointer<T>(value_handle, 1);
+
+                gpu::GPUPointer<T> self_ptr = singleton.get_pointer(gpu_handle_, size());
+
+                hip_catch(hipMemcpy(value_ptr, (void *)&value, sizeof(TOther), hipMemcpyHostToDevice));
+
+                blas::gpu::scal(gpu::get_blas_handle(), size(), (T *)value_ptr, self_ptr, 1);
+
+                singleton.release_handle(value_handle);
+                singleton.release_handle(gpu_handle_);
+            } else {
+#endif
+                blas::scal(size(), value, data_, 1);
+#ifdef EINSUMS_COMPUTE_CODE
+            }
+#endif
+        }
+
+        size_t elems = size();
+
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        for (size_t i = 0; i < elems; i++) {
+            if constexpr (!IsComplexV<T>) {
+                data_[i] *= T{value};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                data_[i] *= T{std::real(value), std::imag(value)};
+            } else {
+                data_[i] *= T{value};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void mul_assign_scalar(TOther value) {
+        if (is_contiguous()) {
+            mul_assign_scalar_contiguous(value);
+            return;
+        }
+
+        if (data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        BufferVector<size_t> index_strides;
+
+        dims_to_strides(dims(), index_strides);
+
+        EINSUMS_OMP_PARALLEL_FOR
+        for (size_t i = 0; i < elems; i++) {
+            size_t this_sentinel;
+
+            sentinel_to_sentinels(i, index_strides, strides(), this_sentinel);
+
+            if constexpr (!IsComplexV<T>) {
+                data_[this_sentinel] *= T{value};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                data_[this_sentinel] *= T{std::real(value), std::imag(value)};
+            } else {
+                data_[this_sentinel] *= T{value};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void div_assign_scalar_contiguous(TOther value) {
+        if (data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+        if constexpr (std::is_same_v<T, TOther>) {
+#ifdef EINSUMS_COMPUTE_CODE
+            auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+            if (singleton.handle_is_allocated(gpu_handle_)) {
+                size_t             value_handle = singleton.create_handle();
+                gpu::GPUPointer<T> value_ptr    = singleton.get_pointer<T>(value_handle, 1);
+
+                gpu::GPUPointer<T> self_ptr = singleton.get_pointer(gpu_handle_, size());
+
+                T temp_val = T{1.0} / value;
+
+                hip_catch(hipMemcpy(value_ptr, (void *)&temp_val, sizeof(TOther), hipMemcpyHostToDevice));
+
+                blas::gpu::scal(gpu::get_blas_handle(), size(), (T *)value_ptr, self_ptr, 1);
+
+                singleton.release_handle(value_handle);
+                singleton.release_handle(gpu_handle_);
+            } else {
+#endif
+                blas::scal(size(), T{1.0} / value, data_, 1);
+#ifdef EINSUMS_COMPUTE_CODE
+            }
+#endif
+        }
+
+        size_t elems = size();
+
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        for (size_t i = 0; i < elems; i++) {
+            if constexpr (!IsComplexV<T>) {
+                data_[i] /= T{value};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                data_[i] /= T{std::real(value), std::imag(value)};
+            } else {
+                data_[i] /= T{value};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
+    }
+
+    template <typename TOther>
+    void div_assign_scalar(TOther value) {
+        if (is_contiguous()) {
+            div_assign_scalar_contiguous(value);
+            return;
+        }
+
+        if (data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        BufferVector<size_t> index_strides;
+
+        dims_to_strides(dims(), index_strides);
+
+        EINSUMS_OMP_PARALLEL_FOR
+        for (size_t i = 0; i < elems; i++) {
+            size_t this_sentinel;
+
+            sentinel_to_sentinels(i, index_strides, strides(), this_sentinel);
+
+            if constexpr (!IsComplexV<T>) {
+                data_[this_sentinel] /= T{value};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                data_[this_sentinel] /= T{std::real(value), std::imag(value)};
+            } else {
+                data_[this_sentinel] /= T{value};
+            }
+        }
+
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+            copy_to_gpu(this_ptr);
+            singleton.release_handle(gpu_handle_);
+        }
+#endif
     }
 
 #ifdef EINSUMS_COMPUTE_CODE

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImpl.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImpl.hpp
@@ -1,0 +1,840 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <Einsums/TensorBase/IndexUtilities.hpp>
+#include <Einsums/TypeSupport/Lockable.hpp>
+
+#include <mutex>
+#include <numeric>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#include "Einsums/Concepts/NamedRequirements.hpp"
+#include "Einsums/Errors/Error.hpp"
+#include "Einsums/Print.hpp"
+#include "Einsums/TensorBase/Common.hpp"
+
+namespace einsums {
+
+namespace detail {
+
+/**
+ * @struct TensorData<T>
+ *
+ * @brief Underlying implementation details for tensors.
+ *
+ * @tparam T The data type being stored. It can be const or non-const. It can also be any numerical or complex type, though most
+ * library functions only support float, double, std::complex<float>, and std::complex<double>.
+ */
+template <typename T>
+struct TensorData final {
+  public:
+    using ValueType          = T;
+    using ReferenceType      = T &;
+    using ConstReferenceType = T const &;
+    using PointerType        = T *;
+    using ConstPointerType   = T const *;
+
+    // Normal constructors. Note that the copy constructor only creates a copy of the view, not a new tensor with the same data.
+    constexpr TensorData() noexcept = default;
+
+    constexpr TensorData(TensorData<T> const &other)
+        : data_{other.data_}, rank_{other.rank_}, size_{other.size_}, dims_{other.dims_}, strides_{other.strides_} {}
+
+    constexpr TensorData(TensorData<T> &&other) noexcept
+        : data_{other.data_}, rank_{other.rank_}, size_{other.size_}, dims_{std::move(other.dims_)}, strides_{std::move(other.strides_)} {
+        other.data_ = nullptr;
+        other.rank_ = 0;
+        other.size_ = 0;
+        other.dims_.clear();
+        other.strides_.clear();
+    }
+
+    // Move and copy assignment. Note that the copy assignment only creates a copy of the view, not a new tensor with the same data.
+    constexpr TensorData<T> &operator=(TensorData<T> const &other) {
+        data_ = other.data_;
+        rank_ = other.rank_;
+        size_ = other.size_;
+        dims_.resize(rank_);
+        strides_.resize(rank_);
+
+        dims_.assign(other.dims_.cbegin(), other.dims_.cend());
+        strides_.assign(other.strides_.cbegin(), other.strides_.cend());
+    }
+
+    constexpr TensorData<T> &operator=(TensorData<T> &&other) {
+        data_    = other.data_;
+        rank_    = other.rank_;
+        size_    = other.size_;
+        dims_    = std::move(other.dims_);
+        strides_ = std::move(other.strides_);
+
+        other.data_ = nullptr;
+        other.rank_ = 0;
+        other.size_ = 0;
+        other.dims_.clear();
+        other.strides_.clear();
+    }
+
+    // Destructor.
+    constexpr ~TensorData() noexcept {
+        data_ = nullptr;
+        rank_ = 0;
+        size_ = 0;
+        dims_.clear();
+        strides_.clear();
+    }
+
+    // Now the more useful constructors.
+    template <ContainerOrInitializer Dims>
+    constexpr TensorData(T *data, Dims const &dims, bool row_major = false)
+        : data_{data}, dims_(dims.begin(), dims.end()), strides_(dims.size()), rank_{dims.size()} {
+
+        size_ = dims_to_strides(dims_, strides_, row_major);
+    }
+
+    template <ContainerOrInitializer Dims, ContainerOrInitializer Strides>
+    constexpr TensorData(T *data, Dims const &dims, Strides const &strides)
+        : data_{data}, dims_(dims.cbegin(), dims.cend()), strides_(strides.begin(), strides.end()), rank_{dims.size()}, size_{1} {
+        for (int i = 0; i < rank_; i++) {
+            size_ *= dims_[i];
+        }
+    }
+
+    // Getters
+
+    constexpr size_t rank() const noexcept { return rank_; }
+
+    constexpr size_t size() const noexcept { return size_; }
+
+    constexpr std::vector<size_t> const &dims() const noexcept { return dims_; }
+
+    constexpr std::vector<size_t> const &strides() const noexcept { return strides_; }
+
+    constexpr T *data() noexcept { return data_; }
+
+    constexpr T const *data() const noexcept { return data_; }
+
+    // Indexed getters.
+
+    constexpr size_t dim(int i) const {
+        int temp = i;
+        if (temp < 0) {
+            temp += rank_;
+        }
+
+        if (temp < 0 || temp >= rank_) {
+            EINSUMS_THROW_EXCEPTION(std::out_of_range, "The index passed to dim is out of range! Expected between {} and {}, got {}.",
+                                    -rank_, rank_ - 1, i);
+        }
+
+        return dims_[temp];
+    }
+
+    constexpr size_t stride(int i) const {
+        int temp = i;
+        if (temp < 0) {
+            temp += rank_;
+        }
+
+        if (temp < 0 || temp >= rank_) {
+            EINSUMS_THROW_EXCEPTION(std::out_of_range, "The index passed to stride is out of range! Expected between {} and {}, got {}.",
+                                    -rank_, rank_ - 1, i);
+        }
+
+        return strides_[temp];
+    }
+
+    // Indexed data retrieval.
+    template <std::integral... MultiIndex>
+    constexpr T *data_no_check(MultiIndex &&...index) {
+        return data_no_check(std::make_tuple(std::forward<MultiIndex>(index)...));
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr T *data_no_check(std::tuple<MultiIndex...> const &index) {
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to data!");
+        }
+
+        size_t offset = 0;
+        for_sequence<sizeof...(MultiIndex)>([&offset, &index, this](size_t n) { offset += std::get<n>(index) * strides_[n]; });
+
+        return data_ + offset;
+    }
+
+    template <ContainerOrInitializer MultiIndex>
+    constexpr T *data_no_check(MultiIndex const &index) {
+        if (index.size() > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices in the container passed to data!");
+        }
+
+        return data_ + std::inner_product(index.begin(), index.end(), strides_.cbegin(), 0);
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr T const *data_no_check(MultiIndex &&...index) const {
+        return data_no_check(std::make_tuple(std::forward<MultiIndex>(index)...));
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr T const *data_no_check(std::tuple<MultiIndex...> const &index) const {
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to data!");
+        }
+
+        size_t offset = 0;
+        for_sequence<sizeof...(MultiIndex)>([&offset, &index, this](size_t n) { offset += std::get<n>(index) * strides_[n]; });
+
+        return data_ + offset;
+    }
+
+    template <ContainerOrInitializer MultiIndex>
+    constexpr T const *data_no_check(MultiIndex const &index) const {
+        if (index.size() > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices in the container passed to data!");
+        }
+
+        return data_ + std::inner_product(index.begin(), index.end(), strides_.cbegin(), 0);
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr T *data(MultiIndex &&...index) {
+        return data(std::make_tuple(std::forward<MultiIndex>(index)...));
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr T *data(std::tuple<MultiIndex...> const &index) {
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to data!");
+        }
+
+        size_t offset = 0;
+        for_sequence<sizeof...(MultiIndex)>(
+            [&offset, &index, this](size_t n) { offset += adjust_index(std::get<n>(index), dims_[n], n) * strides_[n]; });
+
+        return data_ + offset;
+    }
+
+    template <ContainerOrInitializer MultiIndex>
+    constexpr T *data(MultiIndex const &index) {
+        if (index.size() > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices in the container passed to data!");
+        }
+
+        size_t offset = 0;
+
+        for (int i = 0; i < index.size(); i++) {
+            offset += adjust_index(index[i], dims_[i], i) * strides_[i];
+        }
+
+        return data_ + offset;
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr T const *data(MultiIndex &&...index) const {
+        return data(std::make_tuple(std::forward<MultiIndex>(index)...));
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr T const *data(std::tuple<MultiIndex...> const &index) const {
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to data!");
+        }
+
+        size_t offset = 0;
+        for_sequence<sizeof...(MultiIndex)>(
+            [&offset, &index, this](size_t n) { offset += adjust_index(std::get<n>(index), dims_[n], n) * strides_[n]; });
+
+        return data_ + offset;
+    }
+
+    template <ContainerOrInitializer MultiIndex>
+    constexpr T const *data(MultiIndex const &index) const {
+        if (index.size() > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices in the container passed to data!");
+        }
+
+        size_t offset = 0;
+
+        for (int i = 0; i < index.size(); i++) {
+            offset += adjust_index(index[i], dims_[i], i) * strides_[i];
+        }
+
+        return data_ + offset;
+    }
+
+    // Const conversion.
+    constexpr operator TensorData<T const>() { return TensorData<T const>(data_, dims_, strides_); }
+
+    // Subscripting.
+    template <std::integral... MultiIndex>
+    constexpr ReferenceType subscript_no_check(MultiIndex &&...index) {
+        if (sizeof...(MultiIndex) < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data_no_check(std::forward<MultiIndex>(index)...);
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr ReferenceType subscript_no_check(std::tuple<MultiIndex...> const &index) {
+        if (sizeof...(MultiIndex) < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data_no_check(index);
+    }
+
+    template <ContainerOrInitializer Index>
+    constexpr ReferenceType subscript_no_check(Index const &index) {
+        if (index.size() < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (index.size() > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data_no_check(index);
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr ConstReferenceType subscript_no_check(MultiIndex &&...index) const {
+        if (sizeof...(MultiIndex) < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data_no_check(std::forward<MultiIndex>(index)...);
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr ConstReferenceType subscript_no_check(std::tuple<MultiIndex...> const &index) const {
+        if (sizeof...(MultiIndex) < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data_no_check(index);
+    }
+
+    template <ContainerOrInitializer Index>
+    constexpr ConstReferenceType subscript_no_check(Index const &index) const {
+        if (index.size() < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (index.size() > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data_no_check(index);
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr ReferenceType subscript(MultiIndex &&...index) {
+        if (sizeof...(MultiIndex) < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data(std::forward<MultiIndex>(index)...);
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr ReferenceType subscript(std::tuple<MultiIndex...> const &index) {
+        if (sizeof...(MultiIndex) < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data(index);
+    }
+
+    template <ContainerOrInitializer Index>
+    constexpr ReferenceType subscript(Index const &index) {
+        if (index.size() < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (index.size() > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data(index);
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr ConstReferenceType subscript(MultiIndex &&...index) const {
+        if (sizeof...(MultiIndex) < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data(std::forward<MultiIndex>(index)...);
+    }
+
+    template <std::integral... MultiIndex>
+    constexpr ConstReferenceType subscript(std::tuple<MultiIndex...> const &index) const {
+        if (sizeof...(MultiIndex) < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (sizeof...(MultiIndex) > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data(index);
+    }
+
+    template <ContainerOrInitializer Index>
+    constexpr ConstReferenceType subscript(Index const &index) const {
+        if (index.size() < rank_) {
+            EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+        }
+        if (index.size() > rank_) {
+            EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+        }
+        return *data(index);
+    }
+
+    // View creation.
+    template <typename... MultiIndex>
+        requires(!std::is_integral_v<MultiIndex> || ... || false)
+    constexpr TensorData<T> subscript_no_check(MultiIndex &&...index) {
+        std::vector<size_t> out_dims{}, out_strides{};
+
+        out_dims.reserve(rank_);
+        out_strides.reserve(rank_);
+
+        size_t offset = compute_view<false, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
+
+        return TensorData<T>(data_ + offset, out_dims, out_strides);
+    }
+
+    template <typename... MultiIndex>
+        requires(!std::is_integral_v<MultiIndex> || ... || false)
+    constexpr TensorData<T> subscript_no_check(std::tuple<MultiIndex...> const &index) {
+        std::vector<size_t> out_dims{}, out_strides{};
+
+        out_dims.reserve(rank_);
+        out_strides.reserve(rank_);
+
+        size_t offset = compute_view<false, 0>(out_dims, out_strides, index);
+
+        return TensorData<T>(data_ + offset, out_dims, out_strides);
+    }
+
+    template <typename... MultiIndex>
+        requires(!std::is_integral_v<MultiIndex> || ... || false)
+    constexpr TensorData<T> const subscript_no_check(MultiIndex &&...index) const {
+        std::vector<size_t> out_dims{}, out_strides{};
+
+        out_dims.reserve(rank_);
+        out_strides.reserve(rank_);
+
+        size_t offset = compute_view<false, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
+
+        return TensorData<T>(data_ + offset, out_dims, out_strides);
+    }
+
+    template <typename... MultiIndex>
+        requires(!std::is_integral_v<MultiIndex> || ... || false)
+    constexpr TensorData<T> const subscript_no_check(std::tuple<MultiIndex...> const &index) const {
+        std::vector<size_t> out_dims{}, out_strides{};
+
+        out_dims.reserve(rank_);
+        out_strides.reserve(rank_);
+
+        size_t offset = compute_view<false, 0>(out_dims, out_strides, index);
+
+        return TensorData<T>(data_ + offset, out_dims, out_strides);
+    }
+
+    template <typename... MultiIndex>
+        requires(!std::is_integral_v<MultiIndex> || ... || false)
+    constexpr TensorData<T> subscript(MultiIndex &&...index) {
+        std::vector<size_t> out_dims{}, out_strides{};
+
+        out_dims.reserve(rank_);
+        out_strides.reserve(rank_);
+
+        size_t offset = compute_view<true, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
+
+        return TensorData<T>(data_ + offset, out_dims, out_strides);
+    }
+
+    template <typename... MultiIndex>
+        requires(!std::is_integral_v<MultiIndex> || ... || false)
+    constexpr TensorData<T> subscript(std::tuple<MultiIndex...> const &index) {
+        std::vector<size_t> out_dims{}, out_strides{};
+
+        out_dims.reserve(rank_);
+        out_strides.reserve(rank_);
+
+        size_t offset = compute_view<true, 0>(out_dims, out_strides, index);
+
+        return TensorData<T>(data_ + offset, out_dims, out_strides);
+    }
+
+    template <typename... MultiIndex>
+        requires(!std::is_integral_v<MultiIndex> || ... || false)
+    constexpr TensorData<T> const subscript(MultiIndex &&...index) const {
+        std::vector<size_t> out_dims{}, out_strides{};
+
+        out_dims.reserve(rank_);
+        out_strides.reserve(rank_);
+
+        size_t offset = compute_view<true, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
+
+        return TensorData<T>(data_ + offset, out_dims, out_strides);
+    }
+
+    template <typename... MultiIndex>
+        requires(!std::is_integral_v<MultiIndex> || ... || false)
+    constexpr TensorData<T> const subscript(std::tuple<MultiIndex...> const &index) const {
+        std::vector<size_t> out_dims{}, out_strides{};
+
+        out_dims.reserve(rank_);
+        out_strides.reserve(rank_);
+
+        size_t offset = compute_view<true, 0>(out_dims, out_strides, index);
+
+        return TensorData<T>(data_ + offset, out_dims, out_strides);
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+
+    void copy_to_gpu() {
+        std::vector<size_t> index_strides(rank_);
+
+        dims_to_strides(dims_, index_strides);
+
+        if (size_ < 2048) {
+            std::vector<T> buffer(size_);
+
+            for (size_t i = 0; i < size_; i++) {
+                size_t sentinel;
+
+                sentinel_to_sentinels(i, index_strides, strides_, sentinel);
+
+                buffer[i] = data_[sentinel];
+            }
+
+            hip_catch(hipMemcpy((void *)gpu_ptr_, (void const *)buffer.data(), size_ * sizeof(T), hipMemcpyHostToDevice));
+        } else {
+            // Double buffer bigger transactions.
+            std::vector<T, BufferAllocator<T>> buffer1(1024), buffer2(1024);
+            std::binary_semaphore              buffer1_semaphore(1), buffer2_semaphore(1);
+            bool                               buffer1_ready = false, buffer2_ready = false;
+
+#    pragma omp parallel
+            {
+#    pragma omp task
+                {
+                    for (size_t i = 0; i < size_; i += 2048) {
+                        while (buffer1_ready) {
+                            std::yield();
+                        }
+                        buffer1_semaphore.acquire();
+                        for (size_t j = 0; j < std::min(size_ - i, 1024); j++) {
+                            size_t sentinel;
+                            sentinel_to_sentinels(i + j, index_strides, strides_, sentinel);
+                            buffer1[j] = data_[sentinel];
+                        }
+
+                        if (size_ - i < 1024) {
+                            buffer1.resize(size_ - i);
+                        }
+
+                        buffer1_ready = true;
+
+                        buffer1_semaphore.release();
+
+                        while (buffer2_ready) {
+                            std::yield();
+                        }
+
+                        buffer2_semaphore.acquire();
+
+                        for (size_t j = 0; j < std::min(size_ - i - 1024, 1024); j++) {
+                            size_t sentinel;
+                            sentinel_to_sentinels(i + j + 1024, index_strides, strides_, sentinel);
+                            buffer2[j] = data_[sentinel];
+                        }
+
+                        if (size_ - i - 1024 < 1024) {
+                            buffer2.resize(size_ - i);
+                        }
+
+                        buffer2_ready = true;
+
+                        buffer2_semaphore.release();
+                    }
+                }
+
+#    pragma omp task
+                {
+                    std::yield();
+                    for (size_t i = 0; i < size_; i += 2048) {
+                        while (!buffer1_ready) {
+                            std::yield();
+                        }
+                        buffer1_semaphore.acquire();
+
+                        hip_catch(
+                            hipMemcpy((void *)(gpu_ptr_ + i), (void *)buffer1.data(), buffer1.size() * sizeof(T), hipMemcpyHostToDevice));
+
+                        buffer1_ready = false;
+
+                        buffer1_semaphore.release();
+
+                        while (!buffer2_ready) {
+                            std::yield();
+                        }
+
+                        buffer2_semaphore.acquire();
+
+                        hip_catch(hipMemcpy((void *)(gpu_ptr_ + i + 1024), (void *)buffer2.data(), buffer2.size() * sizeof(T),
+                                            hipMemcpyHostToDevice));
+
+                        buffer2_ready = false;
+
+                        buffer2_semaphore.release();
+                    }
+                }
+#    pragma omp taskgroup
+            }
+        }
+    }
+
+    void copy_from_gpu() {
+
+        std::vector<size_t> index_strides(rank_);
+
+        dims_to_strides(dims_, index_strides);
+
+        if (size_ < 2048) {
+            std::vector<T> buffer(size_);
+
+            hip_catch(hipMemcpy((void *)buffer.data(), (void const *)gpu_ptr_, size_ * sizeof(T), hipMemcpyDeviceToHost));
+
+            for (size_t i = 0; i < size_; i++) {
+                size_t sentinel;
+
+                sentinel_to_sentinels(i, index_strides, strides_, sentinel);
+
+                buffer[i]       = data_[sentinel];
+                data_[sentinel] = buffer[i];
+            }
+
+        } else {
+            // Double buffer bigger transactions.
+            std::vector<T, BufferAllocator<T>> buffer1(1024), buffer2(1024);
+            std::binary_semaphore              buffer1_semaphore(1), buffer2_semaphore(1);
+            bool                               buffer1_ready = true, buffer2_ready = true;
+
+#    pragma omp parallel
+            {
+#    pragma omp task
+                {
+                    for (size_t i = 0; i < size_; i += 2048) {
+                        while (buffer1_ready) {
+                            std::yield();
+                        }
+                        buffer1_semaphore.acquire();
+                        for (size_t j = 0; j < std::min(size_ - i, 1024); j++) {
+                            size_t sentinel;
+                            sentinel_to_sentinels(i + j, index_strides, strides_, sentinel);
+                            data_[sentinel] = buffer1[j];
+                        }
+
+                        buffer1_ready = true;
+
+                        buffer1_semaphore.release();
+
+                        while (buffer2_ready) {
+                            std::yield();
+                        }
+
+                        buffer2_semaphore.acquire();
+
+                        for (size_t j = 0; j < std::min(size_ - i - 1024, 1024); j++) {
+                            size_t sentinel;
+                            sentinel_to_sentinels(i + j + 1024, index_strides, strides_, sentinel);
+                            buffer2[j]      = data_[sentinel];
+                            data_[sentinel] = buffer2[j];
+                        }
+
+                        buffer2_ready = true;
+
+                        buffer2_semaphore.release();
+                    }
+                }
+
+#    pragma omp task
+                {
+                    for (size_t i = 0; i < size_; i += 2048) {
+                        while (!buffer1_ready) {
+                            std::yield();
+                        }
+                        buffer1_semaphore.acquire();
+
+                        hip_catch(hipMemcpy((void *)buffer1.data(), (void const *)(gpu_ptr_ + i), buffer1.size() * sizeof(T),
+                                            hipMemcpyDeviceToHost));
+
+                        buffer1_ready = false;
+
+                        buffer1_semaphore.release();
+
+                        while (!buffer2_ready) {
+                            std::yield();
+                        }
+
+                        buffer2_semaphore.acquire();
+
+                        hip_catch(hipMemcpy((void *)buffer2.data(), (void const *)(gpu_ptr_ + i + 1024), buffer2.size() * sizeof(T),
+                                            hipMemcpyDeviceToHost));
+
+                        buffer2_ready = false;
+
+                        buffer2_semaphore.release();
+                    }
+                }
+#    pragma omp taskgroup
+            }
+        }
+    }
+
+    gpu::GPUPointer<T> request_gpu_ptr(bool copy_on_create = true) {
+        if (gpu_ptr_) {
+            return gpu_ptr_;
+        } else {
+            gpu_ptr_ = allocator_.allocate(size_);
+
+            if (copy_on_create) {
+                copy_to_gpu();
+            }
+
+            return gpu_ptr_;
+        }
+    }
+
+    void free_gpu_ptr(bool copy_on_destroy = true) {
+        if (gpu_ptr_) {
+            if (copy_on_destroy) {
+                copy_from_gpu();
+            }
+
+            allocator_.deallocate(gpu_ptr_, size_);
+            gpu_ptr_ = nullptr;
+        }
+    }
+#endif
+
+  private:
+    template <bool CheckInds, size_t I>
+    constexpr size_t compute_view(std::vector<size_t> &out_dims, std::vector<size_t> &out_strides) {
+        return 0;
+    }
+
+    template <bool CheckInds, size_t I, std::integral First, typename... Rest>
+    constexpr size_t compute_view(std::vector<size_t> &out_dims, std::vector<size_t> &out_strides, First first, Rest &&...rest) {
+        auto index = first;
+        if constexpr (CheckInds) {
+            index = adjust_index(index, dims_[I], I);
+        }
+
+        return index * strides_[I] + compute_view<CheckInds, I + 1>(out_dims, out_strides, std::forward<Rest>(rest)...);
+    }
+
+    template <bool CheckInds, size_t I, typename... Rest>
+    constexpr size_t compute_view(std::vector<size_t> &out_dims, std::vector<size_t> &out_strides, Range const &first, Rest &&...rest) {
+        auto index = first;
+        if constexpr (CheckInds) {
+            index[0] = adjust_index(index[0], dims_[I], I);
+            index[1] = adjust_index(index[1], dims_[I] + 1, I);
+        }
+
+        if (index[0] > index[1]) {
+            auto temp = index[0];
+            index[0]  = index[1];
+            index[1]  = temp;
+        }
+
+        out_dims.push_back(index[1] - index[0]);
+        out_strides.push_back(strides_[I]);
+
+        return index[0] * strides_[I] + compute_view<CheckInds, I + 1>(out_dims, out_strides, std::forward<Rest>(rest)...);
+    }
+
+    template <bool CheckInds, size_t I, typename... Rest>
+    constexpr size_t compute_view(std::vector<size_t> &out_dims, std::vector<size_t> &out_strides, AllT const &, Rest &&...rest) {
+
+        out_dims.push_back(dims_[I]);
+        out_strides.push_back(strides_[I]);
+
+        return compute_view<CheckInds, I + 1>(out_dims, out_strides, std::forward<Rest>(rest)...);
+    }
+
+    template <bool CheckInds, size_t I, typename... MultiIndex>
+    constexpr size_t compute_view(std::vector<size_t> &out_dims, std::vector<size_t> &out_strides,
+                                  std::tuple<MultiIndex...> const &indices) {
+        using CurrType = typename std::tuple_element_t<I, std::tuple<MultiIndex...>>;
+        size_t index   = 0;
+        if constexpr (I >= sizeof...(MultiIndex)) {
+            return 0;
+        } else {
+            if constexpr (std::is_integral_v<CurrType>) {
+                index = std::get<I>(indices);
+                if constexpr (CheckInds) {
+                    index = adjust_index(index, dims_[I], I);
+                }
+
+            } else if constexpr (std::is_same_v<Range, CurrType>) {
+                auto range = std::get<I>(indices);
+                if constexpr (CheckInds) {
+                    range[0] = adjust_index(range[0], dims_[I], I);
+                    range[1] = adjust_index(range[1], dims_[I] + 1, I);
+                }
+
+                if (range[0] > range[1]) {
+                    auto temp = range[0];
+                    range[0]  = range[1];
+                    range[1]  = temp;
+                }
+
+                index = range[0];
+                out_dims.push_back(range[1] - range[0]);
+                out_strides.push_back(strides_[I]);
+            } else if constexpr (std::is_same_v<AllT, CurrType>) {
+                out_dims.push_back(dims_[I]);
+                out_strides.push_back(strides_[I]);
+            }
+            return index * strides_[I] + compute_view<CheckInds, I + 1>(out_dims, out_strides, indices);
+        }
+    }
+
+    T *data_{nullptr};
+
+    size_t rank_{0}, size_{0};
+
+    std::vector<size_t> dims_{}, strides_{};
+
+#ifdef EINSUMS_COMPUTE_CODE
+    GPUAllocator<T> allocator_{};
+    GPUPointer<T>   gpu_ptr_{nullptr};
+#endif
+};
+
+} // namespace detail
+
+} // namespace einsums

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImpl.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImpl.hpp
@@ -5,8 +5,15 @@
 
 #pragma once
 
+#include <Einsums/BufferAllocator/BufferAllocator.hpp>
+#include <Einsums/Concepts/Complex.hpp>
+#include <Einsums/Concepts/NamedRequirements.hpp>
+#include <Einsums/Errors/Error.hpp>
+#include <Einsums/Print.hpp>
+#include <Einsums/TensorBase/Common.hpp>
 #include <Einsums/TensorBase/IndexUtilities.hpp>
 #include <Einsums/TypeSupport/Lockable.hpp>
+#include <Einsums/BLASVendor.hpp>
 
 #include <mutex>
 #include <numeric>
@@ -15,17 +22,74 @@
 #include <utility>
 #include <vector>
 
-#include "Einsums/Concepts/NamedRequirements.hpp"
-#include "Einsums/Errors/Error.hpp"
-#include "Einsums/Print.hpp"
-#include "Einsums/TensorBase/Common.hpp"
+#ifdef EINSUMS_COMPUTE_CODE
+#    include <Einsums/GPUMemory/GPUAllocator.hpp>
+#    include <Einsums/GPUMemory/GPUMemoryTracker.hpp>
+#    include <Einsums/GPUMemory/GPUPointer.hpp>
+
+#    include <hip/hip_common.h>
+#    include <hip/hip_complex.h>
+#    include <hip/hip_runtime.h>
+#    include <hip/hip_runtime_api.h>
+#endif
 
 namespace einsums {
+
+/**
+ * @brief Adjust the index if it is negative and raise an error if it is out of range.
+ *
+ * The @c index_position parameter is used for creating the exception message. If it is negative,
+ * then the exception message will look something like <tt>"The index is out of range! Expected between -5 and 4, got 6!"</tt>.
+ * However, for better diagnostics, a non-negative index_position, for example 2, will give an exception message like
+ * <tt>"The third index is out of range! Expected between -5 and 4, got 6!"</tt>. Note that these are zero-indexed, so
+ * passing in 2 prints out "third".
+ *
+ * @param index The index to adjust and check.
+ * @param dim The dimension to compare to.
+ * @param index_position Used for the error message. If it is negative, then the index position
+ * will not be included in the error message.
+ */
+template <std::integral IntType>
+constexpr size_t adjust_index(IntType index, size_t dim, int index_position = -1) {
+    if constexpr (std::is_signed_v<IntType>) {
+        auto hold = index;
+
+        if (hold < 0) {
+            hold += dim;
+        }
+
+        if (hold < 0 || hold >= dim) {
+            if (index_position < 0) {
+                EINSUMS_THROW_EXCEPTION(std::out_of_range, "The index is out of range! Expected between {} and {}, got {}!",
+                                        -(ptrdiff_t)dim, dim - 1, index);
+            } else {
+                EINSUMS_THROW_EXCEPTION(std::out_of_range, "The {} index is out of range! Expected between {} and {}, got {}!",
+                                        print::ordinal<int>(index_position + 1), -(ptrdiff_t)dim, dim - 1, index);
+            }
+        }
+        return hold;
+    } else {
+        if (index >= dim) {
+            if (index_position < 0) {
+                EINSUMS_THROW_EXCEPTION(std::out_of_range, "The index is out of range! Expected between {} and {}, got {}!", 0, dim - 1,
+                                        index);
+            } else {
+                EINSUMS_THROW_EXCEPTION(std::out_of_range, "The {} index is out of range! Expected between {} and {}, got {}!",
+                                        print::ordinal<int>(index_position + 1), 0, dim - 1, index);
+            }
+        }
+
+        return index;
+    }
+}
+
+template <typename T>
+struct TensorImpl;
 
 namespace detail {
 
 /**
- * @struct TensorData<T>
+ * @struct TensorImpl<T>
  *
  * @brief Underlying implementation details for tensors.
  *
@@ -33,7 +97,7 @@ namespace detail {
  * library functions only support float, double, std::complex<float>, and std::complex<double>.
  */
 template <typename T>
-struct TensorData final {
+struct TensorImpl final {
   public:
     using ValueType          = T;
     using ReferenceType      = T &;
@@ -42,22 +106,27 @@ struct TensorData final {
     using ConstPointerType   = T const *;
 
     // Normal constructors. Note that the copy constructor only creates a copy of the view, not a new tensor with the same data.
-    constexpr TensorData() noexcept = default;
+    constexpr TensorImpl() noexcept = default;
 
-    constexpr TensorData(TensorData<T> const &other)
-        : data_{other.data_}, rank_{other.rank_}, size_{other.size_}, dims_{other.dims_}, strides_{other.strides_} {}
+    constexpr TensorImpl(TensorImpl<T> const &other)
+        : data_{other.data_}, rank_{other.rank_}, size_{other.size_}, dims_{other.dims_}, strides_{other.strides_},
+          is_contiguous_{other.is_contiguous_} {
+        gpu_init();
+    }
 
-    constexpr TensorData(TensorData<T> &&other) noexcept
-        : data_{other.data_}, rank_{other.rank_}, size_{other.size_}, dims_{std::move(other.dims_)}, strides_{std::move(other.strides_)} {
+    constexpr TensorImpl(TensorImpl<T> &&other) noexcept
+        : data_{other.data_}, rank_{other.rank_}, size_{other.size_}, dims_{std::move(other.dims_)}, strides_{std::move(other.strides_)},
+          is_contiguous_{other.is_contiguous_} {
         other.data_ = nullptr;
         other.rank_ = 0;
         other.size_ = 0;
         other.dims_.clear();
         other.strides_.clear();
+        gpu_init();
     }
 
     // Move and copy assignment. Note that the copy assignment only creates a copy of the view, not a new tensor with the same data.
-    constexpr TensorData<T> &operator=(TensorData<T> const &other) {
+    constexpr TensorImpl<T> &operator=(TensorImpl<T> const &other) {
         data_ = other.data_;
         rank_ = other.rank_;
         size_ = other.size_;
@@ -66,44 +135,77 @@ struct TensorData final {
 
         dims_.assign(other.dims_.cbegin(), other.dims_.cend());
         strides_.assign(other.strides_.cbegin(), other.strides_.cend());
+        is_contiguous_ = other.is_contiguous_;
+        gpu_init();
     }
 
-    constexpr TensorData<T> &operator=(TensorData<T> &&other) {
-        data_    = other.data_;
-        rank_    = other.rank_;
-        size_    = other.size_;
-        dims_    = std::move(other.dims_);
-        strides_ = std::move(other.strides_);
+    constexpr TensorImpl<T> &operator=(TensorImpl<T> &&other) {
+        data_          = other.data_;
+        rank_          = other.rank_;
+        size_          = other.size_;
+        dims_          = std::move(other.dims_);
+        strides_       = std::move(other.strides_);
+        is_contiguous_ = other.is_contiguous_;
 
         other.data_ = nullptr;
         other.rank_ = 0;
         other.size_ = 0;
         other.dims_.clear();
         other.strides_.clear();
+        gpu_init();
     }
 
     // Destructor.
-    constexpr ~TensorData() noexcept {
+    constexpr ~TensorImpl() noexcept {
         data_ = nullptr;
         rank_ = 0;
         size_ = 0;
         dims_.clear();
         strides_.clear();
+#ifdef EINSUMS_COMPUTE_CODE
+        gpu::GPUMemoryTracker::get_singleton().release_handle(gpu_handle_, true);
+#endif
     }
 
     // Now the more useful constructors.
     template <ContainerOrInitializer Dims>
-    constexpr TensorData(T *data, Dims const &dims, bool row_major = false)
+    constexpr TensorImpl(T *data, Dims const &dims, bool row_major = false)
         : data_{data}, dims_(dims.begin(), dims.end()), strides_(dims.size()), rank_{dims.size()} {
 
-        size_ = dims_to_strides(dims_, strides_, row_major);
+        size_          = dims_to_strides(dims_, strides_, row_major);
+        is_contiguous_ = true;
     }
 
     template <ContainerOrInitializer Dims, ContainerOrInitializer Strides>
-    constexpr TensorData(T *data, Dims const &dims, Strides const &strides)
+    constexpr TensorImpl(T *data, Dims const &dims, Strides const &strides)
         : data_{data}, dims_(dims.cbegin(), dims.cend()), strides_(strides.begin(), strides.end()), rank_{dims.size()}, size_{1} {
         for (int i = 0; i < rank_; i++) {
             size_ *= dims_[i];
+        }
+
+        // Check to see if it is contiguous.
+        if (strides[0] == 1) {
+            size_t expected = 1;
+            for (int i = 0; i < rank_; i++) {
+                if (strides_[i] != expected) {
+                    is_contiguous_ = false;
+                    break;
+                }
+                expected *= dims_[i];
+            }
+            is_contiguous_ = true;
+        } else if (strides[rank_ - 1] == 1) {
+            size_t expected = 1;
+            for (int i = rank_ - 1; i >= 0; i--) {
+                if (strides_[i] != expected) {
+                    is_contiguous_ = false;
+                    break;
+                }
+                expected *= dims_[i];
+            }
+            is_contiguous_ = true;
+        } else {
+            is_contiguous_ = false;
         }
     }
 
@@ -113,13 +215,21 @@ struct TensorData final {
 
     constexpr size_t size() const noexcept { return size_; }
 
-    constexpr std::vector<size_t> const &dims() const noexcept { return dims_; }
+    constexpr BufferVector<size_t> const &dims() const noexcept { return dims_; }
 
-    constexpr std::vector<size_t> const &strides() const noexcept { return strides_; }
+    constexpr BufferVector<size_t> const &strides() const noexcept { return strides_; }
 
     constexpr T *data() noexcept { return data_; }
 
     constexpr T const *data() const noexcept { return data_; }
+
+    constexpr bool is_contiguous() const noexcept { return is_contiguous_; }
+
+    // Setters
+
+    constexpr void reset_data(T *data) noexcept { data_ = data; }
+
+    constexpr void reset_data(T const *data) noexcept { data_ = data; }
 
     // Indexed getters.
 
@@ -271,7 +381,7 @@ struct TensorData final {
     }
 
     // Const conversion.
-    constexpr operator TensorData<T const>() { return TensorData<T const>(data_, dims_, strides_); }
+    constexpr operator TensorImpl<T const>() { return TensorImpl<T const>(data_, dims_, strides_); }
 
     // Subscripting.
     template <std::integral... MultiIndex>
@@ -409,117 +519,273 @@ struct TensorData final {
     // View creation.
     template <typename... MultiIndex>
         requires(!std::is_integral_v<MultiIndex> || ... || false)
-    constexpr TensorData<T> subscript_no_check(MultiIndex &&...index) {
-        std::vector<size_t> out_dims{}, out_strides{};
+    constexpr TensorImpl<T> subscript_no_check(MultiIndex &&...index) {
+        BufferVector<size_t> out_dims{}, out_strides{};
 
         out_dims.reserve(rank_);
         out_strides.reserve(rank_);
 
         size_t offset = compute_view<false, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
 
-        return TensorData<T>(data_ + offset, out_dims, out_strides);
+        return TensorImpl<T>(data_ + offset, out_dims, out_strides);
     }
 
     template <typename... MultiIndex>
         requires(!std::is_integral_v<MultiIndex> || ... || false)
-    constexpr TensorData<T> subscript_no_check(std::tuple<MultiIndex...> const &index) {
-        std::vector<size_t> out_dims{}, out_strides{};
+    constexpr TensorImpl<T> subscript_no_check(std::tuple<MultiIndex...> const &index) {
+        BufferVector<size_t> out_dims{}, out_strides{};
 
         out_dims.reserve(rank_);
         out_strides.reserve(rank_);
 
         size_t offset = compute_view<false, 0>(out_dims, out_strides, index);
 
-        return TensorData<T>(data_ + offset, out_dims, out_strides);
+        return TensorImpl<T>(data_ + offset, out_dims, out_strides);
     }
 
     template <typename... MultiIndex>
         requires(!std::is_integral_v<MultiIndex> || ... || false)
-    constexpr TensorData<T> const subscript_no_check(MultiIndex &&...index) const {
-        std::vector<size_t> out_dims{}, out_strides{};
+    constexpr TensorImpl<T> const subscript_no_check(MultiIndex &&...index) const {
+        BufferVector<size_t> out_dims{}, out_strides{};
 
         out_dims.reserve(rank_);
         out_strides.reserve(rank_);
 
         size_t offset = compute_view<false, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
 
-        return TensorData<T>(data_ + offset, out_dims, out_strides);
+        return TensorImpl<T>(data_ + offset, out_dims, out_strides);
     }
 
     template <typename... MultiIndex>
         requires(!std::is_integral_v<MultiIndex> || ... || false)
-    constexpr TensorData<T> const subscript_no_check(std::tuple<MultiIndex...> const &index) const {
-        std::vector<size_t> out_dims{}, out_strides{};
+    constexpr TensorImpl<T> const subscript_no_check(std::tuple<MultiIndex...> const &index) const {
+        BufferVector<size_t> out_dims{}, out_strides{};
 
         out_dims.reserve(rank_);
         out_strides.reserve(rank_);
 
         size_t offset = compute_view<false, 0>(out_dims, out_strides, index);
 
-        return TensorData<T>(data_ + offset, out_dims, out_strides);
+        return TensorImpl<T>(data_ + offset, out_dims, out_strides);
     }
 
     template <typename... MultiIndex>
         requires(!std::is_integral_v<MultiIndex> || ... || false)
-    constexpr TensorData<T> subscript(MultiIndex &&...index) {
-        std::vector<size_t> out_dims{}, out_strides{};
+    constexpr TensorImpl<T> subscript(MultiIndex &&...index) {
+        BufferVector<size_t> out_dims{}, out_strides{};
 
         out_dims.reserve(rank_);
         out_strides.reserve(rank_);
 
         size_t offset = compute_view<true, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
 
-        return TensorData<T>(data_ + offset, out_dims, out_strides);
+        return TensorImpl<T>(data_ + offset, out_dims, out_strides);
     }
 
     template <typename... MultiIndex>
         requires(!std::is_integral_v<MultiIndex> || ... || false)
-    constexpr TensorData<T> subscript(std::tuple<MultiIndex...> const &index) {
-        std::vector<size_t> out_dims{}, out_strides{};
+    constexpr TensorImpl<T> subscript(std::tuple<MultiIndex...> const &index) {
+        BufferVector<size_t> out_dims{}, out_strides{};
 
         out_dims.reserve(rank_);
         out_strides.reserve(rank_);
 
         size_t offset = compute_view<true, 0>(out_dims, out_strides, index);
 
-        return TensorData<T>(data_ + offset, out_dims, out_strides);
+        return TensorImpl<T>(data_ + offset, out_dims, out_strides);
     }
 
     template <typename... MultiIndex>
         requires(!std::is_integral_v<MultiIndex> || ... || false)
-    constexpr TensorData<T> const subscript(MultiIndex &&...index) const {
-        std::vector<size_t> out_dims{}, out_strides{};
+    constexpr TensorImpl<T> const subscript(MultiIndex &&...index) const {
+        BufferVector<size_t> out_dims{}, out_strides{};
 
         out_dims.reserve(rank_);
         out_strides.reserve(rank_);
 
         size_t offset = compute_view<true, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
 
-        return TensorData<T>(data_ + offset, out_dims, out_strides);
+        return TensorImpl<T>(data_ + offset, out_dims, out_strides);
     }
 
     template <typename... MultiIndex>
         requires(!std::is_integral_v<MultiIndex> || ... || false)
-    constexpr TensorData<T> const subscript(std::tuple<MultiIndex...> const &index) const {
-        std::vector<size_t> out_dims{}, out_strides{};
+    constexpr TensorImpl<T> const subscript(std::tuple<MultiIndex...> const &index) const {
+        BufferVector<size_t> out_dims{}, out_strides{};
 
         out_dims.reserve(rank_);
         out_strides.reserve(rank_);
 
         size_t offset = compute_view<true, 0>(out_dims, out_strides, index);
 
-        return TensorData<T>(data_ + offset, out_dims, out_strides);
+        return TensorImpl<T>(data_ + offset, out_dims, out_strides);
+    }
+
+    template <typename TOther>
+    void copy_from_both_contiguous(TensorImpl<TOther> const &other) {
+        if (other.rank() != rank()) {
+            EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+        }
+
+        if (other.dims() != dims()) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+        }
+
+        if (other.data() == data() || data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        for (size_t i = 0; i < elems; i++) {
+            if constexpr (!IsComplexV<T>) {
+                data_[i] = T{std::real(other.data_[i])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val = other.data_[i];
+                data_[i] = T{std::real(val), std::imag(val)};
+            } else {
+                data_[i] = T{other.data_[i]};
+            }
+        }
+    }
+
+    template <typename TOther>
+    void copy_from(TensorImpl<TOther> const &other) {
+        if (other.is_contiguous() && is_contiguous()) {
+            copy_from_assume_contiguous(other);
+            return;
+        }
+
+        if (other.rank() != rank()) {
+            EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+        }
+
+        if (other.dims() != dims()) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+        }
+
+        if (other.data() == data() || data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        BufferVector<size_t> index_strides;
+
+        dims_to_strides(dims(), index_strides);
+
+        EINSUMS_OMP_PARALLEL_FOR
+        for (size_t i = 0; i < elems; i++) {
+            size_t this_sentinel, other_sentinel;
+
+            sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
+
+            if constexpr (!IsComplexV<T>) {
+                data_[this_sentinel] = T{std::real(other.data_[other_sentinel])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val             = other.data_[other_sentinel];
+                data_[this_sentinel] = T{std::real(val), std::imag(val)};
+            } else {
+                data_[this_sentinel] = T{other.data_[other_sentinel]};
+            }
+        }
+    }
+
+    template <typename TOther>
+    void add_assign_both_contiguous(TensorImpl<TOther> const &other) {
+        if (other.rank() != rank()) {
+            EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+        }
+
+        if (other.dims() != dims()) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+        }
+
+        if (other.data() == data() || data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        if constexpr (std::is_same_v<TOther, T>) {
+            #ifdef EINSUMS_COMPUTE_CODE
+            auto singleton = gpu::GPUMemoryTracker::get_singleton();
+            if(singleton.handle_is_allocated(gpu_handle_) && singleton.handle_is_allocated(other.gpu_handle_)) {
+                hipblas_catch(hipblasSaxpy());
+            }
+            #endif
+            blas::vendor::axpy(size(), );
+        }
+
+        size_t elems = size();
+
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        for (size_t i = 0; i < elems; i++) {
+            if constexpr (!IsComplexV<T>) {
+                data_[i] = T{std::real(other.data_[i])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val = other.data_[i];
+                data_[i] = T{std::real(val), std::imag(val)};
+            } else {
+                data_[i] = T{other.data_[i]};
+            }
+        }
+    }
+
+    template <typename TOther>
+    void add_assign(TensorImpl<TOther> const &other) {
+        if (other.is_contiguous() && is_contiguous()) {
+            copy_from_assume_contiguous(other);
+            return;
+        }
+
+        if (other.rank() != rank()) {
+            EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+        }
+
+        if (other.dims() != dims()) {
+            EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+        }
+
+        if (other.data() == data() || data() == nullptr) {
+            // Don't copy.
+            return;
+        }
+
+        size_t elems = size();
+
+        BufferVector<size_t> index_strides;
+
+        dims_to_strides(dims(), index_strides);
+
+        EINSUMS_OMP_PARALLEL_FOR
+        for (size_t i = 0; i < elems; i++) {
+            size_t this_sentinel, other_sentinel;
+
+            sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
+
+            if constexpr (!IsComplexV<T>) {
+                data_[this_sentinel] = T{std::real(other.data_[other_sentinel])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val             = other.data_[other_sentinel];
+                data_[this_sentinel] = T{std::real(val), std::imag(val)};
+            } else {
+                data_[this_sentinel] = T{other.data_[other_sentinel]};
+            }
+        }
     }
 
 #ifdef EINSUMS_COMPUTE_CODE
 
-    void copy_to_gpu() {
-        std::vector<size_t> index_strides(rank_);
+    void copy_to_gpu(gpu::GPUPointer<T> gpu_ptr) {
+        BufferVector<size_t> index_strides(rank_);
 
         dims_to_strides(dims_, index_strides);
 
         if (size_ < 2048) {
-            std::vector<T> buffer(size_);
+            BufferVector<T> buffer(size_);
 
             for (size_t i = 0; i < size_; i++) {
                 size_t sentinel;
@@ -529,12 +795,12 @@ struct TensorData final {
                 buffer[i] = data_[sentinel];
             }
 
-            hip_catch(hipMemcpy((void *)gpu_ptr_, (void const *)buffer.data(), size_ * sizeof(T), hipMemcpyHostToDevice));
+            hip_catch(hipMemcpy((void *)gpu_ptr, (void const *)buffer.data(), size_ * sizeof(T), hipMemcpyHostToDevice));
         } else {
             // Double buffer bigger transactions.
-            std::vector<T, BufferAllocator<T>> buffer1(1024), buffer2(1024);
-            std::binary_semaphore              buffer1_semaphore(1), buffer2_semaphore(1);
-            bool                               buffer1_ready = false, buffer2_ready = false;
+            BufferVector<T>       buffer1(1024), buffer2(1024);
+            std::binary_semaphore buffer1_semaphore(1), buffer2_semaphore(1);
+            bool                  buffer1_ready = false, buffer2_ready = false;
 
 #    pragma omp parallel
             {
@@ -542,10 +808,10 @@ struct TensorData final {
                 {
                     for (size_t i = 0; i < size_; i += 2048) {
                         while (buffer1_ready) {
-                            std::yield();
+                            std::this_thread::yield();
                         }
                         buffer1_semaphore.acquire();
-                        for (size_t j = 0; j < std::min(size_ - i, 1024); j++) {
+                        for (size_t j = 0; j < std::min(size_ - i, (size_t)1024); j++) {
                             size_t sentinel;
                             sentinel_to_sentinels(i + j, index_strides, strides_, sentinel);
                             buffer1[j] = data_[sentinel];
@@ -560,12 +826,12 @@ struct TensorData final {
                         buffer1_semaphore.release();
 
                         while (buffer2_ready) {
-                            std::yield();
+                            std::this_thread::yield();
                         }
 
                         buffer2_semaphore.acquire();
 
-                        for (size_t j = 0; j < std::min(size_ - i - 1024, 1024); j++) {
+                        for (size_t j = 0; j < std::min(size_ - i - 1024, (size_t)1024); j++) {
                             size_t sentinel;
                             sentinel_to_sentinels(i + j + 1024, index_strides, strides_, sentinel);
                             buffer2[j] = data_[sentinel];
@@ -583,27 +849,27 @@ struct TensorData final {
 
 #    pragma omp task
                 {
-                    std::yield();
+                    std::this_thread::yield();
                     for (size_t i = 0; i < size_; i += 2048) {
                         while (!buffer1_ready) {
-                            std::yield();
+                            std::this_thread::yield();
                         }
                         buffer1_semaphore.acquire();
 
                         hip_catch(
-                            hipMemcpy((void *)(gpu_ptr_ + i), (void *)buffer1.data(), buffer1.size() * sizeof(T), hipMemcpyHostToDevice));
+                            hipMemcpy((void *)(gpu_ptr + i), (void *)buffer1.data(), buffer1.size() * sizeof(T), hipMemcpyHostToDevice));
 
                         buffer1_ready = false;
 
                         buffer1_semaphore.release();
 
                         while (!buffer2_ready) {
-                            std::yield();
+                            std::this_thread::yield();
                         }
 
                         buffer2_semaphore.acquire();
 
-                        hip_catch(hipMemcpy((void *)(gpu_ptr_ + i + 1024), (void *)buffer2.data(), buffer2.size() * sizeof(T),
+                        hip_catch(hipMemcpy((void *)(gpu_ptr + i + 1024), (void *)buffer2.data(), buffer2.size() * sizeof(T),
                                             hipMemcpyHostToDevice));
 
                         buffer2_ready = false;
@@ -616,16 +882,16 @@ struct TensorData final {
         }
     }
 
-    void copy_from_gpu() {
+    void copy_from_gpu(gpu::GPUPointer<T> gpu_ptr) {
 
-        std::vector<size_t> index_strides(rank_);
+        BufferVector<size_t> index_strides(rank_);
 
         dims_to_strides(dims_, index_strides);
 
         if (size_ < 2048) {
-            std::vector<T> buffer(size_);
+            BufferVector<T> buffer(size_);
 
-            hip_catch(hipMemcpy((void *)buffer.data(), (void const *)gpu_ptr_, size_ * sizeof(T), hipMemcpyDeviceToHost));
+            hip_catch(hipMemcpy((void *)buffer.data(), (void const *)gpu_ptr, size_ * sizeof(T), hipMemcpyDeviceToHost));
 
             for (size_t i = 0; i < size_; i++) {
                 size_t sentinel;
@@ -638,9 +904,9 @@ struct TensorData final {
 
         } else {
             // Double buffer bigger transactions.
-            std::vector<T, BufferAllocator<T>> buffer1(1024), buffer2(1024);
-            std::binary_semaphore              buffer1_semaphore(1), buffer2_semaphore(1);
-            bool                               buffer1_ready = true, buffer2_ready = true;
+            BufferVector<T>       buffer1(1024), buffer2(1024);
+            std::binary_semaphore buffer1_semaphore(1), buffer2_semaphore(1);
+            bool                  buffer1_ready = true, buffer2_ready = true;
 
 #    pragma omp parallel
             {
@@ -648,10 +914,10 @@ struct TensorData final {
                 {
                     for (size_t i = 0; i < size_; i += 2048) {
                         while (buffer1_ready) {
-                            std::yield();
+                            std::this_thread::yield();
                         }
                         buffer1_semaphore.acquire();
-                        for (size_t j = 0; j < std::min(size_ - i, 1024); j++) {
+                        for (size_t j = 0; j < std::min(size_ - i, (size_t)1024); j++) {
                             size_t sentinel;
                             sentinel_to_sentinels(i + j, index_strides, strides_, sentinel);
                             data_[sentinel] = buffer1[j];
@@ -662,12 +928,12 @@ struct TensorData final {
                         buffer1_semaphore.release();
 
                         while (buffer2_ready) {
-                            std::yield();
+                            std::this_thread::yield();
                         }
 
                         buffer2_semaphore.acquire();
 
-                        for (size_t j = 0; j < std::min(size_ - i - 1024, 1024); j++) {
+                        for (size_t j = 0; j < std::min(size_ - i - 1024, (size_t)1024); j++) {
                             size_t sentinel;
                             sentinel_to_sentinels(i + j + 1024, index_strides, strides_, sentinel);
                             buffer2[j]      = data_[sentinel];
@@ -684,11 +950,11 @@ struct TensorData final {
                 {
                     for (size_t i = 0; i < size_; i += 2048) {
                         while (!buffer1_ready) {
-                            std::yield();
+                            std::this_thread::yield();
                         }
                         buffer1_semaphore.acquire();
 
-                        hip_catch(hipMemcpy((void *)buffer1.data(), (void const *)(gpu_ptr_ + i), buffer1.size() * sizeof(T),
+                        hip_catch(hipMemcpy((void *)buffer1.data(), (void const *)(gpu_ptr + i), buffer1.size() * sizeof(T),
                                             hipMemcpyDeviceToHost));
 
                         buffer1_ready = false;
@@ -696,12 +962,12 @@ struct TensorData final {
                         buffer1_semaphore.release();
 
                         while (!buffer2_ready) {
-                            std::yield();
+                            std::this_thread::yield();
                         }
 
                         buffer2_semaphore.acquire();
 
-                        hip_catch(hipMemcpy((void *)buffer2.data(), (void const *)(gpu_ptr_ + i + 1024), buffer2.size() * sizeof(T),
+                        hip_catch(hipMemcpy((void *)buffer2.data(), (void const *)(gpu_ptr + i + 1024), buffer2.size() * sizeof(T),
                                             hipMemcpyDeviceToHost));
 
                         buffer2_ready = false;
@@ -714,40 +980,38 @@ struct TensorData final {
         }
     }
 
-    gpu::GPUPointer<T> request_gpu_ptr(bool copy_on_create = true) {
-        if (gpu_ptr_) {
-            return gpu_ptr_;
-        } else {
-            gpu_ptr_ = allocator_.allocate(size_);
+    gpu::GPUPointer<T> request_gpu_ptr() {
+        auto [ptr, do_copy] = gpu::GPUMemoryTracker::get_singleton().get_pointer<T>(gpu_handle_, size());
 
-            if (copy_on_create) {
-                copy_to_gpu();
-            }
-
-            return gpu_ptr_;
+        if (do_copy) {
+            copy_to_gpu(ptr);
         }
+
+        return ptr;
     }
 
-    void free_gpu_ptr(bool copy_on_destroy = true) {
-        if (gpu_ptr_) {
-            if (copy_on_destroy) {
-                copy_from_gpu();
-            }
-
-            allocator_.deallocate(gpu_ptr_, size_);
-            gpu_ptr_ = nullptr;
+    void release_gpu_ptr(gpu::GPUPointer<T> &ptr) {
+        if (ptr) {
+            gpu::GPUMemoryTracker::get_singleton().release_handle(gpu_handle_);
         }
     }
 #endif
 
   private:
-    template <bool CheckInds, size_t I>
-    constexpr size_t compute_view(std::vector<size_t> &out_dims, std::vector<size_t> &out_strides) {
+    void gpu_init() {
+#ifdef EINSUMS_COMPUTE_CODE
+        gpu_handle_ = gpu::GPUMemoryTracker::get_singleton().create_handle();
+#endif
+    }
+
+    template <bool CheckInds, size_t I, typename Alloc1, typename Alloc2>
+    constexpr size_t compute_view(std::vector<size_t, Alloc1> &out_dims, std::vector<size_t, Alloc2> &out_strides) {
         return 0;
     }
 
-    template <bool CheckInds, size_t I, std::integral First, typename... Rest>
-    constexpr size_t compute_view(std::vector<size_t> &out_dims, std::vector<size_t> &out_strides, First first, Rest &&...rest) {
+    template <bool CheckInds, size_t I, typename Alloc1, typename Alloc2, std::integral First, typename... Rest>
+    constexpr size_t compute_view(std::vector<size_t, Alloc1> &out_dims, std::vector<size_t, Alloc2> &out_strides, First first,
+                                  Rest &&...rest) {
         auto index = first;
         if constexpr (CheckInds) {
             index = adjust_index(index, dims_[I], I);
@@ -756,8 +1020,9 @@ struct TensorData final {
         return index * strides_[I] + compute_view<CheckInds, I + 1>(out_dims, out_strides, std::forward<Rest>(rest)...);
     }
 
-    template <bool CheckInds, size_t I, typename... Rest>
-    constexpr size_t compute_view(std::vector<size_t> &out_dims, std::vector<size_t> &out_strides, Range const &first, Rest &&...rest) {
+    template <bool CheckInds, size_t I, typename Alloc1, typename Alloc2, typename... Rest>
+    constexpr size_t compute_view(std::vector<size_t, Alloc1> &out_dims, std::vector<size_t, Alloc2> &out_strides, Range const &first,
+                                  Rest &&...rest) {
         auto index = first;
         if constexpr (CheckInds) {
             index[0] = adjust_index(index[0], dims_[I], I);
@@ -776,8 +1041,9 @@ struct TensorData final {
         return index[0] * strides_[I] + compute_view<CheckInds, I + 1>(out_dims, out_strides, std::forward<Rest>(rest)...);
     }
 
-    template <bool CheckInds, size_t I, typename... Rest>
-    constexpr size_t compute_view(std::vector<size_t> &out_dims, std::vector<size_t> &out_strides, AllT const &, Rest &&...rest) {
+    template <bool CheckInds, size_t I, typename Alloc1, typename Alloc2, typename... Rest>
+    constexpr size_t compute_view(std::vector<size_t, Alloc1> &out_dims, std::vector<size_t, Alloc2> &out_strides, AllT const &,
+                                  Rest &&...rest) {
 
         out_dims.push_back(dims_[I]);
         out_strides.push_back(strides_[I]);
@@ -785,8 +1051,8 @@ struct TensorData final {
         return compute_view<CheckInds, I + 1>(out_dims, out_strides, std::forward<Rest>(rest)...);
     }
 
-    template <bool CheckInds, size_t I, typename... MultiIndex>
-    constexpr size_t compute_view(std::vector<size_t> &out_dims, std::vector<size_t> &out_strides,
+    template <bool CheckInds, size_t I, typename Alloc1, typename Alloc2, typename... MultiIndex>
+    constexpr size_t compute_view(std::vector<size_t, Alloc1> &out_dims, std::vector<size_t, Alloc2> &out_strides,
                                   std::tuple<MultiIndex...> const &indices) {
         using CurrType = typename std::tuple_element_t<I, std::tuple<MultiIndex...>>;
         size_t index   = 0;
@@ -827,12 +1093,13 @@ struct TensorData final {
 
     size_t rank_{0}, size_{0};
 
-    std::vector<size_t> dims_{}, strides_{};
+    BufferVector<size_t> dims_{}, strides_{};
 
 #ifdef EINSUMS_COMPUTE_CODE
-    GPUAllocator<T> allocator_{};
-    GPUPointer<T>   gpu_ptr_{nullptr};
+    size_t gpu_handle_{0};
 #endif
+
+    bool is_contiguous_{false};
 };
 
 } // namespace detail

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImplConstructors.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImplConstructors.hpp
@@ -1,0 +1,149 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <Einsums/BLAS.hpp>
+#include <Einsums/BufferAllocator/BufferAllocator.hpp>
+#include <Einsums/Concepts/Complex.hpp>
+#include <Einsums/Concepts/NamedRequirements.hpp>
+#include <Einsums/Errors/Error.hpp>
+#include <Einsums/Print.hpp>
+#include <Einsums/Tensor/Backends/TensorImpl.hpp>
+#include <Einsums/TensorBase/Common.hpp>
+#include <Einsums/TensorBase/IndexUtilities.hpp>
+#include <Einsums/TypeSupport/Lockable.hpp>
+
+#include <mutex>
+#include <numeric>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#ifdef EINSUMS_COMPUTE_CODE
+#    include <Einsums/GPUMemory/GPUAllocator.hpp>
+#    include <Einsums/GPUMemory/GPUMemoryTracker.hpp>
+#    include <Einsums/GPUMemory/GPUPointer.hpp>
+#    include <Einsums/GPUStreams/GPUStreams.hpp>
+#    include <Einsums/hipBLAS.hpp>
+
+#    include <hip/hip_common.h>
+#    include <hip/hip_complex.h>
+#    include <hip/hip_runtime.h>
+#    include <hip/hip_runtime_api.h>
+#endif
+
+namespace einsums {
+namespace detail {
+
+template <typename T>
+constexpr TensorImpl<T>::TensorImpl(TensorImpl<T> const &other)
+    : data_{other.data_}, rank_{other.rank_}, size_{other.size_}, dims_{other.dims_}, strides_{other.strides_},
+      is_contiguous_{other.is_contiguous_} {
+    gpu_init();
+}
+
+template <typename T>
+constexpr TensorImpl<T>::TensorImpl(TensorImpl<T> &&other) noexcept
+    : data_{other.data_}, rank_{other.rank_}, size_{other.size_}, dims_{std::move(other.dims_)}, strides_{std::move(other.strides_)},
+      is_contiguous_{other.is_contiguous_} {
+    other.data_ = nullptr;
+    other.rank_ = 0;
+    other.size_ = 0;
+    other.dims_.clear();
+    other.strides_.clear();
+    gpu_init();
+}
+
+template<typename T>
+constexpr TensorImpl<T> &TensorImpl<T>::operator=(TensorImpl<T> const &other) {
+    data_ = other.data_;
+    rank_ = other.rank_;
+    size_ = other.size_;
+    dims_.resize(rank_);
+    strides_.resize(rank_);
+
+    dims_.assign(other.dims_.cbegin(), other.dims_.cend());
+    strides_.assign(other.strides_.cbegin(), other.strides_.cend());
+    is_contiguous_ = other.is_contiguous_;
+    gpu_init();
+}
+
+template<typename T>
+constexpr TensorImpl<T> &TensorImpl<T>::operator=(TensorImpl<T> &&other) {
+    data_          = other.data_;
+    rank_          = other.rank_;
+    size_          = other.size_;
+    dims_          = std::move(other.dims_);
+    strides_       = std::move(other.strides_);
+    is_contiguous_ = other.is_contiguous_;
+
+    other.data_ = nullptr;
+    other.rank_ = 0;
+    other.size_ = 0;
+    other.dims_.clear();
+    other.strides_.clear();
+    gpu_init();
+}
+
+template<typename T>
+constexpr TensorImpl<T>::~TensorImpl() noexcept {
+    data_ = nullptr;
+    rank_ = 0;
+    size_ = 0;
+    dims_.clear();
+    strides_.clear();
+#ifdef EINSUMS_COMPUTE_CODE
+    gpu::GPUMemoryTracker::get_singleton().release_handle(gpu_handle_, true);
+#endif
+}
+
+// Now the more useful constructors.
+template<typename T>
+template <ContainerOrInitializer Dims>
+constexpr TensorImpl<T>::TensorImpl(T *data, Dims const &dims, bool row_major = false)
+    : data_{data}, dims_(dims.begin(), dims.end()), strides_(dims.size()), rank_{dims.size()} {
+
+    size_          = dims_to_strides(dims_, strides_, row_major);
+    is_contiguous_ = true;
+}
+
+template<typename T>
+template <ContainerOrInitializer Dims, ContainerOrInitializer Strides>
+constexpr TensorImpl<T>::TensorImpl(T *data, Dims const &dims, Strides const &strides)
+    : data_{data}, dims_(dims.cbegin(), dims.cend()), strides_(strides.begin(), strides.end()), rank_{dims.size()}, size_{1} {
+    for (int i = 0; i < rank_; i++) {
+        size_ *= dims_[i];
+    }
+
+    // Check to see if it is contiguous.
+    if (strides[0] == 1) {
+        size_t expected = 1;
+        for (int i = 0; i < rank_; i++) {
+            if (strides_[i] != expected) {
+                is_contiguous_ = false;
+                break;
+            }
+            expected *= dims_[i];
+        }
+        is_contiguous_ = true;
+    } else if (strides[rank_ - 1] == 1) {
+        size_t expected = 1;
+        for (int i = rank_ - 1; i >= 0; i--) {
+            if (strides_[i] != expected) {
+                is_contiguous_ = false;
+                break;
+            }
+            expected *= dims_[i];
+        }
+        is_contiguous_ = true;
+    } else {
+        is_contiguous_ = false;
+    }
+}
+
+} // namespace detail
+} // namespace einsums

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImplGetters.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImplGetters.hpp
@@ -1,0 +1,73 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <Einsums/BLAS.hpp>
+#include <Einsums/BufferAllocator/BufferAllocator.hpp>
+#include <Einsums/Concepts/Complex.hpp>
+#include <Einsums/Concepts/NamedRequirements.hpp>
+#include <Einsums/Errors/Error.hpp>
+#include <Einsums/Print.hpp>
+#include <Einsums/Tensor/Backends/TensorImpl.hpp>
+#include <Einsums/TensorBase/Common.hpp>
+#include <Einsums/TensorBase/IndexUtilities.hpp>
+#include <Einsums/TypeSupport/Lockable.hpp>
+
+#include <mutex>
+#include <numeric>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#ifdef EINSUMS_COMPUTE_CODE
+#    include <Einsums/GPUMemory/GPUAllocator.hpp>
+#    include <Einsums/GPUMemory/GPUMemoryTracker.hpp>
+#    include <Einsums/GPUMemory/GPUPointer.hpp>
+#    include <Einsums/GPUStreams/GPUStreams.hpp>
+#    include <Einsums/hipBLAS.hpp>
+
+#    include <hip/hip_common.h>
+#    include <hip/hip_complex.h>
+#    include <hip/hip_runtime.h>
+#    include <hip/hip_runtime_api.h>
+#endif
+
+namespace einsums {
+namespace detail {
+
+template <typename T>
+constexpr size_t TensorImpl<T>::dim(int i) const {
+    int temp = i;
+    if (temp < 0) {
+        temp += rank_;
+    }
+
+    if (temp < 0 || temp >= rank_) {
+        EINSUMS_THROW_EXCEPTION(std::out_of_range, "The index passed to dim is out of range! Expected between {} and {}, got {}.", -rank_,
+                                rank_ - 1, i);
+    }
+
+    return dims_[temp];
+}
+
+template <typename T>
+constexpr size_t TensorImpl<T>::stride(int i) const {
+    int temp = i;
+    if (temp < 0) {
+        temp += rank_;
+    }
+
+    if (temp < 0 || temp >= rank_) {
+        EINSUMS_THROW_EXCEPTION(std::out_of_range, "The index passed to stride is out of range! Expected between {} and {}, got {}.",
+                                -rank_, rank_ - 1, i);
+    }
+
+    return strides_[temp];
+}
+
+} // namespace detail
+} // namespace einsums

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImplOperations.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImplOperations.hpp
@@ -1,0 +1,883 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <Einsums/BLAS.hpp>
+#include <Einsums/BufferAllocator/BufferAllocator.hpp>
+#include <Einsums/Concepts/Complex.hpp>
+#include <Einsums/Concepts/NamedRequirements.hpp>
+#include <Einsums/Errors/Error.hpp>
+#include <Einsums/Print.hpp>
+#include <Einsums/Tensor/Backends/TensorImpl.hpp>
+#include <Einsums/TensorBase/Common.hpp>
+#include <Einsums/TensorBase/IndexUtilities.hpp>
+#include <Einsums/TypeSupport/Lockable.hpp>
+
+#include <mutex>
+#include <numeric>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#ifdef EINSUMS_COMPUTE_CODE
+#    include <Einsums/GPUMemory/GPUAllocator.hpp>
+#    include <Einsums/GPUMemory/GPUMemoryTracker.hpp>
+#    include <Einsums/GPUMemory/GPUPointer.hpp>
+#    include <Einsums/GPUStreams/GPUStreams.hpp>
+#    include <Einsums/hipBLAS.hpp>
+
+#    include <hip/hip_common.h>
+#    include <hip/hip_complex.h>
+#    include <hip/hip_runtime.h>
+#    include <hip/hip_runtime_api.h>
+#endif
+
+namespace einsums {
+namespace detail {
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::copy_from_both_contiguous(TensorImpl<TOther> const &other) {
+    if (other.rank() != rank()) {
+        EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+    }
+
+    if (other.dims() != dims()) {
+        EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+    }
+
+    if (other.data() == data() || data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    EINSUMS_OMP_PARALLEL_FOR_SIMD
+    for (size_t i = 0; i < elems; i++) {
+        if constexpr (!IsComplexV<T>) {
+            data_[i] = T{std::real(other.data_[i])};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            auto val = other.data_[i];
+            data_[i] = T{std::real(val), std::imag(val)};
+        } else {
+            data_[i] = T{other.data_[i]};
+        }
+    }
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::copy_from(TensorImpl<TOther> const &other) {
+    if (other.is_contiguous() && is_contiguous()) {
+        copy_from_assume_contiguous(other);
+        return;
+    }
+
+    if (other.rank() != rank()) {
+        EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+    }
+
+    if (other.dims() != dims()) {
+        EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+    }
+
+    if (other.data() == data() || data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    BufferVector<size_t> index_strides;
+
+    dims_to_strides(dims(), index_strides);
+
+    EINSUMS_OMP_PARALLEL_FOR
+    for (size_t i = 0; i < elems; i++) {
+        size_t this_sentinel, other_sentinel;
+
+        sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
+
+        if constexpr (!IsComplexV<T>) {
+            data_[this_sentinel] = T{std::real(other.data_[other_sentinel])};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            auto val             = other.data_[other_sentinel];
+            data_[this_sentinel] = T{std::real(val), std::imag(val)};
+        } else {
+            data_[this_sentinel] = T{other.data_[other_sentinel]};
+        }
+    }
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::add_assign_both_contiguous(TensorImpl<TOther> const &other) {
+    if (other.rank() != rank()) {
+        EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+    }
+
+    if (other.dims() != dims()) {
+        EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+    }
+
+    if (other.data() == data() || data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    if constexpr (std::is_same_v<TOther, T>) {
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_) && singleton.handle_is_allocated(other.gpu_handle_)) {
+            auto [this_ptr, test]   = singleton.get_pointer(gpu_handle_, size());
+            auto [other_ptr, test2] = singleton.get_pointer(other.gpu_handle_, size());
+            auto *one               = gpu::detail::Einsums_GPUMemory_vars::get_singleton().get_const(T{1.0});
+            hipblas_catch(hipblasSaxpy(gpu::get_blas_handle(), size(), one, other_ptr, 1, this_ptr, 1));
+
+            gpu::stream_wait();
+
+            copy_from_gpu(this_ptr);
+
+            singleton.release_handle(gpu_handle_);
+            singleton.release_handle(other.gpu_handle_);
+        } else {
+#endif
+            blas::axpy(size(), T{1.0}, other.data_, 1, data_, 1);
+#ifdef EINSUMS_COMPUTE_CODE
+        }
+#endif
+    } else {
+
+        size_t elems = size();
+
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        for (size_t i = 0; i < elems; i++) {
+            if constexpr (!IsComplexV<T>) {
+                data_[i] += T{std::real(other.data_[i])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val = other.data_[i];
+                data_[i] += T{std::real(val), std::imag(val)};
+            } else {
+                data_[i] += T{other.data_[i]};
+            }
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::add_assign(TensorImpl<TOther> const &other) {
+    if (other.is_contiguous() && is_contiguous()) {
+        add_assign_both_contiguous(other);
+        return;
+    }
+
+    if (other.rank() != rank()) {
+        EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+    }
+
+    if (other.dims() != dims()) {
+        EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+    }
+
+    if (other.data() == data() || data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    BufferVector<size_t> index_strides;
+
+    dims_to_strides(dims(), index_strides);
+
+    EINSUMS_OMP_PARALLEL_FOR
+    for (size_t i = 0; i < elems; i++) {
+        size_t this_sentinel, other_sentinel;
+
+        sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
+
+        if constexpr (!IsComplexV<T>) {
+            data_[this_sentinel] += T{std::real(other.data_[other_sentinel])};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            auto val = other.data_[other_sentinel];
+            data_[this_sentinel] += T{std::real(val), std::imag(val)};
+        } else {
+            data_[this_sentinel] += T{other.data_[other_sentinel]};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::sub_assign_both_contiguous(TensorImpl<TOther> const &other) {
+    if (other.rank() != rank()) {
+        EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+    }
+
+    if (other.dims() != dims()) {
+        EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+    }
+
+    if (other.data() == data() || data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    if constexpr (std::is_same_v<TOther, T>) {
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_) && singleton.handle_is_allocated(other.gpu_handle_)) {
+            auto [this_ptr, test]   = singleton.get_pointer(gpu_handle_, size());
+            auto [other_ptr, test2] = singleton.get_pointer(other.gpu_handle_, size());
+            auto *negative_one      = gpu::detail::Einsums_GPUMemory_vars::get_singleton().get_const(T{-1.0});
+            hipblas_catch(hipblasSaxpy(gpu::get_blas_handle(), size(), negative_one, other_ptr, 1, this_ptr, 1));
+
+            gpu::stream_wait();
+
+            copy_from_gpu(this_ptr);
+
+            singleton.release_handle(gpu_handle_);
+            singleton.release_handle(other.gpu_handle_);
+        } else {
+#endif
+            blas::axpy(size(), T{-1.0}, other.data_, 1, data_, 1);
+#ifdef EINSUMS_COMPUTE_CODE
+        }
+#endif
+    } else {
+
+        size_t elems = size();
+
+        EINSUMS_OMP_PARALLEL_FOR_SIMD
+        for (size_t i = 0; i < elems; i++) {
+            if constexpr (!IsComplexV<T>) {
+                data_[i] -= T{std::real(other.data_[i])};
+            } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+                auto val = other.data_[i];
+                data_[i] -= T{std::real(val), std::imag(val)};
+            } else {
+                data_[i] -= T{other.data_[i]};
+            }
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::sub_assign(TensorImpl<TOther> const &other) {
+    if (other.is_contiguous() && is_contiguous()) {
+        sub_assign_both_contiguous(other);
+        return;
+    }
+
+    if (other.rank() != rank()) {
+        EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+    }
+
+    if (other.dims() != dims()) {
+        EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+    }
+
+    if (other.data() == data() || data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    BufferVector<size_t> index_strides;
+
+    dims_to_strides(dims(), index_strides);
+
+    EINSUMS_OMP_PARALLEL_FOR
+    for (size_t i = 0; i < elems; i++) {
+        size_t this_sentinel, other_sentinel;
+
+        sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
+
+        if constexpr (!IsComplexV<T>) {
+            data_[this_sentinel] -= T{std::real(other.data_[other_sentinel])};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            auto val = other.data_[other_sentinel];
+            data_[this_sentinel] -= T{std::real(val), std::imag(val)};
+        } else {
+            data_[this_sentinel] -= T{other.data_[other_sentinel]};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::mul_assign_both_contiguous(TensorImpl<TOther> const &other) {
+    if (other.rank() != rank()) {
+        EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+    }
+
+    if (other.dims() != dims()) {
+        EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+    }
+
+    if (other.data() == data() || data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    EINSUMS_OMP_PARALLEL_FOR_SIMD
+    for (size_t i = 0; i < elems; i++) {
+        if constexpr (!IsComplexV<T>) {
+            data_[i] *= T{std::real(other.data_[i])};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            auto val = other.data_[i];
+            data_[i] *= T{std::real(val), std::imag(val)};
+        } else {
+            data_[i] *= T{other.data_[i]};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::mul_assign(TensorImpl<TOther> const &other) {
+    if (other.is_contiguous() && is_contiguous()) {
+        mul_assign_both_contiguous(other);
+        return;
+    }
+
+    if (other.rank() != rank()) {
+        EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+    }
+
+    if (other.dims() != dims()) {
+        EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+    }
+
+    if (other.data() == data() || data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    BufferVector<size_t> index_strides;
+
+    dims_to_strides(dims(), index_strides);
+
+    EINSUMS_OMP_PARALLEL_FOR
+    for (size_t i = 0; i < elems; i++) {
+        size_t this_sentinel, other_sentinel;
+
+        sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
+
+        if constexpr (!IsComplexV<T>) {
+            data_[this_sentinel] *= T{std::real(other.data_[other_sentinel])};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            auto val = other.data_[other_sentinel];
+            data_[this_sentinel] *= T{std::real(val), std::imag(val)};
+        } else {
+            data_[this_sentinel] *= T{other.data_[other_sentinel]};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::div_assign_both_contiguous(TensorImpl<TOther> const &other) {
+    if (other.rank() != rank()) {
+        EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+    }
+
+    if (other.dims() != dims()) {
+        EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+    }
+
+    if (other.data() == data() || data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    EINSUMS_OMP_PARALLEL_FOR_SIMD
+    for (size_t i = 0; i < elems; i++) {
+        if constexpr (!IsComplexV<T>) {
+            data_[i] /= T{std::real(other.data_[i])};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            auto val = other.data_[i];
+            data_[i] /= T{std::real(val), std::imag(val)};
+        } else {
+            data_[i] /= T{other.data_[i]};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::div_assign(TensorImpl<TOther> const &other) {
+    if (other.is_contiguous() && is_contiguous()) {
+        div_assign_both_contiguous(other);
+        return;
+    }
+
+    if (other.rank() != rank()) {
+        EINSUMS_THROW_EXCEPTION(rank_error, "Can only copy data between tensors of the same rank!");
+    }
+
+    if (other.dims() != dims()) {
+        EINSUMS_THROW_EXCEPTION(dimension_error, "Can only copy data between tensors with the same dimensions!");
+    }
+
+    if (other.data() == data() || data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    BufferVector<size_t> index_strides;
+
+    dims_to_strides(dims(), index_strides);
+
+    EINSUMS_OMP_PARALLEL_FOR
+    for (size_t i = 0; i < elems; i++) {
+        size_t this_sentinel, other_sentinel;
+
+        sentinel_to_sentinels(i, index_strides, strides(), this_sentinel, other.strides(), other_sentinel);
+
+        if constexpr (!IsComplexV<T>) {
+            data_[this_sentinel] /= T{std::real(other.data_[other_sentinel])};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            auto val = other.data_[other_sentinel];
+            data_[this_sentinel] /= T{std::real(val), std::imag(val)};
+        } else {
+            data_[this_sentinel] /= T{other.data_[other_sentinel]};
+        }
+    }
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::add_assign_scalar_contiguous(TOther value) {
+    if (data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    EINSUMS_OMP_PARALLEL_FOR_SIMD
+    for (size_t i = 0; i < elems; i++) {
+        if constexpr (!IsComplexV<T>) {
+            data_[i] += T{value};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            data_[i] += T{std::real(value), std::imag(value)};
+        } else {
+            data_[i] += T{value};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::add_assign_scalar(TOther value) {
+    if (is_contiguous()) {
+        add_assign_scalar_contiguous(value);
+        return;
+    }
+
+    if (data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    BufferVector<size_t> index_strides;
+
+    dims_to_strides(dims(), index_strides);
+
+    EINSUMS_OMP_PARALLEL_FOR
+    for (size_t i = 0; i < elems; i++) {
+        size_t this_sentinel;
+
+        sentinel_to_sentinels(i, index_strides, strides(), this_sentinel);
+
+        if constexpr (!IsComplexV<T>) {
+            data_[this_sentinel] += T{value};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            data_[this_sentinel] += T{std::real(value), std::imag(value)};
+        } else {
+            data_[this_sentinel] += T{value};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::sub_assign_scalar_contiguous(TOther value) {
+    if (data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    EINSUMS_OMP_PARALLEL_FOR_SIMD
+    for (size_t i = 0; i < elems; i++) {
+        if constexpr (!IsComplexV<T>) {
+            data_[i] -= T{value};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            data_[i] -= T{std::real(value), std::imag(value)};
+        } else {
+            data_[i] -= T{value};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::sub_assign_scalar(TOther value) {
+    if (is_contiguous()) {
+        sub_assign_scalar_contiguous(value);
+        return;
+    }
+
+    if (data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    BufferVector<size_t> index_strides;
+
+    dims_to_strides(dims(), index_strides);
+
+    EINSUMS_OMP_PARALLEL_FOR
+    for (size_t i = 0; i < elems; i++) {
+        size_t this_sentinel;
+
+        sentinel_to_sentinels(i, index_strides, strides(), this_sentinel);
+
+        if constexpr (!IsComplexV<T>) {
+            data_[this_sentinel] -= T{value};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            data_[this_sentinel] -= T{std::real(value), std::imag(value)};
+        } else {
+            data_[this_sentinel] -= T{value};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::mul_assign_scalar_contiguous(TOther value) {
+    if (data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+    if constexpr (std::is_same_v<T, TOther>) {
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            size_t             value_handle = singleton.create_handle();
+            gpu::GPUPointer<T> value_ptr    = singleton.get_pointer<T>(value_handle, 1);
+
+            gpu::GPUPointer<T> self_ptr = singleton.get_pointer(gpu_handle_, size());
+
+            hip_catch(hipMemcpy(value_ptr, (void *)&value, sizeof(TOther), hipMemcpyHostToDevice));
+
+            blas::gpu::scal(gpu::get_blas_handle(), size(), (T *)value_ptr, self_ptr, 1);
+
+            singleton.release_handle(value_handle);
+            singleton.release_handle(gpu_handle_);
+        } else {
+#endif
+            blas::scal(size(), value, data_, 1);
+#ifdef EINSUMS_COMPUTE_CODE
+        }
+#endif
+    }
+
+    size_t elems = size();
+
+    EINSUMS_OMP_PARALLEL_FOR_SIMD
+    for (size_t i = 0; i < elems; i++) {
+        if constexpr (!IsComplexV<T>) {
+            data_[i] *= T{value};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            data_[i] *= T{std::real(value), std::imag(value)};
+        } else {
+            data_[i] *= T{value};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::mul_assign_scalar(TOther value) {
+    if (is_contiguous()) {
+        mul_assign_scalar_contiguous(value);
+        return;
+    }
+
+    if (data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    BufferVector<size_t> index_strides;
+
+    dims_to_strides(dims(), index_strides);
+
+    EINSUMS_OMP_PARALLEL_FOR
+    for (size_t i = 0; i < elems; i++) {
+        size_t this_sentinel;
+
+        sentinel_to_sentinels(i, index_strides, strides(), this_sentinel);
+
+        if constexpr (!IsComplexV<T>) {
+            data_[this_sentinel] *= T{value};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            data_[this_sentinel] *= T{std::real(value), std::imag(value)};
+        } else {
+            data_[this_sentinel] *= T{value};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::div_assign_scalar_contiguous(TOther value) {
+    if (data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+    if constexpr (std::is_same_v<T, TOther>) {
+#ifdef EINSUMS_COMPUTE_CODE
+        auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+        if (singleton.handle_is_allocated(gpu_handle_)) {
+            size_t             value_handle = singleton.create_handle();
+            gpu::GPUPointer<T> value_ptr    = singleton.get_pointer<T>(value_handle, 1);
+
+            gpu::GPUPointer<T> self_ptr = singleton.get_pointer(gpu_handle_, size());
+
+            T temp_val = T{1.0} / value;
+
+            hip_catch(hipMemcpy(value_ptr, (void *)&temp_val, sizeof(TOther), hipMemcpyHostToDevice));
+
+            blas::gpu::scal(gpu::get_blas_handle(), size(), (T *)value_ptr, self_ptr, 1);
+
+            singleton.release_handle(value_handle);
+            singleton.release_handle(gpu_handle_);
+        } else {
+#endif
+            blas::scal(size(), T{1.0} / value, data_, 1);
+#ifdef EINSUMS_COMPUTE_CODE
+        }
+#endif
+    }
+
+    size_t elems = size();
+
+    EINSUMS_OMP_PARALLEL_FOR_SIMD
+    for (size_t i = 0; i < elems; i++) {
+        if constexpr (!IsComplexV<T>) {
+            data_[i] /= T{value};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            data_[i] /= T{std::real(value), std::imag(value)};
+        } else {
+            data_[i] /= T{value};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+template <typename T>
+template <typename TOther>
+void TensorImpl<T>::div_assign_scalar(TOther value) {
+    if (is_contiguous()) {
+        div_assign_scalar_contiguous(value);
+        return;
+    }
+
+    if (data() == nullptr) {
+        // Don't copy.
+        return;
+    }
+
+    size_t elems = size();
+
+    BufferVector<size_t> index_strides;
+
+    dims_to_strides(dims(), index_strides);
+
+    EINSUMS_OMP_PARALLEL_FOR
+    for (size_t i = 0; i < elems; i++) {
+        size_t this_sentinel;
+
+        sentinel_to_sentinels(i, index_strides, strides(), this_sentinel);
+
+        if constexpr (!IsComplexV<T>) {
+            data_[this_sentinel] /= T{value};
+        } else if constexpr (IsComplexV<T> && IsComplexV<TOther> && !std::is_same_v<T, TOther>) {
+            data_[this_sentinel] /= T{std::real(value), std::imag(value)};
+        } else {
+            data_[this_sentinel] /= T{value};
+        }
+    }
+
+#ifdef EINSUMS_COMPUTE_CODE
+    auto &singleton = gpu::GPUMemoryTracker::get_singleton();
+    if (singleton.handle_is_allocated(gpu_handle_)) {
+        auto [this_ptr, test] = singleton.get_pointer(gpu_handle_, size());
+        copy_to_gpu(this_ptr);
+        singleton.release_handle(gpu_handle_);
+    }
+#endif
+}
+
+} // namespace detail
+} // namespace einsums

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImplSubscript.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/Backends/TensorImplSubscript.hpp
@@ -1,0 +1,431 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <Einsums/BLAS.hpp>
+#include <Einsums/BufferAllocator/BufferAllocator.hpp>
+#include <Einsums/Concepts/Complex.hpp>
+#include <Einsums/Concepts/NamedRequirements.hpp>
+#include <Einsums/Errors/Error.hpp>
+#include <Einsums/Print.hpp>
+#include <Einsums/Tensor/Backends/TensorImpl.hpp>
+#include <Einsums/TensorBase/Common.hpp>
+#include <Einsums/TensorBase/IndexUtilities.hpp>
+#include <Einsums/TypeSupport/Lockable.hpp>
+
+#include <mutex>
+#include <numeric>
+#include <stdexcept>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+#ifdef EINSUMS_COMPUTE_CODE
+#    include <Einsums/GPUMemory/GPUAllocator.hpp>
+#    include <Einsums/GPUMemory/GPUMemoryTracker.hpp>
+#    include <Einsums/GPUMemory/GPUPointer.hpp>
+#    include <Einsums/GPUStreams/GPUStreams.hpp>
+#    include <Einsums/hipBLAS.hpp>
+
+#    include <hip/hip_common.h>
+#    include <hip/hip_complex.h>
+#    include <hip/hip_runtime.h>
+#    include <hip/hip_runtime_api.h>
+#endif
+
+namespace einsums {
+namespace detail {
+
+// Indexed data retrieval.
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr T *TensorImpl<T>::data_no_check(MultiIndex &&...index) {
+    return data_no_check(std::make_tuple(std::forward<MultiIndex>(index)...));
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr T *TensorImpl<T>::data_no_check(std::tuple<MultiIndex...> const &index) {
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to data!");
+    }
+
+    size_t offset = 0;
+    for_sequence<sizeof...(MultiIndex)>([&offset, &index, this](size_t n) { offset += std::get<n>(index) * strides_[n]; });
+
+    return data_ + offset;
+}
+
+template <typename T>
+template <ContainerOrInitializer MultiIndex>
+constexpr T *TensorImpl<T>::data_no_check(MultiIndex const &index) {
+    if (index.size() > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices in the container passed to data!");
+    }
+
+    return data_ + std::inner_product(index.begin(), index.end(), strides_.cbegin(), 0);
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr T const *TensorImpl<T>::data_no_check(MultiIndex &&...index) const {
+    return data_no_check(std::make_tuple(std::forward<MultiIndex>(index)...));
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr T const *TensorImpl<T>::data_no_check(std::tuple<MultiIndex...> const &index) const {
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to data!");
+    }
+
+    size_t offset = 0;
+    for_sequence<sizeof...(MultiIndex)>([&offset, &index, this](size_t n) { offset += std::get<n>(index) * strides_[n]; });
+
+    return data_ + offset;
+}
+
+template <typename T>
+template <ContainerOrInitializer MultiIndex>
+constexpr T const *TensorImpl<T>::data_no_check(MultiIndex const &index) const {
+    if (index.size() > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices in the container passed to data!");
+    }
+
+    return data_ + std::inner_product(index.begin(), index.end(), strides_.cbegin(), 0);
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr T *TensorImpl<T>::data(MultiIndex &&...index) {
+    return data(std::make_tuple(std::forward<MultiIndex>(index)...));
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr T *TensorImpl<T>::data(std::tuple<MultiIndex...> const &index) {
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to data!");
+    }
+
+    size_t offset = 0;
+    for_sequence<sizeof...(MultiIndex)>(
+        [&offset, &index, this](size_t n) { offset += adjust_index(std::get<n>(index), dims_[n], n) * strides_[n]; });
+
+    return data_ + offset;
+}
+
+template <typename T>
+template <ContainerOrInitializer MultiIndex>
+constexpr T *TensorImpl<T>::data(MultiIndex const &index) {
+    if (index.size() > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices in the container passed to data!");
+    }
+
+    size_t offset = 0;
+
+    for (int i = 0; i < index.size(); i++) {
+        offset += adjust_index(index[i], dims_[i], i) * strides_[i];
+    }
+
+    return data_ + offset;
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr T const *TensorImpl<T>::data(MultiIndex &&...index) const {
+    return data(std::make_tuple(std::forward<MultiIndex>(index)...));
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr T const *TensorImpl<T>::data(std::tuple<MultiIndex...> const &index) const {
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to data!");
+    }
+
+    size_t offset = 0;
+    for_sequence<sizeof...(MultiIndex)>(
+        [&offset, &index, this](size_t n) { offset += adjust_index(std::get<n>(index), dims_[n], n) * strides_[n]; });
+
+    return data_ + offset;
+}
+
+template <typename T>
+template <ContainerOrInitializer MultiIndex>
+constexpr T const *TensorImpl<T>::data(MultiIndex const &index) const {
+    if (index.size() > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices in the container passed to data!");
+    }
+
+    size_t offset = 0;
+
+    for (int i = 0; i < index.size(); i++) {
+        offset += adjust_index(index[i], dims_[i], i) * strides_[i];
+    }
+
+    return data_ + offset;
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr TensorImpl<T>::ReferenceType TensorImpl<T>::subscript_no_check(MultiIndex &&...index) {
+    if (sizeof...(MultiIndex) < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data_no_check(std::forward<MultiIndex>(index)...);
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr TensorImpl<T>::ReferenceType TensorImpl<T>::subscript_no_check(std::tuple<MultiIndex...> const &index) {
+    if (sizeof...(MultiIndex) < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data_no_check(index);
+}
+
+template <typename T>
+template <ContainerOrInitializer Index>
+constexpr TensorImpl<T>::ReferenceType TensorImpl<T>::subscript_no_check(Index const &index) {
+    if (index.size() < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (index.size() > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data_no_check(index);
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr TensorImpl<T>::ConstReferenceType TensorImpl<T>::subscript_no_check(MultiIndex &&...index) const {
+    if (sizeof...(MultiIndex) < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data_no_check(std::forward<MultiIndex>(index)...);
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr TensorImpl<T>::ConstReferenceType TensorImpl<T>::subscript_no_check(std::tuple<MultiIndex...> const &index) const {
+    if (sizeof...(MultiIndex) < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data_no_check(index);
+}
+
+template <typename T>
+template <ContainerOrInitializer Index>
+constexpr TensorImpl<T>::ConstReferenceType TensorImpl<T>::subscript_no_check(Index const &index) const {
+    if (index.size() < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (index.size() > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data_no_check(index);
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr TensorImpl<T>::ReferenceType TensorImpl<T>::subscript(MultiIndex &&...index) {
+    if (sizeof...(MultiIndex) < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data(std::forward<MultiIndex>(index)...);
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr TensorImpl<T>::ReferenceType TensorImpl<T>::subscript(std::tuple<MultiIndex...> const &index) {
+    if (sizeof...(MultiIndex) < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data(index);
+}
+
+template <typename T>
+template <ContainerOrInitializer Index>
+constexpr TensorImpl<T>::ReferenceType TensorImpl<T>::subscript(Index const &index) {
+    if (index.size() < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (index.size() > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data(index);
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr TensorImpl<T>::ConstReferenceType TensorImpl<T>::subscript(MultiIndex &&...index) const {
+    if (sizeof...(MultiIndex) < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data(std::forward<MultiIndex>(index)...);
+}
+
+template <typename T>
+template <std::integral... MultiIndex>
+constexpr TensorImpl<T>::ConstReferenceType TensorImpl<T>::subscript(std::tuple<MultiIndex...> const &index) const {
+    if (sizeof...(MultiIndex) < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (sizeof...(MultiIndex) > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data(index);
+}
+
+template <typename T>
+template <ContainerOrInitializer Index>
+constexpr TensorImpl<T>::ConstReferenceType TensorImpl<T>::subscript(Index const &index) const {
+    if (index.size() < rank_) {
+        EINSUMS_THROW_EXCEPTION(not_enough_args, "Not enough indices passed to subscript tensor!");
+    }
+    if (index.size() > rank_) {
+        EINSUMS_THROW_EXCEPTION(too_many_args, "Too many indices passed to subscript tensor!");
+    }
+    return *data(index);
+}
+
+// View creation.
+template <typename T>
+template <typename... MultiIndex>
+    requires(!std::is_integral_v<MultiIndex> || ... || false)
+constexpr TensorImpl<T> TensorImpl<T>::subscript_no_check(MultiIndex &&...index) {
+    BufferVector<size_t> out_dims{}, out_strides{};
+
+    out_dims.reserve(rank_);
+    out_strides.reserve(rank_);
+
+    size_t offset = compute_view<false, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
+
+    return TensorImpl<T>(data_ + offset, out_dims, out_strides);
+}
+
+template <typename T>
+template <typename... MultiIndex>
+    requires(!std::is_integral_v<MultiIndex> || ... || false)
+constexpr TensorImpl<T> TensorImpl<T>::subscript_no_check(std::tuple<MultiIndex...> const &index) {
+    BufferVector<size_t> out_dims{}, out_strides{};
+
+    out_dims.reserve(rank_);
+    out_strides.reserve(rank_);
+
+    size_t offset = compute_view<false, 0>(out_dims, out_strides, index);
+
+    return TensorImpl<T>(data_ + offset, out_dims, out_strides);
+}
+
+template <typename T>
+template <typename... MultiIndex>
+    requires(!std::is_integral_v<MultiIndex> || ... || false)
+constexpr TensorImpl<T> const TensorImpl<T>::subscript_no_check(MultiIndex &&...index) const {
+    BufferVector<size_t> out_dims{}, out_strides{};
+
+    out_dims.reserve(rank_);
+    out_strides.reserve(rank_);
+
+    size_t offset = compute_view<false, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
+
+    return TensorImpl<T>(data_ + offset, out_dims, out_strides);
+}
+
+template <typename T>
+template <typename... MultiIndex>
+    requires(!std::is_integral_v<MultiIndex> || ... || false)
+constexpr TensorImpl<T> const TensorImpl<T>::subscript_no_check(std::tuple<MultiIndex...> const &index) const {
+    BufferVector<size_t> out_dims{}, out_strides{};
+
+    out_dims.reserve(rank_);
+    out_strides.reserve(rank_);
+
+    size_t offset = compute_view<false, 0>(out_dims, out_strides, index);
+
+    return TensorImpl<T>(data_ + offset, out_dims, out_strides);
+}
+
+template <typename T>
+template <typename... MultiIndex>
+    requires(!std::is_integral_v<MultiIndex> || ... || false)
+constexpr TensorImpl<T> TensorImpl<T>::subscript(MultiIndex &&...index) {
+    BufferVector<size_t> out_dims{}, out_strides{};
+
+    out_dims.reserve(rank_);
+    out_strides.reserve(rank_);
+
+    size_t offset = compute_view<true, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
+
+    return TensorImpl<T>(data_ + offset, out_dims, out_strides);
+}
+
+template <typename T>
+template <typename... MultiIndex>
+    requires(!std::is_integral_v<MultiIndex> || ... || false)
+constexpr TensorImpl<T> TensorImpl<T>::subscript(std::tuple<MultiIndex...> const &index) {
+    BufferVector<size_t> out_dims{}, out_strides{};
+
+    out_dims.reserve(rank_);
+    out_strides.reserve(rank_);
+
+    size_t offset = compute_view<true, 0>(out_dims, out_strides, index);
+
+    return TensorImpl<T>(data_ + offset, out_dims, out_strides);
+}
+
+template <typename T>
+template <typename... MultiIndex>
+    requires(!std::is_integral_v<MultiIndex> || ... || false)
+constexpr TensorImpl<T> const TensorImpl<T>::subscript(MultiIndex &&...index) const {
+    BufferVector<size_t> out_dims{}, out_strides{};
+
+    out_dims.reserve(rank_);
+    out_strides.reserve(rank_);
+
+    size_t offset = compute_view<true, 0>(out_dims, out_strides, std::forward<MultiIndex>(index)...);
+
+    return TensorImpl<T>(data_ + offset, out_dims, out_strides);
+}
+
+template <typename T>
+template <typename... MultiIndex>
+    requires(!std::is_integral_v<MultiIndex> || ... || false)
+constexpr TensorImpl<T> const TensorImpl<T>::subscript(std::tuple<MultiIndex...> const &index) const {
+    BufferVector<size_t> out_dims{}, out_strides{};
+
+    out_dims.reserve(rank_);
+    out_strides.reserve(rank_);
+
+    size_t offset = compute_view<true, 0>(out_dims, out_strides, index);
+
+    return TensorImpl<T>(data_ + offset, out_dims, out_strides);
+}
+} // namespace detail
+} // namespace einsums

--- a/libs/Einsums/Tensor/include/Einsums/Tensor/TensorForward.hpp
+++ b/libs/Einsums/Tensor/include/Einsums/Tensor/TensorForward.hpp
@@ -9,6 +9,7 @@
 
 #include <cstddef>
 #include <vector>
+#include "Einsums/BufferAllocator/BufferAllocator.hpp"
 
 namespace einsums {
 
@@ -83,7 +84,7 @@ struct DiskView;
 template <typename T, size_t Rank>
 struct DiskTensor;
 
-template <typename T>
+template <typename T, typename Alloc = BufferAllocator<T>>
 struct RuntimeTensor;
 
 template <typename T>

--- a/libs/Einsums/TensorBase/src/IndexUtilities.cpp
+++ b/libs/Einsums/TensorBase/src/IndexUtilities.cpp
@@ -4,16 +4,3 @@
 //----------------------------------------------------------------------------------------------
 
 #include <Einsums/TensorBase/IndexUtilities.hpp>
-
-EINSUMS_EXPORT size_t einsums::dims_to_strides(std::vector<size_t> const &dims, std::vector<size_t> &out) {
-    size_t stride = 1;
-
-    out.resize(dims.size());
-
-    for (int i = dims.size() - 1; i >= 0; i--) {
-        out[i] = stride;
-        stride *= dims[i];
-    }
-
-    return stride;
-}

--- a/libs/Einsums/TypeSupport/CMakeLists.txt
+++ b/libs/Einsums/TypeSupport/CMakeLists.txt
@@ -14,6 +14,8 @@ set(TypeSupportHeaders
     Einsums/TypeSupport/TypeName.hpp
     Einsums/TypeSupport/Lockable.hpp
     Einsums/TypeSupport/Singleton.hpp
+    Einsums/TypeSupport/TypeSwitch.hpp
+    Einsums/TypeSupport/SizeOf.hpp
 )
 
 set(TypeSupportSources)

--- a/libs/Einsums/TypeSupport/include/Einsums/TypeSupport/Observable.hpp
+++ b/libs/Einsums/TypeSupport/include/Einsums/TypeSupport/Observable.hpp
@@ -11,7 +11,6 @@
 #include <list>
 #include <mutex>
 #include <thread>
-#include <vector>
 
 namespace einsums {
 

--- a/libs/Einsums/TypeSupport/include/Einsums/TypeSupport/SizeOf.hpp
+++ b/libs/Einsums/TypeSupport/include/Einsums/TypeSupport/SizeOf.hpp
@@ -1,0 +1,40 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+namespace einsums {
+
+template <typename T>
+struct SizeOf {
+    constexpr static size_t value = sizeof(T);
+};
+
+template <>
+struct SizeOf<void> {
+    constexpr static size_t value = 1;
+};
+
+template <>
+struct SizeOf<void const> {
+    constexpr static size_t value = 1;
+};
+
+/**
+ * @property SizeOf
+ *
+ * @brief Provides extended @c sizeof functionality.
+ *
+ * Because @c sizeof(void) is an invalid statement, this gives a value for it. In particular,
+ * since @c void is used for typeless data, we generally want it to have a size of one byte,
+ * especially for anything that deals with generic memory manipulations.
+ *
+ * @tparam T The type to measure.
+ */
+template <typename T>
+constexpr size_t SizeOfV = SizeOf<T>::value;
+} // namespace einsums

--- a/libs/Einsums/TypeSupport/include/Einsums/TypeSupport/TypeSwitch.hpp
+++ b/libs/Einsums/TypeSupport/include/Einsums/TypeSupport/TypeSwitch.hpp
@@ -1,0 +1,111 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <type_traits>
+namespace einsums {
+
+/**
+ * @struct Case<SwitchType, Condition, Result>
+ *
+ * @brief Represents a case for the type switch types.
+ *
+ * @tparam Result If the type given matches the condition, then this will be the result.
+ * @tparam Condition The type or types to compare against.
+ */
+template <typename Result, typename... Condition>
+struct Case {};
+
+/**
+ * @struct Default<Result>
+ *
+ * @brief Represents the default case for the type switch.
+ *
+ * @tparam Result The type to return.
+ */
+template <typename Result>
+struct Default {};
+
+/**
+ * @struct Switch<switch_type, Cases...>
+ *
+ * @brief Like a switch statement but for types.
+ *
+ * Compares the switch type to each of the cases. If the type matches one of the cases, then the resulting type will be
+ * the one contained in that case. There can be a default case as well. If the switch reaches the end without figuring out
+ * a type, then an error will be thrown.
+ *
+ * @tparam switch_type The type to check.
+ * @tparam Cases The cases to check. There may be a default case at the end as well.
+ */
+template <typename switch_type, typename... Cases>
+struct Switch {
+    using type = void;
+    void func() {
+        static_assert(false, "Switch type was given an unrecognized case! Make sure to use the einsums::Case or einsums::Default types "
+                             "when passing to this struct.");
+    }
+};
+
+#ifndef DOXYGEN
+// Case where all cases have failed. This is an error.
+template <typename switch_type>
+struct Switch<switch_type> {
+    using type = void;
+    void func() { static_assert(false, "Switch type reached its end without returning a type! Add a default case or check your cases."); }
+};
+
+// Case where the first check in the first case fails. Repeat the check on the next check in the first case.
+template <typename switch_type, typename Result, typename First, typename... Rest, typename... Cases>
+struct Switch<switch_type, Case<Result, First, Rest...>, Cases...> {
+    using type = typename Switch<switch_type, Case<Result, Rest...>, Cases...>::type;
+};
+
+// Case where the first check in the first case succeeds. Return the result.
+template <typename switch_type, typename Result, typename... Rest, typename... Cases>
+struct Switch<switch_type, Case<Result, switch_type, Rest...>, Cases...> {
+    using type = Result;
+};
+
+// Case where all checks in the first case have failed. Continue to the next case.
+template <typename switch_type, typename Result, typename... Cases>
+struct Switch<switch_type, Case<Result>, Cases...> {
+    using type = typename Switch<switch_type, Cases...>::type;
+};
+
+// Case where we find a default case, but there are still cases after it. This is an error.
+template <typename switch_type, typename Result, typename... Cases>
+struct Switch<switch_type, Default<Result>, Cases...> {
+    using type = void;
+    void func() {
+        static_assert(false, "Switch type was given a default case while there are still other cases to process! Re-order your cases so "
+                             "that the default case, if present, is last.");
+    }
+};
+
+// Default case.
+template <typename switch_type, typename Result>
+struct Switch<switch_type, Default<Result>> {
+    using type = Result;
+};
+#endif
+
+/**
+ * @typedef SwitchT<switch_type, Cases...>
+ *
+ * @brief Like a switch statement but for types.
+ *
+ * Compares the switch type to each of the cases. If the type matches one of the cases, then the resulting type will be
+ * the one contained in that case. There can be a default case as well. If the switch reaches the end without figuring out
+ * a type, then an error will be thrown.
+ *
+ * @tparam switch_type The type to check.
+ * @tparam Cases The cases to check. There may be a default case at the end as well.
+ */
+template <typename... Args>
+using SwitchT = typename Switch<Args...>::type;
+
+} // namespace einsums

--- a/libs/Einsums/hipBLAS/CMakeLists.txt
+++ b/libs/Einsums/hipBLAS/CMakeLists.txt
@@ -1,0 +1,32 @@
+#----------------------------------------------------------------------------------------------
+# Copyright (c) The Einsums Developers. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+#----------------------------------------------------------------------------------------------
+
+if(EINSUMS_WITH_GPU_SUPPORT)
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
+set(hipBLASHeaders Einsums/hipBLAS/hipBLAS.hpp)
+
+set(hipBLASSources )
+
+include(Einsums_AddModule)
+einsums_add_module(
+  Einsums hipBLAS
+  SOURCES ${hipBLASSources}
+  HEADERS ${hipBLASHeaders}
+  DEPENDENCIES 
+  MODULE_DEPENDENCIES Einsums_GPUStreams Einsums_Errors
+  CMAKE_SUBDIRS examples tests
+  BASE_LIBNAME Einsums
+)
+
+
+
+        if(EINSUMS_WITH_CUDA)
+          foreach(f IN LISTS hipBLASSources)
+            set_source_file_properties("src/${f}" PROPERTIES LANGUAGE CUDA)
+          endforeach()
+        endif()
+        endif()
+        

--- a/libs/Einsums/hipBLAS/README.rst
+++ b/libs/Einsums/hipBLAS/README.rst
@@ -1,0 +1,10 @@
+
+..
+    Copyright (c) The Einsums Developers. All rights reserved.
+    Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+=======
+hipBLAS
+=======
+
+This module is part of einsums.

--- a/libs/Einsums/hipBLAS/docs/index.rst
+++ b/libs/Einsums/hipBLAS/docs/index.rst
@@ -1,0 +1,16 @@
+..
+    Copyright (c) The Einsums Developers. All rights reserved.
+    Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+.. _modules_Einsums_hipBLAS:
+
+===============
+Einsums hipBLAS
+===============
+
+.. todo::
+    
+    High-level description of the module.
+
+See the :ref:`API reference <modules_Einsums_hipBLAS_api>` of this module for more
+details.

--- a/libs/Einsums/hipBLAS/examples/CMakeLists.txt
+++ b/libs/Einsums/hipBLAS/examples/CMakeLists.txt
@@ -1,0 +1,41 @@
+#----------------------------------------------------------------------------------------------
+# Copyright (c) The Einsums Developers. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+#----------------------------------------------------------------------------------------------
+
+if(EINSUMS_WITH_EXAMPLES)
+  einsums_add_pseudo_target(Examples.Modules.Einsums.hipBLAS)
+  einsums_add_pseudo_dependencies(Examples.Modules Examples.Modules.Einsums.hipBLAS)
+  if(EINSUMS_WITH_TESTS AND EINSUMS_WITH_TESTS_EXAMPLES)
+    einsums_add_pseudo_target(Tests.Examples.Modules.Einsums.hipBLAS)
+    einsums_add_pseudo_dependencies(
+      Tests.Examples.Modules Tests.Examples.Modules.Einsums.hipBLAS
+    )
+  endif()
+else()
+  return()
+endif()
+
+set(example_programs)
+
+foreach(example_program ${example_programs})
+  set(sources ${example_program}.cpp)
+
+  source_group("Source Files" FILES ${sources})
+
+  # add example executable
+  einsums_add_executable(
+    ${example_program} INTERNAL_FLAGS
+    SOURCES ${sources} ${${example_program}_FLAGS}
+    FOLDER "Examples/Modules/Einsums/hipBLAS"
+    NOINSTALL
+  )
+
+  einsums_add_example_target_dependencies("Modules.Einsums.hipBLAS" ${example_program})
+
+  if(EINSUMS_WITH_TESTS AND EINSUMS_WITH_TESTS_EXAMPLES)
+    einsums_add_example_test(
+      "Modules.Einsums.hipBLAS" ${example_program} ${${example_program}_PARAMETERS}
+    )
+  endif()
+endforeach()

--- a/libs/Einsums/hipBLAS/include/Einsums/hipBLAS/.gitkeep
+++ b/libs/Einsums/hipBLAS/include/Einsums/hipBLAS/.gitkeep
@@ -1,0 +1,1 @@
+# Keep directory around

--- a/libs/Einsums/hipBLAS/include/Einsums/hipBLAS/hipBLAS.hpp
+++ b/libs/Einsums/hipBLAS/include/Einsums/hipBLAS/hipBLAS.hpp
@@ -1,0 +1,155 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <Einsums/Config.hpp>
+
+#include <Einsums/Errors/Errors.hpp>
+#include <Einsums/GPUStreams.hpp>
+
+#include <hip/driver_types.h>
+#include <hip/hip_common.h>
+#include <hip/hip_complex.h>
+#include <hip/hip_runtime_api.h>
+#include <hipblas/hipblas.h>
+#include <hipsolver/hipsolver.h>
+#include <hipsolver/internal/hipsolver-types.h>
+
+namespace einsums {
+
+namespace blas {
+namespace gpu {
+
+template <typename T>
+int iamax(hipblasHandle_t handle, int n, T const *x, int incx);
+
+template <>
+inline int iamax(hipblasHandle_t handle, int n, float const *x, int incx) {
+    int result;
+
+    hipblas_catch(hipblasIsamax(handle, n, x, incx, &result));
+
+    return result;
+}
+
+template <>
+inline int iamax(hipblasHandle_t handle, int n, double const *x, int incx) {
+    int result;
+
+    hipblas_catch(hipblasIdamax(handle, n, x, incx, &result));
+
+    return result;
+}
+
+template <>
+inline int iamax(hipblasHandle_t handle, int n, std::complex<float> const *x, int incx) {
+    int result;
+
+    hipblas_catch(hipblasIcamax(handle, n, (hipblasComplex *)x, incx, &result));
+
+    return result;
+}
+
+template <>
+inline int iamax(hipblasHandle_t handle, int n, std::complex<double> const *x, int incx) {
+    int result;
+
+    hipblas_catch(hipblasIzamax(handle, n, (hipblasDoubleComplex *)x, incx, &result));
+
+    return result;
+}
+
+template <typename T>
+inline int iamin(hipblasHandle_t handle, int n, T const *x, int incx);
+
+template <>
+inline int iamin(hipblasHandle_t handle, int n, float const *x, int incx) {
+    int result;
+
+    hipblas_catch(hipblasIsamin(handle, n, x, incx, &result));
+
+    return result;
+}
+
+template <>
+inline int iamin(hipblasHandle_t handle, int n, double const *x, int incx) {
+    int result;
+
+    hipblas_catch(hipblasIdamin(handle, n, x, incx, &result));
+
+    return result;
+}
+
+template <>
+inline int iamin(hipblasHandle_t handle, int n, std::complex<float> const *x, int incx) {
+    int result;
+
+    hipblas_catch(hipblasIcamin(handle, n, (hipblasComplex *)x, incx, &result));
+
+    return result;
+}
+
+template <>
+inline int iamin(hipblasHandle_t handle, int n, std::complex<double> const *x, int incx) {
+    int result;
+
+    hipblas_catch(hipblasIzamin(handle, n, (hipblasDoubleComplex *)x, incx, &result));
+
+    return result;
+}
+
+template <typename T>
+void axpy(hipblasHandle_t handle, int n, T const *alpha, T const *x, int incx, T *y, int incy);
+
+template <>
+inline void axpy(hipblasHandle_t handle, int n, float const *alpha, float const *x, int incx, float *y, int incy) {
+    hipblas_catch(hipblasSaxpy(handle, n, alpha, x, incx, y, incy));
+}
+
+template <>
+inline void axpy(hipblasHandle_t handle, int n, double const *alpha, double const *x, int incx, double *y, int incy) {
+    hipblas_catch(hipblasDaxpy(handle, n, alpha, x, incx, y, incy));
+}
+
+template <>
+inline void axpy(hipblasHandle_t handle, int n, std::complex<float> const *alpha, std::complex<float> const *x, int incx,
+                 std::complex<float> *y, int incy) {
+    hipblas_catch(hipblasCaxpy(handle, n, (hipblasComplex *)alpha, (hipblasComplex *)x, incx, (hipblasComplex *)y, incy));
+}
+
+template <>
+inline void axpy(hipblasHandle_t handle, int n, std::complex<double> const *alpha, std::complex<double> const *x, int incx,
+                 std::complex<double> *y, int incy) {
+    hipblas_catch(hipblasZaxpy(handle, n, (hipblasDoubleComplex *)alpha, (hipblasDoubleComplex *)x, incx, (hipblasDoubleComplex *)y, incy));
+}
+
+template <typename T>
+void scal(hipblasHandle_t handle, int n, T const *alpha, T *x, int incx);
+
+template <>
+inline void scal(hipblasHandle_t handle, int n, float const *alpha, float *x, int incx) {
+    hipblas_catch(hipblasSscal(handle, n, alpha, x, incx));
+}
+
+template <>
+inline void scal(hipblasHandle_t handle, int n, double const *alpha, double *x, int incx) {
+    hipblas_catch(hipblasDscal(handle, n, alpha, x, incx));
+}
+
+template <>
+inline void scal(hipblasHandle_t handle, int n, std::complex<float> const *alpha, std::complex<float> *x, int incx) {
+    hipblas_catch(hipblasCscal(handle, n, (hipblasComplex *)alpha, (hipblasComplex *)x, incx));
+}
+
+template <>
+inline void scal(hipblasHandle_t handle, int n, std::complex<double> const *alpha, std::complex<double> *x, int incx) {
+    hipblas_catch(hipblasZscal(handle, n, (hipblasDoubleComplex *)alpha, (hipblasDoubleComplex *)x, incx));
+}
+
+} // namespace gpu
+} // namespace blas
+
+} // namespace einsums

--- a/libs/Einsums/hipBLAS/include/Einsums/hipBLAS/hipBLAS.hpp
+++ b/libs/Einsums/hipBLAS/include/Einsums/hipBLAS/hipBLAS.hpp
@@ -7,7 +7,7 @@
 
 #include <Einsums/Config.hpp>
 
-#include <Einsums/Errors/Errors.hpp>
+#include <Einsums/Errors/Error.hpp>
 #include <Einsums/GPUStreams.hpp>
 
 #include <hip/driver_types.h>

--- a/libs/Einsums/hipBLAS/src/.gitkeep
+++ b/libs/Einsums/hipBLAS/src/.gitkeep
@@ -1,0 +1,1 @@
+# Keep directory around

--- a/libs/Einsums/hipBLAS/tests/CMakeLists.txt
+++ b/libs/Einsums/hipBLAS/tests/CMakeLists.txt
@@ -1,0 +1,39 @@
+#----------------------------------------------------------------------------------------------
+# Copyright (c) The Einsums Developers. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+#----------------------------------------------------------------------------------------------
+
+include(Einsums_Message)
+
+if(EINSUMS_WITH_TESTS)
+  if(EINSUMS_WITH_TESTS_UNIT)
+    einsums_add_pseudo_target(Tests.Unit.Modules.Einsums.hipBLAS)
+    einsums_add_pseudo_dependencies(Tests.Unit.Modules Tests.Unit.Modules.Einsums.hipBLAS)
+    add_subdirectory(unit)
+  endif()
+
+  if(EINSUMS_WITH_TESTS_REGRESSIONS)
+    einsums_add_pseudo_target(Tests.Regressions.Modules.Einsums.hipBLAS)
+    einsums_add_pseudo_dependencies(
+      Tests.Regressions.Modules Tests.Regressions.Modules.Einsums.hipBLAS
+    )
+    add_subdirectory(regressions)
+  endif()
+
+  if(EINSUMS_WITH_TESTS_BENCHMARKS)
+    einsums_add_pseudo_target(Tests.Performance.Modules.Einsums.hipBLAS)
+    einsums_add_pseudo_dependencies(
+      Tests.Performance.Modules Tests.Performance.Modules.Einsums.hipBLAS
+    )
+    add_subdirectory(performance)
+  endif()
+
+  if(EINSUMS_WITH_TESTS_HEADERS)
+    einsums_add_header_tests(
+      Modules.Einsums.hipBLAS
+      HEADERS ${hipBLASHeaders}
+      HEADER_ROOT ${PROJECT_SOURCE_DIR}/include
+      DEPENDENCIES Einsums_hipBLAS 
+    )
+  endif()
+endif()

--- a/libs/Einsums/hipBLAS/tests/performance/CMakeLists.txt
+++ b/libs/Einsums/hipBLAS/tests/performance/CMakeLists.txt
@@ -1,0 +1,4 @@
+#----------------------------------------------------------------------------------------------
+# Copyright (c) The Einsums Developers. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+#----------------------------------------------------------------------------------------------

--- a/libs/Einsums/hipBLAS/tests/regressions/CMakeLists.txt
+++ b/libs/Einsums/hipBLAS/tests/regressions/CMakeLists.txt
@@ -1,0 +1,4 @@
+#----------------------------------------------------------------------------------------------
+# Copyright (c) The Einsums Developers. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+#----------------------------------------------------------------------------------------------

--- a/libs/Einsums/hipBLAS/tests/unit/CMakeLists.txt
+++ b/libs/Einsums/hipBLAS/tests/unit/CMakeLists.txt
@@ -1,0 +1,48 @@
+#----------------------------------------------------------------------------------------------
+# Copyright (c) The Einsums Developers. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+#----------------------------------------------------------------------------------------------
+
+#
+# Example of a more involved unit test file that includes standard C++ and a HIP test. Example1.cpp
+# requires an additional library to successfully link. Example2.hip should only run on one thread.
+#
+# set(ExampleTests Example1.cpp Example2.hip )
+#
+# set(Example1_cpp_FLAGS DEPENDENCIES SomeOtherGreatLibrary) set(Example2_hip_PARAMETERS THREADS 1)
+
+# Name of test file. Include .cpp, .hip, etc. extension.
+set(hipBLASTests)
+
+foreach(test ${hipBLASTests})
+  # Extract base name of test Example1.cpp -> Example1, Example.2.hip -> Example
+  get_filename_component(TestName ${test} NAME_WE)
+  # Extract extension of the test Example1.cpp -> .cpp, Example.2.hip -> .2.hip
+  get_filename_component(Extension ${test} EXT)
+
+  # Remove the leading dot and replace any periods with underscores
+  string(SUBSTRING ${Extension} 1 -1 EXT_NO_DOT) # Remove the leading dot
+  string(REPLACE "." "_" TestExtension ${EXT_NO_DOT})
+
+  # Check if the cleaned extension is "cu" or "hip"
+  if(NOT EINSUMS_WITH_GPU_SUPPORT AND (TestExtension STREQUAL "cu" OR TestExtension STREQUAL "hip"))
+    # Skip this iteration
+    continue()
+  endif()
+
+  set(Sources ${test})
+
+  source_group("Source Files" FILES ${Sources})
+
+  einsums_add_executable(
+    ${TestName}_test
+    INTERNAL_FLAGS
+    SOURCES ${Sources}
+    ${${TestName}_${TestExtension}_FLAGS}
+    NOINSTALL
+  )
+
+  einsums_add_unit_test(
+    "Modules.Einsums.hipBLAS" ${TestName} ${${TestName}_${TestExtension}_PARAMETERS}
+  )
+endforeach()

--- a/libs/Einsums/modules.rst
+++ b/libs/Einsums/modules.rst
@@ -41,3 +41,4 @@ Einsums Modules
     /libs/Einsums/TypeSupport/docs/index.rst
     /libs/Einsums/Utilities/docs/index.rst
     /libs/Einsums/Version/docs/index.rst
+    /libs/Einsums/hipBLAS/docs/index.rst


### PR DESCRIPTION
I want to move the tensor code into a separate object so that we don't have to physically copy-paste portions of code and maintain all of those copy-pasted versions. Also, I think internal vector objects should use the buffer allocators.