### PR TITLE
Add the induced 2-norm

### DIFF
--- a/docs/sphinx/changelogs/v2/v2.0.0.rst
+++ b/docs/sphinx/changelogs/v2/v2.0.0.rst
@@ -26,6 +26,7 @@ What's New
       that take plans as inputs.
     * The files are raw binary files to hopefully reduce the file size.
 * Einsums has its own argument parser.
+* `norm` can now handle vectors and can compute the spectral norm.
 
 What's Removed
 --------------

--- a/libs/Einsums/LinearAlgebra/include/Einsums/LinearAlgebra.hpp
+++ b/libs/Einsums/LinearAlgebra/include/Einsums/LinearAlgebra.hpp
@@ -1060,7 +1060,7 @@ enum class Norm : char {
     ONE       = '1', /**< \f$val = norm1(A)\f$, 1-norm of the matrix A (maximum column sum) */
     INFTY     = 'I', /**< \f$val = normI(A)\f$, infinity norm of the matrix A (maximum row sum) */
     FROBENIUS = 'F', /**< \f$val = normF(A)\f$, Frobenius norm of the matrix A (square root of sum of squares). */
-    TWO       = '2'  /**< @f$val = \sqrt{max(\lambda(A^H A))}@f$, norm induced by the 2-norm of a vector. */
+    TWO       = '2'  /**< @f$val = \sqrt{max(\lambda(A^H A))}@f$, norm induced by the 2-norm of a vector. Also called the spectral norm. */
 };
 
 /**

--- a/libs/Einsums/LinearAlgebra/include/Einsums/LinearAlgebra/Base.hpp
+++ b/libs/Einsums/LinearAlgebra/include/Einsums/LinearAlgebra/Base.hpp
@@ -1344,7 +1344,12 @@ auto norm(char norm_type, einsums::detail::TensorImpl<T> const &a) -> RemoveComp
                 return impl_frobenius_norm(a);
             }
         case '2':
-            EINSUMS_THROW_EXCEPTION(not_implemented, "Haven't got around to implementing yet. It should be a simple svd.");
+            if (a.rank() == 1) {
+                return blas::nrm2(a.dim(0), a.data(), a.get_incx());
+            } else {
+                auto result = svd(a, 'n', 'n');
+                return std::get<1>(result)(0);
+            }
         default:
             EINSUMS_THROW_EXCEPTION(enum_error, "The norm type passed to norm is not valid!");
         }
@@ -1366,7 +1371,12 @@ auto norm(char norm_type, einsums::detail::TensorImpl<T> const &a) -> RemoveComp
         case 'F':
             return impl_frobenius_norm(a);
         case '2':
-            EINSUMS_THROW_EXCEPTION(not_implemented, "Haven't got around to implementing yet. It should be a simple svd.");
+            if (a.rank() == 1) {
+                return impl_frobenius_norm(a);
+            } else {
+                EINSUMS_THROW_EXCEPTION(not_implemented, "We haven't implemented the spectral norm for matrices that don't have a LAPACK-"
+                                                         "compatible type. If you need this, reach out to us so we can implement it.");
+            }
         default:
             EINSUMS_THROW_EXCEPTION(enum_error, "The norm type passed to norm is not valid!");
         }

--- a/libs/Einsums/LinearAlgebra/tests/unit/norm.cpp
+++ b/libs/Einsums/LinearAlgebra/tests/unit/norm.cpp
@@ -21,8 +21,6 @@ TEMPLATE_TEST_CASE("Norms", "[linear-algebra]", float, double) {
 
     A.vector_data() = temp;
 
-    println(A);
-
     T result = linear_algebra::norm(linear_algebra::Norm::ONE, A);
 
     if (A.impl().is_row_major()) {

--- a/libs/Einsums/LinearAlgebra/tests/unit/norm.cpp
+++ b/libs/Einsums/LinearAlgebra/tests/unit/norm.cpp
@@ -9,8 +9,8 @@
 
 using namespace einsums;
 
-template <NotComplex T>
-void norm_test() {
+TEMPLATE_TEST_CASE("Norms", "[linear-algebra]", float, double) {
+    using T = TestType;
 
     auto A = create_tensor<T>("a", 9, 9);
 
@@ -21,6 +21,8 @@ void norm_test() {
 
     A.vector_data() = temp;
 
+    println(A);
+
     T result = linear_algebra::norm(linear_algebra::Norm::ONE, A);
 
     if (A.impl().is_row_major()) {
@@ -28,9 +30,24 @@ void norm_test() {
     } else {
         REQUIRE_THAT(result, Catch::Matchers::WithinRel(33.0, 0.1));
     }
-}
 
-TEST_CASE("norm") {
-    norm_test<float>();
-    norm_test<double>();
+    result = linear_algebra::norm(linear_algebra::Norm::INFTY, A);
+
+    if (A.impl().is_row_major()) {
+        REQUIRE_THAT(result, Catch::Matchers::WithinRel(33.0, 0.1));
+    } else {
+        REQUIRE_THAT(result, Catch::Matchers::WithinRel(15.0, 0.1));
+    }
+
+    result = linear_algebra::norm(linear_algebra::Norm::FROBENIUS, A);
+
+    REQUIRE_THAT(result, Catch::Matchers::WithinRel(246.2681465394987, 0.001));
+
+    result = linear_algebra::norm(linear_algebra::Norm::MAXABS, A);
+
+    REQUIRE_THAT(result, Catch::Matchers::WithinRel(12.0, 0.0001));
+
+    result = linear_algebra::norm(linear_algebra::Norm::TWO, A);
+
+    REQUIRE_THAT(result, Catch::Matchers::WithinRel(19.46610381488656, 0.0001));
 }

--- a/libs/Einsums/LinearAlgebra/tests/unit/norm.cpp
+++ b/libs/Einsums/LinearAlgebra/tests/unit/norm.cpp
@@ -41,7 +41,7 @@ TEMPLATE_TEST_CASE("Norms", "[linear-algebra]", float, double) {
 
     result = linear_algebra::norm(linear_algebra::Norm::FROBENIUS, A);
 
-    REQUIRE_THAT(result, Catch::Matchers::WithinRel(246.2681465394987, 0.001));
+    REQUIRE_THAT(result, Catch::Matchers::WithinRel(25.92296279363144, 0.001));
 
     result = linear_algebra::norm(linear_algebra::Norm::MAXABS, A);
 

--- a/libs/EinsumsPy/LinearAlgebra/src/Export.cpp
+++ b/libs/EinsumsPy/LinearAlgebra/src/Export.cpp
@@ -34,6 +34,7 @@ EINSUMS_EXPORT void export_LinearAlgebra(py::module_ &mod) {
         .value("ONE", einsums::linear_algebra::Norm::ONE)
         .value("INFINITY", einsums::linear_algebra::Norm::INFTY)
         .value("FROBENIUS", einsums::linear_algebra::Norm::FROBENIUS)
+        .value("TWO", einsums::linear_algebra::Norm::TWO)
         .export_values();
 
     py::enum_<einsums::linear_algebra::Vectors>(mod, "Vectors")

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -335,6 +335,13 @@ def test_norm(a, b, dtype, array):
     )
     assert ein.core.norm(ein.core.ONE, A) == pytest.approx(np.linalg.norm(A, 1))
     assert ein.core.norm(ein.core.INFINITY, A) == pytest.approx(np.linalg.norm(A, np.inf))
+    maxabs = 0
+    for i in range(a) :
+        for j in range(b) :
+            if abs(A[i, j]) > maxabs :
+                maxabs = abs(A[i, j])
+    assert ein.core.norm(ein.core.MAXABS, A) == pytest.approx(maxabs)
+    assert ein.core.norm(ein.core.TWO, A) == pytest.approx(np.linalg.norm(A, 2))
 
 
 @pytest.mark.parametrize("a", [10, 100])

--- a/tests/test_linalg_views.py
+++ b/tests/test_linalg_views.py
@@ -193,12 +193,14 @@ def test_geev(width, dtype, array):
             ):
                 min_pos = j
         if min_pos != i:
-            expected_vals[i], expected_vals[min_pos] = expected_vals[min_pos], expected_vals[i]
+            expected_vals[i], expected_vals[min_pos] = (
+                expected_vals[min_pos],
+                expected_vals[i],
+            )
             for j in range(width):
                 temp = expected_vecs[j, i]
                 expected_vecs[j, i] = expected_vecs[j, min_pos]
                 expected_vecs[j, min_pos] = temp
-
 
     for i in range(width):
         assert got_vals[i] == pytest.approx(expected_vals[i])
@@ -398,6 +400,19 @@ def test_norm(a, b, dtype, array):
         np.linalg.norm(A_view, np.inf)
     )
 
+    assert ein.core.norm(ein.core.INFINITY, A_view) == pytest.approx(
+        np.linalg.norm(A_view, np.inf)
+    )
+    maxabs = 0
+    for i in range(a):
+        for j in range(b):
+            if abs(A_view[i, j]) > maxabs:
+                maxabs = abs(A_view[i, j])
+    assert ein.core.norm(ein.core.MAXABS, A_view) == pytest.approx(maxabs)
+    assert ein.core.norm(ein.core.TWO, A_view) == pytest.approx(
+        np.linalg.norm(A_view, 2)
+    )
+
 
 @pytest.mark.parametrize("a", [10, 100])
 def test_vec_norm(a, dtype, array):
@@ -519,8 +534,8 @@ def test_nullspace(a, b, dtype, array):
 
     for j in range(Null_expected.shape[1]):
         scale = 1.0
-        for i in range(b) :
-            if Null[i, j] != 0.0 :
+        for i in range(b):
+            if Null[i, j] != 0.0:
                 scale = Null_expected[i, j] / Null[i, j]
                 break
         for i in range(b):
@@ -563,8 +578,8 @@ def test_qr(a, b, dtype, array):
 
     A_test = np.array(Q) @ np.array(R)
 
-    for i in range(a) :
-        for j in range(b) :
+    for i in range(a):
+        for j in range(b):
             assert A_test[i, j] == pytest.approx(A_copy[i, j])
 
 


### PR DESCRIPTION
I don't know why, but LAPACK seems to lack the induced 2-norm for matrices. Perhaps because it can be calculated using `gesvd`. This fills out the main code path for the induced 2-norm. For types that are incompatible with LAPACK, which we don't fully support yet, the code path is empty. We can fill it out when we need it.