### PR TITLE
Change default log level and debugger for release builds.

### DIFF
--- a/devtools/conda-envs/snippets/common.yml
+++ b/devtools/conda-envs/snippets/common.yml
@@ -19,7 +19,7 @@ dependencies:
   - spdlog
   # HDF5
   # * zlib brings headers; hdf5 package only bring libzlib
-  - hdf5
+  - hdf5<2
   - zlib
   - numpy
   - mimalloc

--- a/libs/Einsums/RuntimeConfiguration/src/RuntimeConfiguration.cpp
+++ b/libs/Einsums/RuntimeConfiguration/src/RuntimeConfiguration.cpp
@@ -172,10 +172,18 @@ RuntimeConfiguration::parse_command_line(std::function<void(argparse::ArgumentPa
                               *global_config.get_bool_map()};
 
         argument_parser->add_argument("--einsums:no-install-signal-handlers")
-            .default_value(true)
             .implicit_value(false)
             .help("do not install signal handlers")
             .store_into(global_bools["install-signal-handlers"]);
+        argument_parser->add_argument("--einsums:install-signal-handlers")
+            .implicit_value(true)
+            .help("do not install signal handlers")
+            .store_into(global_bools["install-signal-handlers"]);
+#ifdef EINSUMS_DEBUG
+        global_bools["install-signal-handlers"] = true;
+#else
+		global_bools["install-signal-handlers"] = false;
+#endif
 
         argument_parser->add_argument("--einsums:no-attach-debugger")
             .default_value(true)
@@ -194,7 +202,7 @@ RuntimeConfiguration::parse_command_line(std::function<void(argparse::ArgumentPa
 #ifdef EINSUMS_DEBUG
             .default_value<std::int64_t>(SPDLOG_LEVEL_DEBUG)
 #else
-            .default_value<std::int64_t>(SPDLOG_LEVEL_INFO)
+            .default_value<std::int64_t>(SPDLOG_LEVEL_WARN)
 #endif
             .help("set log level")
             .choices(0, 1, 2, 3, 4)


### PR DESCRIPTION
Set the default log level on release builds to warnings and up, and sets the default behavior to be to not install debug handlers.