### PR TITLE
PR6: TensorIO — graph-aware slab I/O

### DIFF
--- a/libs/Einsums/CMakeLists.txt
+++ b/libs/Einsums/CMakeLists.txt
@@ -42,6 +42,7 @@ set(_Einsums_modules
   TensorAlgebra
   ComputeGraphTypes
   ComputeGraph
+  TensorIO
   TensorBase
   TensorImpl
   TensorUtilities

--- a/libs/Einsums/TensorIO/CMakeLists.txt
+++ b/libs/Einsums/TensorIO/CMakeLists.txt
@@ -1,0 +1,36 @@
+#----------------------------------------------------------------------------------------------
+# Copyright (c) The Einsums Developers. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+#----------------------------------------------------------------------------------------------
+
+set(TensorIOHeaders
+    Einsums/TensorIO/Format.hpp
+    Einsums/TensorIO/TensorFile.hpp
+    Einsums/TensorIO/DistributedTensorFile.hpp
+    Einsums/TensorIO/Checkpoint.hpp
+    Einsums/TensorIO/GraphIO.hpp
+)
+
+set(TensorIOSources
+    TensorFile.cpp
+    DistributedTensorFile.cpp
+    Checkpoint.cpp
+    InitModule.cpp
+)
+
+include(Einsums_AddModule)
+einsums_add_module(
+  Einsums TensorIO
+  PYBIND
+  SOURCES ${TensorIOSources}
+  HEADERS ${TensorIOHeaders}
+  MODULE_DEPENDENCIES
+    Einsums_Comm
+    Einsums_ComputeGraph
+    Einsums_Config
+    Einsums_Errors
+    Einsums_Tensor
+    Einsums_TensorBase
+    Einsums_Profile
+  CMAKE_SUBDIRS examples tests
+)

--- a/libs/Einsums/TensorIO/docs/index.rst
+++ b/libs/Einsums/TensorIO/docs/index.rst
@@ -1,0 +1,100 @@
+..
+    ----------------------------------------------------------------------------------------------
+     Copyright (c) The Einsums Developers. All rights reserved.
+     Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+    ----------------------------------------------------------------------------------------------
+
+.. _modules_Einsums_TensorIO:
+
+########
+TensorIO
+########
+
+The ``TensorIO`` module provides on-disk tensor storage via HDF5 plus
+graph-aware slab I/O primitives that integrate with the
+:ref:`ComputeGraph <modules_Einsums_ComputeGraph>` for streaming workloads
+that don't fit in memory.
+
+DiskTensor
+==========
+
+``DiskTensor<T, Rank>`` is a tensor whose data lives in an HDF5 dataset
+rather than RAM. The path string maps to an HDF5 dataset path; the file
+is created on first write, persisted across program runs, and lazily read
+when accessed.
+
+.. code-block:: cpp
+
+    #include <Einsums/TensorIO/DiskTensor.hpp>
+
+    using namespace einsums;
+
+    DiskTensor<double, 2> A{"/integrals/oovv", 100, 100};
+
+    // Write a row (or any sub-region)
+    auto in_memory_row = create_random_tensor("row", 100);
+    A(0, All) = in_memory_row;
+
+    // Read it back
+    auto row_back = A(0, All);  // triggers HDF5 read
+
+Slab IO
+=======
+
+For loops that walk a large tensor block by block, ``tensor_io::Slab``
+captures a window onto a ``DiskTensor`` and exposes it via two graph-aware
+wrappers:
+
+- ``read_slice_etn`` — schedule a read of one slab into an in-memory
+  destination as a ComputeGraph node.
+- ``write_slice_etn`` — schedule a write of an in-memory source into one
+  slab as a ComputeGraph node.
+
+The slab is captured by reference, so the SAME slab object can be advanced
+between graph executions to walk an arbitrarily large tensor with a small
+working set.
+
+.. code-block:: cpp
+
+    #include <Einsums/TensorIO/Slab.hpp>
+
+    using namespace einsums::tensor_io;
+
+    DiskTensor<double, 3> big{"/integrals/full", 1000, 1000, 1000};
+
+    Slab slab{big};
+    slab.set_window({0, 0, 0}, {100, 1000, 1000});
+
+    // Build a graph that reads, processes, writes — once.
+    Graph g;
+    {
+        Capture cap{g};
+        auto src = read_slice_etn(g, slab, ...);
+        // ... use src in subsequent graph nodes ...
+        write_slice_etn(g, slab, processed);
+    }
+
+    // Walk the tensor by advancing the slab and re-executing.
+    for (size_t z = 0; z < 1000; z += 100) {
+        slab.set_window({z, 0, 0}, {100, 1000, 1000});
+        g.execute();
+    }
+
+Python surface
+==============
+
+``read_slice`` and ``write_slice`` are exposed in Python as
+``einsums.io.read_slice`` and ``einsums.io.write_slice``. The same
+slab-by-reference pattern applies — the Python ``Slab`` object can be
+advanced between captures.
+
+HDF5 file lifecycle
+===================
+
+By default Einsums creates a per-process HDF5 file named
+``einsums.<pid>.h5`` and cleans it up on shutdown. Override the path with
+``--einsums:hdf5-file-name <path>`` and disable cleanup with
+``--einsums:no-delete-hdf5-files`` to persist data across runs.
+
+See the :ref:`API reference <modules_Einsums_TensorIO_api>` of this module
+for ``DiskTensor``, ``Slab``, and the graph wrappers.

--- a/libs/Einsums/TensorIO/docs/index.rst
+++ b/libs/Einsums/TensorIO/docs/index.rst
@@ -10,91 +10,92 @@
 TensorIO
 ########
 
-The ``TensorIO`` module provides on-disk tensor storage via HDF5 plus
-graph-aware slab I/O primitives that integrate with the
-:ref:`ComputeGraph <modules_Einsums_ComputeGraph>` for streaming workloads
-that don't fit in memory.
+The ``TensorIO`` module stores tensors on disk in a native binary format
+(``.etn``) and adds graph-aware slab I/O primitives that integrate with the
+:ref:`ComputeGraph <modules_Einsums_ComputeGraph>`. Together they let you
+stream a tensor too large for memory through a computation block by block.
 
-DiskTensor
+TensorFile
 ==========
 
-``DiskTensor<T, Rank>`` is a tensor whose data lives in an HDF5 dataset
-rather than RAM. The path string maps to an HDF5 dataset path; the file
-is created on first write, persisted across program runs, and lazily read
-when accessed.
+``TensorFile`` is the serial entry point: it reads and writes whole tensors,
+or hyperslabs of them, in the ``.etn`` format. A file holds many named
+tensors. New tensors append to the end without rewriting existing data.
 
 .. code-block:: cpp
 
-    #include <Einsums/TensorIO/DiskTensor.hpp>
-
-    using namespace einsums;
-
-    DiskTensor<double, 2> A{"/integrals/oovv", 100, 100};
-
-    // Write a row (or any sub-region)
-    auto in_memory_row = create_random_tensor("row", 100);
-    A(0, All) = in_memory_row;
-
-    // Read it back
-    auto row_back = A(0, All);  // triggers HDF5 read
-
-Slab IO
-=======
-
-For loops that walk a large tensor block by block, ``tensor_io::Slab``
-captures a window onto a ``DiskTensor`` and exposes it via two graph-aware
-wrappers:
-
-- ``read_slice_etn`` — schedule a read of one slab into an in-memory
-  destination as a ComputeGraph node.
-- ``write_slice_etn`` — schedule a write of an in-memory source into one
-  slab as a ComputeGraph node.
-
-The slab is captured by reference, so the SAME slab object can be advanced
-between graph executions to walk an arbitrarily large tensor with a small
-working set.
-
-.. code-block:: cpp
-
-    #include <Einsums/TensorIO/Slab.hpp>
+    #include <Einsums/TensorIO/TensorFile.hpp>
 
     using namespace einsums::tensor_io;
 
-    DiskTensor<double, 3> big{"/integrals/full", 1000, 1000, 1000};
+    // Write tensors to a file.
+    TensorFile out("integrals.etn", TensorFile::Mode::Write);
+    out.write("A", A);
+    out.write("B", B);
 
-    Slab slab{big};
-    slab.set_window({0, 0, 0}, {100, 1000, 1000});
+    // Read one back.
+    TensorFile in("integrals.etn", TensorFile::Mode::Read);
+    in.read("A", A);
 
-    // Build a graph that reads, processes, writes — once.
-    Graph g;
+    // Read a sub-region without loading the whole tensor.
+    in.read_slice("A", slice, {{3, 8}, {0, 10}});
+
+Slab I/O
+========
+
+For a loop that walks a large stored tensor block by block, ``tensor_io::Slab``
+names a hyperslab and the two graph-aware wrappers schedule I/O against it:
+
+- ``read_slice_etn`` records a ComputeGraph node that reads the slab into an
+  in-memory destination.
+- ``write_slice_etn`` records a ComputeGraph node that writes an in-memory
+  source into the slab.
+
+A ``Slab`` holds ``ranges``, one half-open ``{start, end}`` pair per
+dimension. The wrappers capture the ``Slab`` by reference, so the same graph
+node can drive a loop: mutate ``slab.ranges`` between executions to walk an
+arbitrarily large tensor with a small working set.
+
+.. code-block:: cpp
+
+    #include <Einsums/TensorIO/GraphIO.hpp>
+
+    using namespace einsums::tensor_io;
+    namespace cg = einsums::compute_graph;
+
+    // "full" already exists in the file; "block" is sized to one slab.
+    Slab slab{{ {0, 100}, {0, 1000}, {0, 1000} }};
+    auto block = create_zero_tensor<double>("block", 100, 1000, 1000);
+
+    // Build a graph that reads one slab, processes it, and writes it back.
+    cg::Graph g("slab_walk");
     {
-        Capture cap{g};
-        auto src = read_slice_etn(g, slab, ...);
-        // ... use src in subsequent graph nodes ...
-        write_slice_etn(g, slab, processed);
+        cg::CaptureGuard guard(g);
+        read_slice_etn("full.etn", "T", slab, &block);
+        // ... use block in subsequent graph nodes ...
+        write_slice_etn("full.etn", "T", slab, &block);
     }
 
-    // Walk the tensor by advancing the slab and re-executing.
+    // Walk the tensor by advancing the slab and re-executing the same graph.
     for (size_t z = 0; z < 1000; z += 100) {
-        slab.set_window({z, 0, 0}, {100, 1000, 1000});
+        slab.ranges[0] = {z, z + 100};
         g.execute();
     }
+
+The target entry must already exist before ``write_slice_etn`` runs, for
+example from a prior ``write_etn`` or ``TensorFile::reserve``. The in-memory
+tensor must match the slab shape; the bound ``TensorFile`` methods throw at
+execute time if the dimensions disagree.
 
 Python surface
 ==============
 
-``read_slice`` and ``write_slice`` are exposed in Python as
-``einsums.io.read_slice`` and ``einsums.io.write_slice``. The same
-slab-by-reference pattern applies — the Python ``Slab`` object can be
-advanced between captures.
+The graph wrappers are exposed in Python under ``einsums.io``. Each C++
+``read_slice_etn`` / ``write_slice_etn`` is bound as ``einsums.io.read_slice``
+/ ``einsums.io.write_slice``, and ``read_etn`` / ``write_etn`` as
+``einsums.io.read`` / ``einsums.io.write``. The slab-by-reference pattern
+carries over: a Python ``Slab`` object can be advanced between graph
+executions the same way.
 
-HDF5 file lifecycle
-===================
-
-By default Einsums creates a per-process HDF5 file named
-``einsums.<pid>.h5`` and cleans it up on shutdown. Override the path with
-``--einsums:hdf5-file-name <path>`` and disable cleanup with
-``--einsums:no-delete-hdf5-files`` to persist data across runs.
-
-See the :ref:`API reference <modules_Einsums_TensorIO_api>` of this module
-for ``DiskTensor``, ``Slab``, and the graph wrappers.
+See the :ref:`API reference <modules_Einsums_TensorIO_api>` for ``TensorFile``,
+``Slab``, the graph wrappers, distributed I/O, and checkpointing.

--- a/libs/Einsums/TensorIO/docs/tensor_io.rst
+++ b/libs/Einsums/TensorIO/docs/tensor_io.rst
@@ -8,21 +8,21 @@ Tensor I/O (.etn)
 ==================
 
 The ``TensorIO`` module provides high-performance tensor file I/O in a native
-binary format (``.etn``). It replaces HDF5 for performance-critical workloads
-with zero external dependencies.
+binary format, ``.etn``. It replaces HDF5 for performance-critical workloads
+and pulls in no external dependencies.
 
 Features
 =========
 
-- **Binary format**: 64-byte header, 160-byte entries, 64-byte aligned data
-- **Fast**: Raw ``pwrite``/``pread`` — no metadata overhead, near-memory-bandwidth throughput
-- **All datatypes**: float32, float64, complex64, complex128, int32, int64, uint32, uint64
-- **Ranks 1-8**: Vectors through 8-index tensors
-- **Slice reads**: Read a hyperslab without loading the full tensor
-- **Multi-tensor files**: Store many tensors in one file
-- **Distributed I/O**: MPI-coordinated writes to a single file using ``MPI_Exscan``
-- **ComputeGraph integration**: ``read_etn``/``write_etn`` create DiskRead/DiskWrite nodes
-- **Checkpointing**: Save/restore Graph or Workspace state with one call
+- **Binary format**: 64-byte header, 160-byte entries, 64-byte aligned data.
+- **Fast**: raw ``pwrite``/``pread`` with no metadata overhead, near memory-bandwidth throughput.
+- **All datatypes**: float32, float64, complex64, complex128, int32, int64, uint32, uint64.
+- **Ranks 1-8**: vectors through 8-index tensors.
+- **Slice reads**: read a hyperslab without loading the full tensor.
+- **Multi-tensor files**: store many tensors in one file.
+- **Distributed I/O**: MPI-coordinated writes to a single file using ``MPI_Exscan``.
+- **ComputeGraph integration**: ``read_etn``/``write_etn`` create DiskRead/DiskWrite nodes.
+- **Checkpointing**: save and restore Graph or Workspace state with one call.
 
 File Format
 ============
@@ -37,8 +37,9 @@ File Format
    [TensorEntry 1]
    ...
 
-Entry table at the end enables appending tensors without shifting existing data.
-Files created with MPI-IO are standard binary — readable by serial programs.
+Putting the entry table at the end lets you append tensors without shifting
+existing data. Files written through the distributed path are standard binary,
+so serial programs can read them.
 
 TensorFile
 ===========
@@ -75,7 +76,7 @@ Basic read/write for serial programs:
 DistributedTensorFile
 ======================
 
-MPI-parallel I/O — all ranks write to one file:
+MPI-parallel I/O where all ranks write to one file:
 
 .. code-block:: cpp
 
@@ -93,8 +94,9 @@ MPI-parallel I/O — all ranks write to one file:
    in.read("global", tensor);             // All ranks read same data
    in.read_local("partition", local);     // Each rank reads its part
 
-Uses POSIX ``pwrite``/``pread`` for file operations (reliable on all platforms)
-with MPI ``Exscan`` and ``Gather`` for offset coordination. No MPI-IO dependency.
+File operations go through POSIX ``pwrite``/``pread``, which behaves reliably
+on all platforms. MPI ``Exscan`` and ``Gather`` coordinate the per-rank
+offsets. There is no dependency on MPI-IO.
 
 Checkpointing
 ==============

--- a/libs/Einsums/TensorIO/docs/tensor_io.rst
+++ b/libs/Einsums/TensorIO/docs/tensor_io.rst
@@ -1,0 +1,145 @@
+:orphan:
+
+.. Copyright (c) The Einsums Developers. All rights reserved.
+   Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+
+==================
+Tensor I/O (.etn)
+==================
+
+The ``TensorIO`` module provides high-performance tensor file I/O in a native
+binary format (``.etn``). It replaces HDF5 for performance-critical workloads
+with zero external dependencies.
+
+Features
+=========
+
+- **Binary format**: 64-byte header, 160-byte entries, 64-byte aligned data
+- **Fast**: Raw ``pwrite``/``pread`` — no metadata overhead, near-memory-bandwidth throughput
+- **All datatypes**: float32, float64, complex64, complex128, int32, int64, uint32, uint64
+- **Ranks 1-8**: Vectors through 8-index tensors
+- **Slice reads**: Read a hyperslab without loading the full tensor
+- **Multi-tensor files**: Store many tensors in one file
+- **Distributed I/O**: MPI-coordinated writes to a single file using ``MPI_Exscan``
+- **ComputeGraph integration**: ``read_etn``/``write_etn`` create DiskRead/DiskWrite nodes
+- **Checkpointing**: Save/restore Graph or Workspace state with one call
+
+File Format
+============
+
+.. code-block:: text
+
+   [FileHeader]     (64 bytes at offset 0)
+   [Data region 0]  (raw bytes, 64-byte aligned)
+   [Data region 1]
+   ...
+   [TensorEntry 0]  (160 bytes each, at end of file)
+   [TensorEntry 1]
+   ...
+
+Entry table at the end enables appending tensors without shifting existing data.
+Files created with MPI-IO are standard binary — readable by serial programs.
+
+TensorFile
+===========
+
+Basic read/write for serial programs:
+
+.. code-block:: cpp
+
+   #include <Einsums/TensorIO/TensorFile.hpp>
+   using namespace einsums::tensor_io;
+
+   // Write tensors
+   TensorFile out("data.etn", TensorFile::Mode::Write);
+   out.write("A", A);
+   out.write("B", B);
+
+   // Read back
+   TensorFile in("data.etn", TensorFile::Mode::Read);
+   in.read("A", A);
+
+   // Slice read (only loads the requested range)
+   in.read_slice("A", slice, {{3, 8}, {0, 10}});
+
+   // Query
+   in.contains("A");       // true
+   in.dims("A");           // {10, 8}
+   in.dtype("A");          // DType::Float64
+   in.tensor_names();      // {"A", "B"}
+
+   // Append in ReadWrite mode
+   TensorFile rw("data.etn", TensorFile::Mode::ReadWrite);
+   rw.write("C", C);  // Appends without overwriting A, B
+
+DistributedTensorFile
+======================
+
+MPI-parallel I/O — all ranks write to one file:
+
+.. code-block:: cpp
+
+   #include <Einsums/TensorIO/DistributedTensorFile.hpp>
+   using namespace einsums::tensor_io;
+
+   // All ranks collectively write
+   DistributedTensorFile out("checkpoint.etn", DistributedTensorFile::Mode::Write);
+   out.write("global", tensor);           // Rank 0 writes (replicated)
+   out.write_local("partition", local);   // Each rank writes its part
+   out.close();
+
+   // All ranks collectively read
+   DistributedTensorFile in("checkpoint.etn", DistributedTensorFile::Mode::Read);
+   in.read("global", tensor);             // All ranks read same data
+   in.read_local("partition", local);     // Each rank reads its part
+
+Uses POSIX ``pwrite``/``pread`` for file operations (reliable on all platforms)
+with MPI ``Exscan`` and ``Gather`` for offset coordination. No MPI-IO dependency.
+
+Checkpointing
+==============
+
+Save/restore ComputeGraph or Workspace state:
+
+.. code-block:: cpp
+
+   #include <Einsums/TensorIO/Checkpoint.hpp>
+   namespace ckpt = einsums::tensor_io::checkpoint;
+
+   // Graph
+   ckpt::save("scf_iter_5.etn", graph);
+   ckpt::save("scf_iter_5.etn", graph, {"Fock", "Density"});  // subset
+   ckpt::restore("scf_iter_5.etn", graph);
+
+   // Workspace
+   ckpt::save("workspace.etn", workspace);
+   ckpt::restore("workspace.etn", workspace);
+
+   // Distributed
+   ckpt::save_distributed("checkpoint.etn", graph);
+   ckpt::restore_distributed("checkpoint.etn", graph);
+
+ComputeGraph Integration
+=========================
+
+Record I/O operations as graph nodes for scheduling and async overlap:
+
+.. code-block:: cpp
+
+   #include <Einsums/TensorIO/GraphIO.hpp>
+   using namespace einsums::tensor_io;
+
+   {
+       cg::CaptureGuard guard(graph);
+       read_etn("integrals.etn", "ERI", &eri);    // DiskRead node
+       cg::einsum("ik;kj->ij", &C, eri, B);
+       write_etn("result.etn", "C", &C);           // DiskWrite node
+       checkpoint_etn("iter_5.etn", graph);         // Save all tensors
+   }
+
+   // IOPrefetch pass moves reads early for async overlap
+   auto pm = cg::PassManager::create_default();
+   graph.apply(pm);
+
+   cg::DataflowExecutor df;
+   graph.execute(df);  // I/O overlaps with compute

--- a/libs/Einsums/TensorIO/examples/CMakeLists.txt
+++ b/libs/Einsums/TensorIO/examples/CMakeLists.txt
@@ -1,0 +1,36 @@
+#----------------------------------------------------------------------------------------------
+# Copyright (c) The Einsums Developers. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+#----------------------------------------------------------------------------------------------
+
+if(EINSUMS_WITH_EXAMPLES)
+  einsums_add_pseudo_target(Examples.Modules.Einsums.TensorIO)
+  einsums_add_pseudo_dependencies(Examples.Modules Examples.Modules.Einsums.TensorIO)
+  if(EINSUMS_WITH_TESTS AND EINSUMS_WITH_TESTS_EXAMPLES)
+    einsums_add_pseudo_target(Tests.Examples.Modules.Einsums.TensorIO)
+    einsums_add_pseudo_dependencies(
+      Tests.Examples.Modules Tests.Examples.Modules.Einsums.TensorIO
+    )
+  endif()
+else()
+  return()
+endif()
+
+set(example_programs TensorIOExample)
+
+foreach(example_program ${example_programs})
+  einsums_add_executable(
+    TIO_${example_program} INTERNAL_FLAGS
+    SOURCES ${example_program}.cpp
+    FOLDER "Examples/Modules/TensorIO"
+    NOINSTALL
+  )
+
+  einsums_add_example_target_dependencies("Modules.Einsums.TensorIO" TIO_${example_program})
+
+  if(EINSUMS_WITH_TESTS AND EINSUMS_WITH_TESTS_EXAMPLES)
+    einsums_add_example_test(
+      "Modules.Einsums.TensorIO" TIO_${example_program}
+    )
+  endif()
+endforeach()

--- a/libs/Einsums/TensorIO/examples/TensorIOExample.cpp
+++ b/libs/Einsums/TensorIO/examples/TensorIOExample.cpp
@@ -1,0 +1,122 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+/**
+ * @file TensorIOExample.cpp
+ * @brief Example: .etn tensor file I/O with checkpointing.
+ *
+ * Demonstrates:
+ * 1. Writing tensors to a .etn file
+ * 2. Reading back with slice (partial read)
+ * 3. Checkpointing a ComputeGraph and restoring
+ * 4. Using read_etn/write_etn inside graph capture
+ */
+
+#include <Einsums/ComputeGraph.hpp>
+#include <Einsums/Print.hpp>
+#include <Einsums/Runtime.hpp>
+#include <Einsums/Tensor/Tensor.hpp>
+#include <Einsums/TensorIO/Checkpoint.hpp>
+#include <Einsums/TensorIO/GraphIO.hpp>
+#include <Einsums/TensorIO/TensorFile.hpp>
+#include <Einsums/TensorUtilities/CreateRandomTensor.hpp>
+#include <Einsums/TensorUtilities/CreateZeroTensor.hpp>
+
+using namespace einsums;
+using namespace einsums::index;
+namespace cg   = einsums::compute_graph;
+namespace tio  = einsums::tensor_io;
+namespace ckpt = einsums::tensor_io::checkpoint;
+
+int einsums_main() {
+    constexpr size_t N = 20;
+
+    // ── 1. Basic TensorFile I/O ──────────────────────────────────────────
+    einsums::println("=== 1. Basic TensorFile I/O ===");
+
+    auto A = create_random_tensor<double>("A", N, N);
+    auto B = create_random_tensor<double>("B", N, N);
+
+    {
+        tio::TensorFile out("/tmp/einsums_example.etn", tio::TensorFile::Mode::Write);
+        out.write("A", A);
+        out.write("B", B);
+        einsums::println("  Wrote {} tensors to /tmp/einsums_example.etn", out.num_tensors());
+    }
+
+    {
+        tio::TensorFile in("/tmp/einsums_example.etn", tio::TensorFile::Mode::Read);
+        einsums::println("  File contains: {}", fmt::join(in.tensor_names(), ", "));
+        einsums::println("  A dims: {}x{}", in.dims("A")[0], in.dims("A")[1]);
+    }
+
+    // ── 2. Slice read ────────────────────────────────────────────────────
+    einsums::println("\n=== 2. Slice read ===");
+
+    auto slice = Tensor<double, 2>("slice", 5, 5);
+    {
+        tio::TensorFile in("/tmp/einsums_example.etn", tio::TensorFile::Mode::Read);
+        in.read_slice<double, 2>("A", slice, {{{0, 5}, {0, 5}}});
+    }
+    einsums::println("  Read 5x5 slice of A: A(0,0) = {:.6f}, slice(0,0) = {:.6f}", A(0, 0), slice(0, 0));
+    einsums::println("  Match: {}", A(0, 0) == slice(0, 0) ? "YES" : "NO");
+
+    // ── 3. Checkpoint a ComputeGraph ─────────────────────────────────────
+    einsums::println("\n=== 3. Checkpoint ===");
+
+    auto C = create_zero_tensor<double>("C", N, N);
+
+    cg::Graph graph("example");
+    {
+        cg::CaptureGuard const guard(graph);
+        cg::einsum("ik;kj->ij", &C, A, B);
+    }
+    graph.execute();
+
+    einsums::println("  C(0,0) = {:.6f} (after compute)", C(0, 0));
+
+    // Save checkpoint
+    ckpt::save("/tmp/einsums_checkpoint.etn", graph);
+    einsums::println("  Saved checkpoint");
+
+    // Corrupt C, then restore
+    double const saved = C(0, 0);
+    C.zero();
+    einsums::println("  C(0,0) = {:.6f} (after zeroing)", C(0, 0));
+
+    ckpt::restore("/tmp/einsums_checkpoint.etn", graph);
+    einsums::println("  C(0,0) = {:.6f} (after restore)", C(0, 0));
+    einsums::println("  Restored correctly: {}", C(0, 0) == saved ? "YES" : "NO");
+
+    // ── 4. GraphIO: read/write in capture ────────────────────────────────
+    einsums::println("\n=== 4. GraphIO ===");
+
+    auto D = create_zero_tensor<double>("D", N, N);
+
+    cg::Graph graph2("graphio_example");
+    {
+        cg::CaptureGuard const guard(graph2);
+        // Read A from file → compute D = A * B → write D to file
+        tio::read_etn("/tmp/einsums_example.etn", "A", &A);
+        cg::einsum("ik;kj->ij", &D, A, B);
+        tio::write_etn("/tmp/einsums_result.etn", "D", &D);
+    }
+    graph2.execute();
+
+    einsums::println("  Executed graph with read_etn → einsum → write_etn");
+    einsums::println("  D(0,0) = {:.6f}", D(0, 0));
+
+    // Cleanup
+    std::remove("/tmp/einsums_example.etn");
+    std::remove("/tmp/einsums_checkpoint.etn");
+    std::remove("/tmp/einsums_result.etn");
+
+    einsums::println("\nDone!");
+    return 0;
+}
+
+int main(int argc, char **argv) {
+    return einsums::start(einsums_main, argc, argv);
+}

--- a/libs/Einsums/TensorIO/examples/TensorIOExample.cpp
+++ b/libs/Einsums/TensorIO/examples/TensorIOExample.cpp
@@ -9,7 +9,7 @@
  *
  * Demonstrates:
  * 1. Writing tensors to a .etn file
- * 2. Reading back with slice (partial read)
+ * 2. Reading part of a tensor back with a slice
  * 3. Checkpointing a ComputeGraph and restoring
  * 4. Using read_etn/write_etn inside graph capture
  */

--- a/libs/Einsums/TensorIO/include/Einsums/TensorIO/Checkpoint.hpp
+++ b/libs/Einsums/TensorIO/include/Einsums/TensorIO/Checkpoint.hpp
@@ -1,0 +1,69 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+#include <Einsums/Config.hpp>
+
+/// @file Checkpoint.hpp
+/// @brief Save/restore tensor state to .etn files.
+///
+/// Works with Graph, Workspace, and Pipeline:
+///
+/// @code
+/// namespace ckpt = einsums::tensor_io::checkpoint;
+///
+/// ckpt::save("scf_iter_5.etn", graph);
+/// ckpt::save("workspace.etn", workspace);
+/// ckpt::restore("scf_iter_5.etn", graph);
+///
+/// // Distributed
+/// ckpt::save_distributed("checkpoint.etn", graph);
+/// ckpt::restore_distributed("checkpoint.etn", graph);
+/// @endcode
+
+#include <Einsums/TensorIO/DistributedTensorFile.hpp>
+#include <Einsums/TensorIO/TensorFile.hpp>
+
+#include <string>
+#include <vector>
+
+// Forward declarations to avoid pulling in full headers
+namespace einsums::compute_graph {
+class Graph;
+class Workspace;
+} // namespace einsums::compute_graph
+
+namespace einsums::tensor_io::checkpoint {
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Serial (single-file POSIX I/O)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Save all materialized tensors from a Graph.
+EINSUMS_EXPORT void save(std::string const &path, compute_graph::Graph const &graph, std::vector<std::string> const &tensor_names = {});
+
+/// Save all tensors from a Workspace.
+EINSUMS_EXPORT void save(std::string const &path, compute_graph::Workspace const &workspace,
+                         std::vector<std::string> const &tensor_names = {});
+
+/// Restore tensor data into a Graph.
+EINSUMS_EXPORT void restore(std::string const &path, compute_graph::Graph &graph);
+
+/// Restore tensor data into a Workspace.
+EINSUMS_EXPORT void restore(std::string const &path, compute_graph::Workspace &workspace);
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Distributed (MPI-coordinated single-file I/O)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/// Save distributed Graph tensors — replicated written once, distributed per-rank.
+EINSUMS_EXPORT void save_distributed(std::string const &path, compute_graph::Graph const &graph,
+                                     std::vector<std::string> const &tensor_names = {});
+
+/// Restore distributed Graph tensors.
+EINSUMS_EXPORT void restore_distributed(std::string const &path, compute_graph::Graph &graph);
+
+} // namespace einsums::tensor_io::checkpoint

--- a/libs/Einsums/TensorIO/include/Einsums/TensorIO/Checkpoint.hpp
+++ b/libs/Einsums/TensorIO/include/Einsums/TensorIO/Checkpoint.hpp
@@ -59,7 +59,7 @@ EINSUMS_EXPORT void restore(std::string const &path, compute_graph::Workspace &w
 // Distributed (MPI-coordinated single-file I/O)
 // ═══════════════════════════════════════════════════════════════════════════════
 
-/// Save distributed Graph tensors — replicated written once, distributed per-rank.
+/// Save distributed Graph tensors: replicated ones written once, distributed ones per-rank.
 EINSUMS_EXPORT void save_distributed(std::string const &path, compute_graph::Graph const &graph,
                                      std::vector<std::string> const &tensor_names = {});
 

--- a/libs/Einsums/TensorIO/include/Einsums/TensorIO/DistributedTensorFile.hpp
+++ b/libs/Einsums/TensorIO/include/Einsums/TensorIO/DistributedTensorFile.hpp
@@ -1,0 +1,206 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+/// @file DistributedTensorFile.hpp
+/// @brief MPI-IO based tensor file for distributed parallel I/O.
+///
+/// All ranks open the same file. Each rank writes its local tensor partitions
+/// at computed offsets. The file is a standard .etn binary file — readable
+/// by the serial TensorFile without MPI.
+///
+/// @code
+/// using namespace einsums::tensor_io;
+///
+/// // All ranks collectively write
+/// DistributedTensorFile out("checkpoint.etn", DistributedTensorFile::Mode::Write);
+/// out.write("ERI", eri);           // Replicated tensor (rank 0 writes)
+/// out.write_local("C", C_local);   // Each rank writes its partition
+/// out.close();
+///
+/// // All ranks collectively read
+/// DistributedTensorFile in("checkpoint.etn", DistributedTensorFile::Mode::Read);
+/// in.read("ERI", eri);             // All ranks read the same data
+/// in.read_local("C", C_local);     // Each rank reads its partition
+/// @endcode
+
+#include <Einsums/Config.hpp>
+
+#include <Einsums/Comm/Collectives.hpp>
+#include <Einsums/Comm/Runtime.hpp>
+#include <Einsums/Tensor/Tensor.hpp>
+#include <Einsums/TensorIO/Format.hpp>
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace einsums::tensor_io {
+
+class EINSUMS_EXPORT DistributedTensorFile {
+  public:
+    enum class Mode : std::uint8_t { Read, Write };
+
+    /// All ranks collectively open the file.
+    explicit DistributedTensorFile(std::string path, Mode mode);
+
+    /// Flushes and closes (collective).
+    ~DistributedTensorFile();
+
+    // Non-copyable
+    DistributedTensorFile(DistributedTensorFile const &)            = delete;
+    DistributedTensorFile &operator=(DistributedTensorFile const &) = delete;
+
+    // ── Write (collective) ───────────────────────────────────────────────
+
+    /// Write a replicated tensor. Rank 0 writes; others skip.
+    template <typename T, size_t Rank>
+    void write(std::string_view name, Tensor<T, Rank> const &tensor);
+
+    /// Write each rank's local partition. All ranks participate.
+    /// Each rank's data is stored at a unique offset. The entry table
+    /// records one TensorEntry per rank with owning_rank set.
+    template <typename T, size_t Rank>
+    void write_local(std::string_view name, Tensor<T, Rank> const &tensor);
+
+    // ── Read (collective) ────────────────────────────────────────────────
+
+    /// Read a replicated tensor. All ranks read the same data.
+    template <typename T, size_t Rank>
+    void read(std::string_view name, Tensor<T, Rank> &tensor);
+
+    /// Read this rank's local partition.
+    template <typename T, size_t Rank>
+    void read_local(std::string_view name, Tensor<T, Rank> &tensor);
+
+    // ── Query ────────────────────────────────────────────────────────────
+
+    [[nodiscard]] bool                     contains(std::string_view name) const;
+    [[nodiscard]] std::vector<std::string> tensor_names() const;
+    [[nodiscard]] size_t                   num_tensors() const { return _entries.size(); }
+
+    /// Close the file (collective). Called automatically by destructor.
+    void close();
+
+  private:
+    std::string                             _path;
+    Mode                                    _mode;
+    int                                     _my_rank;
+    int                                     _num_ranks;
+    FileHeader                              _header;
+    std::vector<TensorEntry>                _entries;
+    std::unordered_map<std::string, size_t> _name_to_index;
+    uint64_t                                _next_data_offset;
+    bool                                    _closed{false};
+
+    int _fd{-1}; // POSIX file descriptor (used on all platforms)
+
+    void write_at(uint64_t offset, void const *data, size_t bytes);
+    void read_at(uint64_t offset, void *data, size_t bytes) const;
+    void write_metadata();
+    void read_metadata();
+
+    /// Compute offset for this rank's data using MPI_Scan prefix sum.
+    uint64_t compute_distributed_offset(size_t local_bytes);
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Template implementations
+// ═══════════════════════════════════════════════════════════════════════════════
+
+template <typename T, size_t Rank>
+void DistributedTensorFile::write(std::string_view name, Tensor<T, Rank> const &tensor) {
+    // Replicated: only rank 0 writes the data
+    size_t data_bytes = tensor.size() * sizeof(T);
+
+    TensorEntry entry;
+    entry.init();
+    entry.set_name(name);
+    entry.dtype = static_cast<uint8_t>(dtype_for<T>());
+    entry.rank  = static_cast<uint8_t>(Rank);
+    for (size_t d = 0; d < Rank; d++)
+        entry.dims[d] = tensor.dim(d);
+    entry.data_size   = data_bytes;
+    entry.owning_rank = ETN_ALL_RANKS;
+
+    // All ranks agree on the offset
+    entry.data_offset = align_up(_next_data_offset, ETN_DATA_ALIGNMENT);
+    _next_data_offset = entry.data_offset + data_bytes;
+
+    // Only rank 0 writes the data
+    if (_my_rank == 0) {
+        write_at(entry.data_offset, tensor.data(), data_bytes);
+    }
+
+    _entries.push_back(entry);
+    _name_to_index[std::string(name)] = _entries.size() - 1;
+}
+
+template <typename T, size_t Rank>
+void DistributedTensorFile::write_local(std::string_view name, Tensor<T, Rank> const &tensor) {
+    size_t local_bytes = tensor.size() * sizeof(T);
+
+    // Use prefix sum to compute each rank's offset
+    uint64_t my_offset = compute_distributed_offset(local_bytes);
+
+    TensorEntry entry;
+    entry.init();
+    entry.set_name(name);
+    entry.dtype = static_cast<uint8_t>(dtype_for<T>());
+    entry.rank  = static_cast<uint8_t>(Rank);
+    for (size_t d = 0; d < Rank; d++)
+        entry.dims[d] = tensor.dim(d);
+    entry.data_offset = my_offset;
+    entry.data_size   = local_bytes;
+    entry.owning_rank = static_cast<uint32_t>(_my_rank);
+
+    // Each rank writes its own data at its own offset
+    write_at(my_offset, tensor.data(), local_bytes);
+
+    _entries.push_back(entry);
+
+    _header.flags |= 0x1;
+    _header.num_ranks = static_cast<uint32_t>(_num_ranks);
+}
+
+template <typename T, size_t Rank>
+void DistributedTensorFile::read(std::string_view name, Tensor<T, Rank> &tensor) {
+    // Find the replicated entry (owning_rank == ETN_ALL_RANKS)
+    std::string const name_str(name);
+    for (auto const &entry : _entries) {
+        if (entry.get_name() == name_str && entry.owning_rank == ETN_ALL_RANKS) {
+            Dim<Rank> dims;
+            for (size_t d = 0; d < Rank; d++)
+                dims[d] = entry.dims[d];
+            tensor.resize(dims);
+            read_at(entry.data_offset, tensor.data(), entry.data_size);
+            return;
+        }
+    }
+    throw std::runtime_error("DistributedTensorFile: replicated tensor '" + std::string(name) + "' not found");
+}
+
+template <typename T, size_t Rank>
+void DistributedTensorFile::read_local(std::string_view name, Tensor<T, Rank> &tensor) {
+    // Find the entry for this specific rank
+    std::string const name_str(name);
+    for (auto const &entry : _entries) {
+        if (entry.get_name() == name_str && std::cmp_equal(entry.owning_rank, _my_rank)) {
+            Dim<Rank> dims;
+            for (size_t d = 0; d < Rank; d++)
+                dims[d] = entry.dims[d];
+            tensor.resize(dims);
+            read_at(entry.data_offset, tensor.data(), entry.data_size);
+            return;
+        }
+    }
+    throw std::runtime_error("DistributedTensorFile: local tensor '" + std::string(name) + "' for rank " + std::to_string(_my_rank) +
+                             " not found");
+}
+
+} // namespace einsums::tensor_io

--- a/libs/Einsums/TensorIO/include/Einsums/TensorIO/DistributedTensorFile.hpp
+++ b/libs/Einsums/TensorIO/include/Einsums/TensorIO/DistributedTensorFile.hpp
@@ -6,10 +6,13 @@
 #pragma once
 
 /// @file DistributedTensorFile.hpp
-/// @brief MPI-IO based tensor file for distributed parallel I/O.
+/// @brief Tensor file for distributed parallel I/O.
+///
+/// File operations use POSIX I/O on every rank; MPI handles only the
+/// offset coordination, not the data transfer.
 ///
 /// All ranks open the same file. Each rank writes its local tensor partitions
-/// at computed offsets. The file is a standard .etn binary file — readable
+/// at computed offsets. The file is a standard .etn binary file, readable
 /// by the serial TensorFile without MPI.
 ///
 /// @code
@@ -105,7 +108,7 @@ class EINSUMS_EXPORT DistributedTensorFile {
     void write_metadata();
     void read_metadata();
 
-    /// Compute offset for this rank's data using MPI_Scan prefix sum.
+    /// Compute this rank's data offset via an MPI_Exscan exclusive prefix sum.
     uint64_t compute_distributed_offset(size_t local_bytes);
 };
 

--- a/libs/Einsums/TensorIO/include/Einsums/TensorIO/Format.hpp
+++ b/libs/Einsums/TensorIO/include/Einsums/TensorIO/Format.hpp
@@ -16,14 +16,15 @@
 /// [Data region 1]
 /// ...
 /// [Data region N-1]
-/// [TensorEntry 0]  (128 bytes each, at end of file)
+/// [TensorEntry 0]  (160 bytes each, at end of file)
 /// [TensorEntry 1]
 /// ...
 /// [TensorEntry N-1]
 /// ```
 ///
-/// Entry table at the end enables appending without shifting existing data.
-/// Files created with MPI-IO are standard binary — readable without MPI.
+/// Putting the entry table at the end allows appending without shifting
+/// existing data. Files written through the distributed path are standard
+/// binary, so they can be read back without MPI.
 
 #include <algorithm>
 #include <complex>
@@ -95,7 +96,7 @@ inline constexpr size_t ETN_MAX_RANK = 8;
 /// Sentinel value for owning_rank meaning "all ranks / serial".
 inline constexpr uint32_t ETN_ALL_RANKS = UINT32_MAX;
 
-/// Per-tensor metadata entry (128 bytes).
+/// Per-tensor metadata entry (160 bytes).
 struct TensorEntry {
     // NOLINTNEXTLINE(modernize-avoid-c-arrays)
     char    name[ETN_MAX_NAME]; ///< Null-terminated tensor name

--- a/libs/Einsums/TensorIO/include/Einsums/TensorIO/Format.hpp
+++ b/libs/Einsums/TensorIO/include/Einsums/TensorIO/Format.hpp
@@ -1,0 +1,195 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+/// @file Format.hpp
+/// @brief Binary format definitions for .etn tensor files.
+///
+/// The .etn format stores tensors as raw binary data with a compact header:
+///
+/// ```
+/// [FileHeader]     (64 bytes at offset 0)
+/// [Data region 0]  (raw bytes, 64-byte aligned)
+/// [Data region 1]
+/// ...
+/// [Data region N-1]
+/// [TensorEntry 0]  (128 bytes each, at end of file)
+/// [TensorEntry 1]
+/// ...
+/// [TensorEntry N-1]
+/// ```
+///
+/// Entry table at the end enables appending without shifting existing data.
+/// Files created with MPI-IO are standard binary — readable without MPI.
+
+#include <algorithm>
+#include <complex>
+#include <cstdint>
+#include <cstring>
+#include <string>
+#include <string_view>
+
+namespace einsums::tensor_io {
+
+/// Magic bytes identifying an .etn file.
+inline constexpr char ETN_MAGIC[8] = {'E', 'I', 'N', 'S', 'U', 'M', 'S', '\0'}; // NOLINT(modernize-avoid-c-arrays)
+
+/// Current format version.
+inline constexpr uint32_t ETN_VERSION = 1;
+
+/// Alignment for data regions (64 bytes for SIMD/cache-line compatibility).
+inline constexpr size_t ETN_DATA_ALIGNMENT = 64;
+
+/// Element type identifiers.
+enum class DType : uint8_t {
+    Float32    = 0,
+    Float64    = 1,
+    Complex64  = 2, ///< std::complex<float>
+    Complex128 = 3, ///< std::complex<double>
+    Int32      = 4,
+    Int64      = 5,
+    UInt32     = 6,
+    UInt64     = 7,
+};
+
+/// File header (64 bytes, at offset 0).
+struct FileHeader {
+    char     magic[8];           ///< "EINSUMS\0"  // NOLINT(modernize-avoid-c-arrays)
+    uint32_t version;            ///< Format version (ETN_VERSION)
+    uint32_t num_tensors;        ///< Number of TensorEntry records
+    uint64_t entry_table_offset; ///< Byte offset to first TensorEntry (end of data)
+    uint64_t data_offset;        ///< Byte offset to first data region (typically 64)
+    uint64_t total_size;         ///< Total file size in bytes
+    uint32_t flags;              ///< Bit flags: 0x1 = has distributed tensors
+    uint32_t num_ranks;          ///< MPI world_size at write time (0 = serial)
+    char     reserved[16];       ///< Reserved for future use  // NOLINT(modernize-avoid-c-arrays)
+
+    /// Initialize with default values.
+    void init() {
+        std::memcpy(magic, ETN_MAGIC, 8);
+        version            = ETN_VERSION;
+        num_tensors        = 0;
+        entry_table_offset = 0;
+        data_offset        = ETN_DATA_ALIGNMENT; // First data region after aligned header
+        total_size         = 0;
+        flags              = 0;
+        num_ranks          = 0;
+        std::memset(reserved, 0, sizeof(reserved));
+    }
+
+    /// Validate magic and version.
+    [[nodiscard]] bool is_valid() const { return std::memcmp(magic, ETN_MAGIC, 8) == 0 && version == ETN_VERSION; }
+};
+
+static_assert(sizeof(FileHeader) == 64, "FileHeader must be exactly 64 bytes");
+
+/// Maximum tensor name length (including null terminator).
+inline constexpr size_t ETN_MAX_NAME = 64;
+
+/// Maximum supported tensor rank.
+inline constexpr size_t ETN_MAX_RANK = 8;
+
+/// Sentinel value for owning_rank meaning "all ranks / serial".
+inline constexpr uint32_t ETN_ALL_RANKS = UINT32_MAX;
+
+/// Per-tensor metadata entry (128 bytes).
+struct TensorEntry {
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    char    name[ETN_MAX_NAME]; ///< Null-terminated tensor name
+    uint8_t dtype;              ///< DType enum value
+    uint8_t rank;               ///< Number of dimensions (1-8)
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    uint8_t reserved1[6]; ///< Padding
+    // NOLINTNEXTLINE(modernize-avoid-c-arrays)
+    uint64_t dims[ETN_MAX_RANK]; ///< Dimension sizes (unused dims = 0)
+    uint64_t data_offset;        ///< Byte offset from file start to data
+    uint64_t data_size;          ///< Size of data region in bytes
+    uint32_t owning_rank;        ///< ETN_ALL_RANKS for serial/replicated
+    uint32_t reserved2;          ///< Padding
+
+    /// Initialize to zeros.
+    void init() {
+        std::memset(this, 0, sizeof(*this));
+        owning_rank = ETN_ALL_RANKS;
+    }
+
+    /// Set the tensor name (truncates if too long).
+    void set_name(std::string_view n) {
+        size_t const len = std::min(n.size(), ETN_MAX_NAME - 1);
+        std::memcpy(name, n.data(), len);
+        name[len] = '\0';
+    }
+
+    /// Get the tensor name as a string.
+    [[nodiscard]] std::string get_name() const { return {name}; }
+};
+
+static_assert(sizeof(TensorEntry) == 160, "TensorEntry must be exactly 160 bytes");
+
+/// Round up to alignment boundary.
+[[nodiscard]] inline constexpr uint64_t align_up(uint64_t offset, uint64_t alignment) {
+    return (offset + alignment - 1) & ~(alignment - 1);
+}
+
+/// Get the element size for a DType.
+[[nodiscard]] inline constexpr size_t dtype_size(DType dt) {
+    switch (dt) {
+    case DType::Float32:
+        return 4;
+    case DType::Float64:
+    case DType::Complex64:
+        return 8;
+    case DType::Complex128:
+        return 16;
+    case DType::Int32:
+        return 4;
+    case DType::Int64:
+        return 8;
+    case DType::UInt32:
+        return 4;
+    case DType::UInt64:
+        return 8;
+    }
+    return 0;
+}
+
+/// Map C++ type to DType.
+template <typename T>
+constexpr DType dtype_for();
+template <>
+inline constexpr DType dtype_for<float>() {
+    return DType::Float32;
+}
+template <>
+inline constexpr DType dtype_for<double>() {
+    return DType::Float64;
+}
+template <>
+inline constexpr DType dtype_for<std::complex<float>>() {
+    return DType::Complex64;
+}
+template <>
+inline constexpr DType dtype_for<std::complex<double>>() {
+    return DType::Complex128;
+}
+template <>
+inline constexpr DType dtype_for<int32_t>() {
+    return DType::Int32;
+}
+template <>
+inline constexpr DType dtype_for<int64_t>() {
+    return DType::Int64;
+}
+template <>
+inline constexpr DType dtype_for<uint32_t>() {
+    return DType::UInt32;
+}
+template <>
+inline constexpr DType dtype_for<uint64_t>() {
+    return DType::UInt64;
+}
+
+} // namespace einsums::tensor_io

--- a/libs/Einsums/TensorIO/include/Einsums/TensorIO/GraphIO.hpp
+++ b/libs/Einsums/TensorIO/include/Einsums/TensorIO/GraphIO.hpp
@@ -1,0 +1,239 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+/// @file GraphIO.hpp
+/// @brief ComputeGraph-aware .etn file I/O operations.
+///
+/// These functions record DiskRead/DiskWrite nodes into the graph during
+/// capture. They work with IOPrefetch for async I/O overlap when using
+/// the DataflowExecutor.
+///
+/// @code
+/// #include <Einsums/TensorIO/GraphIO.hpp>
+///
+/// {
+///     cg::CaptureGuard guard(graph);
+///     tensor_io::read_etn("integrals.etn", "ERI", &eri);
+///     cg::einsum("ik;kj->ij", &C, eri, B);
+///     tensor_io::write_etn("result.etn", "C", &C);
+/// }
+/// @endcode
+
+#include <Einsums/ComputeGraph/Operations.hpp>
+#include <Einsums/ComputeGraph/TensorRank.hpp>
+#include <Einsums/Python/Annotations.hpp>
+#include <Einsums/TensorIO/Checkpoint.hpp>
+#include <Einsums/TensorIO/TensorFile.hpp>
+
+#include <string>
+
+namespace einsums {
+namespace APIARY_MODULE("io") tensor_io {
+
+/**
+ * @brief Read a tensor from a .etn file (graph-aware).
+ *
+ * During graph capture, records a DiskRead node. Outside capture, reads immediately.
+ * Works with IOPrefetch for async overlap when using DataflowExecutor.
+ */
+// clang-format off
+template <CoreBasicTensorConcept TensorType>
+APIARY_EXPOSE
+APIARY_INSTANTIATE_AS("read", einsums::GeneralRuntimeTensor<float, std::allocator<float>>)
+APIARY_INSTANTIATE_AS("read", einsums::GeneralRuntimeTensor<double, std::allocator<double>>)
+APIARY_INSTANTIATE_AS("read", einsums::GeneralRuntimeTensor<std::complex<float>, std::allocator<std::complex<float>>>)
+APIARY_INSTANTIATE_AS("read", einsums::GeneralRuntimeTensor<std::complex<double>, std::allocator<std::complex<double>>>)
+    // clang-format on
+    void read_etn(std::string file_path, std::string tensor_name, TensorType *output) {
+    auto executor = [file_path, tensor_name, output]() {
+        TensorFile file(file_path, TensorFile::Mode::Read);
+        file.read(tensor_name, *output);
+    };
+
+    if (!compute_graph::CaptureContext::current().is_capturing()) {
+        executor();
+        return;
+    }
+
+    compute_graph::read(fmt::format("read_etn({}/{})", file_path, tensor_name), file_path, tensor_name, output, std::move(executor));
+}
+
+/**
+ * @brief Write a tensor to a .etn file (graph-aware).
+ *
+ * During graph capture, records a DiskWrite node that executes after the
+ * tensor is computed. Outside capture, writes immediately.
+ */
+// clang-format off
+template <CoreBasicTensorConcept TensorType>
+APIARY_EXPOSE
+APIARY_INSTANTIATE_AS("write", einsums::GeneralRuntimeTensor<float, std::allocator<float>>)
+APIARY_INSTANTIATE_AS("write", einsums::GeneralRuntimeTensor<double, std::allocator<double>>)
+APIARY_INSTANTIATE_AS("write", einsums::GeneralRuntimeTensor<std::complex<float>, std::allocator<std::complex<float>>>)
+APIARY_INSTANTIATE_AS("write", einsums::GeneralRuntimeTensor<std::complex<double>, std::allocator<std::complex<double>>>)
+    // clang-format on
+    void write_etn(std::string file_path, std::string tensor_name, TensorType const *input) {
+    auto executor = [file_path, tensor_name, input]() {
+        TensorFile file(file_path, TensorFile::Mode::ReadWrite);
+        file.write(tensor_name, *input);
+    };
+
+    if (!compute_graph::CaptureContext::current().is_capturing()) {
+        executor();
+        return;
+    }
+
+    compute_graph::write(fmt::format("write_etn({}/{})", file_path, tensor_name), file_path, tensor_name, input, std::move(executor));
+}
+
+/**
+ * @brief A slab descriptor — per-dimension half-open ranges into a stored tensor.
+ *
+ * Used by @ref read_slice_etn and @ref write_slice_etn to address a
+ * hyperslab of a `.etn` entry. `ranges[d]` is `{start, end}` (end is
+ * exclusive). The struct is captured by reference into the graph
+ * executor lambda, so the *same* graph node can drive a loop by
+ * mutating `ranges` between executor invocations — useful for
+ * read-transform-write-back patterns over batches of an ERI.
+ */
+struct APIARY_EXPOSE Slab {
+    APIARY_EXPOSE Slab() = default;
+    APIARY_EXPOSE explicit Slab(std::vector<std::pair<size_t, size_t>> ranges) : ranges(std::move(ranges)) {}
+
+    APIARY_EXPOSE std::vector<std::pair<size_t, size_t>> ranges;
+};
+
+namespace detail {
+/// Dispatcher: route a Slab onto the right TensorFile slice method.
+/// Static-rank `Tensor<T, N>` exposes `::Rank` as a constant — use the
+/// std::array overload. Runtime-rank `GeneralRuntimeTensor<T, A>` has
+/// no such constant and goes through the std::vector overload.
+template <typename TensorType>
+void file_read_slice_dispatch(TensorFile &file, std::string_view name, TensorType &t, std::vector<std::pair<size_t, size_t>> const &rng) {
+    if constexpr (compute_graph::HasCompileTimeRank<TensorType>) {
+        constexpr size_t                         R = TensorType::Rank;
+        std::array<std::pair<size_t, size_t>, R> arr{};
+        for (size_t d = 0; d < R; ++d) {
+            arr[d] = rng[d];
+        }
+        file.read_slice(name, t, arr);
+    } else {
+        file.read_slice(name, t, rng);
+    }
+}
+
+template <typename TensorType>
+void file_write_slice_dispatch(TensorFile &file, std::string_view name, TensorType const &t,
+                               std::vector<std::pair<size_t, size_t>> const &rng) {
+    if constexpr (compute_graph::HasCompileTimeRank<TensorType>) {
+        constexpr size_t                         R = TensorType::Rank;
+        std::array<std::pair<size_t, size_t>, R> arr{};
+        for (size_t d = 0; d < R; ++d) {
+            arr[d] = rng[d];
+        }
+        file.write_slice(name, t, arr);
+    } else {
+        file.write_slice(name, t, rng);
+    }
+}
+} // namespace detail
+
+/**
+ * @brief Read a slab of a tensor from a .etn file (graph-aware).
+ *
+ * During graph capture, records a DiskRead node whose executor reads
+ * the slab described by @p slab into @p output. The Slab is captured
+ * by reference, so a loop can drive the same graph node over different
+ * slab ranges by mutating `slab.ranges` between executor invocations.
+ *
+ * @p output must be pre-sized to the slab shape. The bound TensorFile
+ * methods will throw at execute time if dimensions disagree.
+ *
+ * @code
+ * Slab slab{{ {0, 4}, {0, 4} }};
+ * tensor_io::read_slice_etn("integrals.etn", "ERI", slab, &block);
+ * @endcode
+ */
+// clang-format off
+template <CoreBasicTensorConcept TensorType>
+APIARY_EXPOSE
+APIARY_INSTANTIATE_AS("read_slice", einsums::GeneralRuntimeTensor<float, std::allocator<float>>)
+APIARY_INSTANTIATE_AS("read_slice", einsums::GeneralRuntimeTensor<double, std::allocator<double>>)
+APIARY_INSTANTIATE_AS("read_slice", einsums::GeneralRuntimeTensor<std::complex<float>, std::allocator<std::complex<float>>>)
+APIARY_INSTANTIATE_AS("read_slice", einsums::GeneralRuntimeTensor<std::complex<double>, std::allocator<std::complex<double>>>)
+    // clang-format on
+    void read_slice_etn(std::string file_path, std::string tensor_name, Slab const &slab, TensorType *output) {
+    auto executor = [file_path, tensor_name, slab_ptr = &slab, output]() {
+        TensorFile file(file_path, TensorFile::Mode::Read);
+        detail::file_read_slice_dispatch(file, tensor_name, *output, slab_ptr->ranges);
+    };
+
+    if (!compute_graph::CaptureContext::current().is_capturing()) {
+        executor();
+        return;
+    }
+
+    compute_graph::read(fmt::format("read_slice_etn({}/{})", file_path, tensor_name), file_path, tensor_name, output, std::move(executor));
+}
+
+/**
+ * @brief Write a slab of a tensor to a .etn file (graph-aware).
+ *
+ * During capture, records a DiskWrite node that, when executed, opens
+ * the file in ReadWrite mode and patches the slab described by
+ * @p slab with the contents of @p input. The target entry must
+ * already exist (e.g. via a prior @ref write_etn or
+ * @ref TensorFile::reserve). The Slab is captured by reference for
+ * loop-driven write-back patterns.
+ *
+ * @code
+ * Slab slab{{ {0, 4}, {0, 4} }};
+ * tensor_io::write_slice_etn("scratch.etn", "T", slab, &block);
+ * @endcode
+ */
+// clang-format off
+template <CoreBasicTensorConcept TensorType>
+APIARY_EXPOSE
+APIARY_INSTANTIATE_AS("write_slice", einsums::GeneralRuntimeTensor<float, std::allocator<float>>)
+APIARY_INSTANTIATE_AS("write_slice", einsums::GeneralRuntimeTensor<double, std::allocator<double>>)
+APIARY_INSTANTIATE_AS("write_slice", einsums::GeneralRuntimeTensor<std::complex<float>, std::allocator<std::complex<float>>>)
+APIARY_INSTANTIATE_AS("write_slice", einsums::GeneralRuntimeTensor<std::complex<double>, std::allocator<std::complex<double>>>)
+    // clang-format on
+    void write_slice_etn(std::string file_path, std::string tensor_name, Slab const &slab, TensorType const *input) {
+    auto executor = [file_path, tensor_name, slab_ptr = &slab, input]() {
+        TensorFile file(file_path, TensorFile::Mode::ReadWrite);
+        detail::file_write_slice_dispatch(file, tensor_name, *input, slab_ptr->ranges);
+    };
+
+    if (!compute_graph::CaptureContext::current().is_capturing()) {
+        executor();
+        return;
+    }
+
+    compute_graph::write(fmt::format("write_slice_etn({}/{})", file_path, tensor_name), file_path, tensor_name, input, std::move(executor));
+}
+
+/**
+ * @brief Checkpoint all graph tensors to a .etn file (graph-aware).
+ *
+ * During capture, records a DiskWrite node. Outside capture, saves immediately.
+ */
+inline void checkpoint_etn(std::string file_path, compute_graph::Graph &graph) {
+    auto &ctx = compute_graph::CaptureContext::current();
+    if (!ctx.is_capturing()) {
+        checkpoint::save(file_path, graph);
+        return;
+    }
+
+    auto *graph_ptr = &graph;
+    auto  executor  = [file_path, graph_ptr]() { checkpoint::save(file_path, *graph_ptr); };
+
+    ctx.record(compute_graph::OpKind::DiskWrite, fmt::format("checkpoint_etn({})", file_path), {}, {}, std::move(executor));
+}
+
+} // namespace APIARY_MODULE("io")tensor_io
+} // namespace einsums

--- a/libs/Einsums/TensorIO/include/Einsums/TensorIO/GraphIO.hpp
+++ b/libs/Einsums/TensorIO/include/Einsums/TensorIO/GraphIO.hpp
@@ -35,7 +35,7 @@ namespace einsums {
 namespace APIARY_MODULE("io") tensor_io {
 
 /**
- * @brief Read a tensor from a .etn file (graph-aware).
+ * @brief Read a tensor from a .etn file, graph-aware.
  *
  * During graph capture, records a DiskRead node. Outside capture, reads immediately.
  * Works with IOPrefetch for async overlap when using DataflowExecutor.
@@ -63,7 +63,7 @@ APIARY_INSTANTIATE_AS("read", einsums::GeneralRuntimeTensor<std::complex<double>
 }
 
 /**
- * @brief Write a tensor to a .etn file (graph-aware).
+ * @brief Write a tensor to a .etn file, graph-aware.
  *
  * During graph capture, records a DiskWrite node that executes after the
  * tensor is computed. Outside capture, writes immediately.
@@ -91,14 +91,14 @@ APIARY_INSTANTIATE_AS("write", einsums::GeneralRuntimeTensor<std::complex<double
 }
 
 /**
- * @brief A slab descriptor — per-dimension half-open ranges into a stored tensor.
+ * @brief A slab descriptor: per-dimension half-open ranges into a stored tensor.
  *
  * Used by @ref read_slice_etn and @ref write_slice_etn to address a
- * hyperslab of a `.etn` entry. `ranges[d]` is `{start, end}` (end is
- * exclusive). The struct is captured by reference into the graph
- * executor lambda, so the *same* graph node can drive a loop by
- * mutating `ranges` between executor invocations — useful for
- * read-transform-write-back patterns over batches of an ERI.
+ * hyperslab of a `.etn` entry. `ranges[d]` is `{start, end}` with end
+ * exclusive. The struct is captured by reference into the graph
+ * executor lambda, so one graph node can drive a loop by mutating
+ * `ranges` between executor invocations. This is what makes
+ * read-transform-write-back patterns over batches of an ERI possible.
  */
 struct APIARY_EXPOSE Slab {
     APIARY_EXPOSE Slab() = default;
@@ -109,8 +109,8 @@ struct APIARY_EXPOSE Slab {
 
 namespace detail {
 /// Dispatcher: route a Slab onto the right TensorFile slice method.
-/// Static-rank `Tensor<T, N>` exposes `::Rank` as a constant — use the
-/// std::array overload. Runtime-rank `GeneralRuntimeTensor<T, A>` has
+/// Static-rank `Tensor<T, N>` exposes `::Rank` as a constant, so it uses
+/// the std::array overload. Runtime-rank `GeneralRuntimeTensor<T, A>` has
 /// no such constant and goes through the std::vector overload.
 template <typename TensorType>
 void file_read_slice_dispatch(TensorFile &file, std::string_view name, TensorType &t, std::vector<std::pair<size_t, size_t>> const &rng) {
@@ -143,7 +143,7 @@ void file_write_slice_dispatch(TensorFile &file, std::string_view name, TensorTy
 } // namespace detail
 
 /**
- * @brief Read a slab of a tensor from a .etn file (graph-aware).
+ * @brief Read a slab of a tensor from a .etn file, graph-aware.
  *
  * During graph capture, records a DiskRead node whose executor reads
  * the slab described by @p slab into @p output. The Slab is captured
@@ -181,13 +181,13 @@ APIARY_INSTANTIATE_AS("read_slice", einsums::GeneralRuntimeTensor<std::complex<d
 }
 
 /**
- * @brief Write a slab of a tensor to a .etn file (graph-aware).
+ * @brief Write a slab of a tensor to a .etn file, graph-aware.
  *
  * During capture, records a DiskWrite node that, when executed, opens
  * the file in ReadWrite mode and patches the slab described by
  * @p slab with the contents of @p input. The target entry must
- * already exist (e.g. via a prior @ref write_etn or
- * @ref TensorFile::reserve). The Slab is captured by reference for
+ * already exist, for example via a prior @ref write_etn or
+ * @ref TensorFile::reserve. The Slab is captured by reference for
  * loop-driven write-back patterns.
  *
  * @code
@@ -218,7 +218,7 @@ APIARY_INSTANTIATE_AS("write_slice", einsums::GeneralRuntimeTensor<std::complex<
 }
 
 /**
- * @brief Checkpoint all graph tensors to a .etn file (graph-aware).
+ * @brief Checkpoint all graph tensors to a .etn file, graph-aware.
  *
  * During capture, records a DiskWrite node. Outside capture, saves immediately.
  */

--- a/libs/Einsums/TensorIO/include/Einsums/TensorIO/TensorFile.hpp
+++ b/libs/Einsums/TensorIO/include/Einsums/TensorIO/TensorFile.hpp
@@ -1,0 +1,514 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#pragma once
+
+/// @file TensorFile.hpp
+/// @brief High-performance tensor I/O in the .etn binary format.
+///
+/// @code
+/// using namespace einsums::tensor_io;
+///
+/// // Write
+/// TensorFile out("integrals.etn", TensorFile::Mode::Write);
+/// out.write("ERI", eri);
+/// out.write("C_mo", C);
+///
+/// // Read
+/// TensorFile in("integrals.etn", TensorFile::Mode::Read);
+/// in.read("ERI", eri);
+///
+/// // Slice read (only loads the requested range)
+/// in.read_slice("ERI", eri_slice, {{0,10}, {0,10}, {0,10}, {0,10}});
+/// @endcode
+
+#include <Einsums/Config.hpp>
+
+#include <Einsums/Python/Annotations.hpp>
+#include <Einsums/Tensor/RuntimeTensor.hpp>
+#include <Einsums/Tensor/Tensor.hpp>
+#include <Einsums/TensorIO/Format.hpp>
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace einsums {
+namespace APIARY_MODULE("io") tensor_io {
+
+class EINSUMS_EXPORT APIARY_EXPOSE APIARY_NOCOPY APIARY_NOMOVE TensorFile {
+  public:
+    enum class APIARY_EXPOSE Mode : std::uint8_t { Read, Write, ReadWrite };
+
+    /// Open or create a tensor file.
+    /// @param path File path (creates parent directories if needed).
+    /// @param mode Read, Write, or ReadWrite.
+    APIARY_EXPOSE explicit TensorFile(std::string path, Mode mode = Mode::ReadWrite);
+
+    /// Flushes pending writes and closes the file.
+    ~TensorFile();
+
+    // Non-copyable, movable.
+    TensorFile(TensorFile const &)            = delete;
+    TensorFile &operator=(TensorFile const &) = delete;
+    TensorFile(TensorFile &&)                 = default;
+    TensorFile &operator=(TensorFile &&)      = default;
+
+    // ── Write ────────────────────────────────────────────────────────────
+
+    /// Write a full tensor to the file.
+    template <typename T, size_t Rank>
+    void write(std::string_view name, Tensor<T, Rank> const &tensor);
+
+    /// Write this rank's local partition of a distributed tensor.
+    template <typename T, size_t Rank>
+    void write_local(std::string_view name, Tensor<T, Rank> const &tensor, int rank, int num_ranks);
+
+    /// Write a slice (hyperslab) of an existing tensor entry. The entry
+    /// must already exist (e.g. from a previous full @ref write or a
+    /// pre-allocated entry). The user tensor's shape must match the
+    /// slab implied by @p ranges.
+    /// @param ranges Per-dimension [start, end) ranges into the stored tensor.
+    template <typename T, size_t Rank>
+    void write_slice(std::string_view name, Tensor<T, Rank> const &tensor, std::array<std::pair<size_t, size_t>, Rank> const &ranges);
+
+    /// Reserve space for a tensor that will be filled in via @ref
+    /// write_slice. Stores the entry header (name, dtype, dims) and
+    /// allocates the data region but writes no data. Use this when you
+    /// plan to fill the tensor block-by-block from a graph or loop.
+    template <typename T>
+    void reserve(std::string_view name, std::vector<size_t> const &dims);
+
+    // ── Read ─────────────────────────────────────────────────────────────
+
+    /// Read a full tensor. Resizes the tensor if dimensions don't match.
+    template <typename T, size_t Rank>
+    void read(std::string_view name, Tensor<T, Rank> &tensor);
+
+    /// Read a slice (hyperslab) of a tensor.
+    /// @param ranges Per-dimension [start, end) ranges.
+    template <typename T, size_t Rank>
+    void read_slice(std::string_view name, Tensor<T, Rank> &tensor, std::array<std::pair<size_t, size_t>, Rank> const &ranges);
+
+    /// Read this rank's local partition of a distributed tensor.
+    template <typename T, size_t Rank>
+    void read_local(std::string_view name, Tensor<T, Rank> &tensor, int rank);
+
+    // ── RuntimeTensor overloads ──────────────────────────────────────────
+    //
+    // RuntimeTensor variants of read / write / read_slice / write_slice.
+    // These are what the Python bindings call into — RuntimeTensor is
+    // the runtime-rank type bound to numpy via the buffer protocol.
+
+    /// Read a full tensor into a RuntimeTensor. Resizes the tensor.
+    template <typename T, typename Alloc>
+    APIARY_EXPOSE APIARY_INSTANTIATE_MEMBER_AS("read", T = float, Alloc = std::allocator<float>)
+        APIARY_INSTANTIATE_MEMBER_AS("read", T = double, Alloc = std::allocator<double>)
+            APIARY_INSTANTIATE_MEMBER_AS("read", T = std::complex<float>, Alloc = std::allocator<std::complex<float>>)
+                APIARY_INSTANTIATE_MEMBER_AS("read", T = std::complex<double>, Alloc = std::allocator<std::complex<double>>) void read(
+                    std::string_view name, GeneralRuntimeTensor<T, Alloc> &tensor);
+
+    /// Write a full RuntimeTensor as a new entry.
+    template <typename T, typename Alloc>
+    APIARY_EXPOSE APIARY_INSTANTIATE_MEMBER_AS("write", T = float, Alloc = std::allocator<float>)
+        APIARY_INSTANTIATE_MEMBER_AS("write", T = double, Alloc = std::allocator<double>)
+            APIARY_INSTANTIATE_MEMBER_AS("write", T = std::complex<float>, Alloc = std::allocator<std::complex<float>>)
+                APIARY_INSTANTIATE_MEMBER_AS("write", T = std::complex<double>, Alloc = std::allocator<std::complex<double>>) void write(
+                    std::string_view name, GeneralRuntimeTensor<T, Alloc> const &tensor);
+
+    /// Read a slice into a pre-sized RuntimeTensor. The tensor's dims
+    /// must equal the slab (ranges[d].second - ranges[d].first).
+    template <typename T, typename Alloc>
+    APIARY_EXPOSE APIARY_INSTANTIATE_MEMBER_AS("read_slice", T = float, Alloc = std::allocator<float>)
+        APIARY_INSTANTIATE_MEMBER_AS("read_slice", T = double, Alloc = std::allocator<double>)
+            APIARY_INSTANTIATE_MEMBER_AS("read_slice", T = std::complex<float>, Alloc = std::allocator<std::complex<float>>)
+                APIARY_INSTANTIATE_MEMBER_AS(
+                    "read_slice", T = std::complex<double>,
+                    Alloc = std::allocator<std::complex<double>>) void read_slice(std::string_view                              name,
+                                                                                  GeneralRuntimeTensor<T, Alloc>               &tensor,
+                                                                                  std::vector<std::pair<size_t, size_t>> const &ranges);
+
+    /// Write a slice (hyperslab) of an existing entry from a RuntimeTensor.
+    template <typename T, typename Alloc>
+    APIARY_EXPOSE APIARY_INSTANTIATE_MEMBER_AS("write_slice", T = float, Alloc = std::allocator<float>)
+        APIARY_INSTANTIATE_MEMBER_AS("write_slice", T = double, Alloc = std::allocator<double>)
+            APIARY_INSTANTIATE_MEMBER_AS("write_slice", T = std::complex<float>, Alloc = std::allocator<std::complex<float>>)
+                APIARY_INSTANTIATE_MEMBER_AS(
+                    "write_slice", T = std::complex<double>,
+                    Alloc = std::allocator<std::complex<double>>) void write_slice(std::string_view                              name,
+                                                                                   GeneralRuntimeTensor<T, Alloc> const         &tensor,
+                                                                                   std::vector<std::pair<size_t, size_t>> const &ranges);
+
+    // ── Query ────────────────────────────────────────────────────────────
+
+    /// Check if a tensor exists in the file.
+    APIARY_EXPOSE [[nodiscard]] bool contains(std::string_view name) const;
+
+    /// Get the stored dimensions of a tensor.
+    APIARY_EXPOSE [[nodiscard]] std::vector<size_t> dims(std::string_view name) const;
+
+    /// Get the stored dtype of a tensor (currently not exposed to Python:
+    /// DType enum lives in Format.hpp and isn't bound). Use ``dims`` and
+    /// ``contains`` from Python; per-dtype dispatch happens via the
+    /// ``read``/``write`` ``dtype=`` kwarg.
+    [[nodiscard]] DType dtype(std::string_view name) const;
+
+    /// List all tensor names in the file.
+    APIARY_EXPOSE [[nodiscard]] std::vector<std::string> tensor_names() const;
+
+    /// Number of tensors in the file.
+    APIARY_EXPOSE [[nodiscard]] size_t num_tensors() const { return _entries.size(); }
+
+    /// Flush pending writes to disk.
+    APIARY_EXPOSE void flush();
+
+    /// Get the file path.
+    APIARY_EXPOSE [[nodiscard]] std::string const &path() const { return _path; }
+
+  private:
+    std::string                             _path;
+    Mode                                    _mode;
+    int                                     _fd{-1}; ///< POSIX file descriptor
+    FileHeader                              _header;
+    std::vector<TensorEntry>                _entries;
+    std::unordered_map<std::string, size_t> _name_to_index;    ///< name → entry index
+    uint64_t                                _next_data_offset; ///< Next available offset for data
+
+    /// Find entry by name (throws if not found).
+    [[nodiscard]] TensorEntry const &find_entry(std::string_view name) const;
+
+    /// Write raw bytes at a specific offset.
+    void write_at(uint64_t offset, void const *data, size_t bytes);
+
+    /// Read raw bytes from a specific offset.
+    void read_at(uint64_t offset, void *data, size_t bytes) const;
+
+    /// Write the header and entry table to disk.
+    void write_metadata();
+
+    /// Read the header and entry table from disk.
+    void read_metadata();
+
+    /// Add a new entry and return its index.
+    size_t add_entry(TensorEntry entry);
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Slab walker — shared between read_slice and write_slice (static + runtime).
+// ═══════════════════════════════════════════════════════════════════════════════
+
+namespace detail {
+
+/// Walk every contiguous innermost run inside a hyperslab of a
+/// column-major tensor and invoke @p visit(file_offset, dst_offset,
+/// inner_bytes) for each. Lets read_slice and write_slice share the
+/// same offset-arithmetic without code duplication.
+///
+/// `entry_dims` and `ranges` are runtime-rank (vectors). The caller is
+/// responsible for ensuring sizes agree with the actual tensor rank.
+template <typename T, typename Visit>
+void walk_slab(uint64_t entry_data_offset, std::vector<size_t> const &entry_dims, std::vector<std::pair<size_t, size_t>> const &ranges,
+               Visit &&visit) {
+    size_t const rank = entry_dims.size();
+    if (rank == 0) {
+        // Scalar entry — emit a single zero-byte run.
+        visit(entry_data_offset, std::size_t{0}, std::size_t{0});
+        return;
+    }
+
+    // Column-major strides for the stored tensor: stride[0]=1, stride[d]=prod dims[0..d-1].
+    std::vector<size_t> strides(rank);
+    strides[0] = 1;
+    for (size_t d = 1; d < rank; ++d) {
+        strides[d] = strides[d - 1] * entry_dims[d - 1];
+    }
+
+    size_t const inner_count = ranges[0].second - ranges[0].first;
+    size_t const inner_bytes = inner_count * sizeof(T);
+
+    if (rank == 1) {
+        uint64_t const src_offset = entry_data_offset + ranges[0].first * sizeof(T);
+        visit(src_offset, std::size_t{0}, inner_bytes);
+        return;
+    }
+
+    std::vector<size_t> idx(rank);
+    for (size_t d = 0; d < rank; ++d) {
+        idx[d] = ranges[d].first;
+    }
+
+    auto advance_outer = [&]() -> bool {
+        for (size_t d = 1; d < rank; ++d) {
+            idx[d]++;
+            if (idx[d] < ranges[d].second) {
+                return true;
+            }
+            idx[d] = ranges[d].first;
+        }
+        return false;
+    };
+
+    size_t dst_offset = 0;
+    do {
+        uint64_t file_offset = entry_data_offset;
+        for (size_t d = 1; d < rank; ++d) {
+            file_offset += idx[d] * strides[d] * sizeof(T);
+        }
+        file_offset += ranges[0].first * sizeof(T);
+        visit(file_offset, dst_offset, inner_bytes);
+        dst_offset += inner_bytes;
+    } while (advance_outer());
+}
+
+} // namespace detail
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Template implementations
+// ═══════════════════════════════════════════════════════════════════════════════
+
+template <typename T, size_t Rank>
+void TensorFile::write(std::string_view name, Tensor<T, Rank> const &tensor) {
+    TensorEntry entry;
+    entry.init();
+    entry.set_name(name);
+    entry.dtype = static_cast<uint8_t>(dtype_for<T>());
+    entry.rank  = static_cast<uint8_t>(Rank);
+    for (size_t d = 0; d < Rank; d++)
+        entry.dims[d] = tensor.dim(d);
+
+    size_t data_bytes = tensor.size() * sizeof(T);
+    entry.data_offset = align_up(_next_data_offset, ETN_DATA_ALIGNMENT);
+    entry.data_size   = data_bytes;
+    entry.owning_rank = ETN_ALL_RANKS;
+
+    write_at(entry.data_offset, tensor.data(), data_bytes);
+    _next_data_offset = entry.data_offset + data_bytes;
+
+    add_entry(entry);
+}
+
+template <typename T, size_t Rank>
+void TensorFile::write_local(std::string_view name, Tensor<T, Rank> const &tensor, int rank, int num_ranks) {
+    TensorEntry entry;
+    entry.init();
+    entry.set_name(name);
+    entry.dtype = static_cast<uint8_t>(dtype_for<T>());
+    entry.rank  = static_cast<uint8_t>(Rank);
+    for (size_t d = 0; d < Rank; d++)
+        entry.dims[d] = tensor.dim(d);
+
+    size_t data_bytes = tensor.size() * sizeof(T);
+    entry.data_offset = align_up(_next_data_offset, ETN_DATA_ALIGNMENT);
+    entry.data_size   = data_bytes;
+    entry.owning_rank = static_cast<uint32_t>(rank);
+
+    write_at(entry.data_offset, tensor.data(), data_bytes);
+    _next_data_offset = entry.data_offset + data_bytes;
+
+    add_entry(entry);
+
+    // Update header flags
+    _header.flags |= 0x1; // has distributed tensors
+    _header.num_ranks = std::max(_header.num_ranks, static_cast<uint32_t>(num_ranks));
+}
+
+template <typename T, size_t Rank>
+void TensorFile::read(std::string_view name, Tensor<T, Rank> &tensor) {
+    auto const &entry = find_entry(name);
+
+    // Resize tensor if needed
+    Dim<Rank> dims;
+    for (size_t d = 0; d < Rank; d++)
+        dims[d] = entry.dims[d];
+    tensor.resize(dims);
+
+    read_at(entry.data_offset, tensor.data(), entry.data_size);
+}
+
+template <typename T, size_t Rank>
+void TensorFile::read_slice(std::string_view name, Tensor<T, Rank> &tensor, std::array<std::pair<size_t, size_t>, Rank> const &ranges) {
+    auto const &entry = find_entry(name);
+
+    Dim<Rank> slice_dims;
+    for (size_t d = 0; d < Rank; ++d) {
+        slice_dims[d] = ranges[d].second - ranges[d].first;
+    }
+    tensor.resize(slice_dims);
+
+    std::vector<size_t> entry_dims(Rank);
+    for (size_t d = 0; d < Rank; ++d) {
+        entry_dims[d] = entry.dims[d];
+    }
+    std::vector<std::pair<size_t, size_t>> rng(ranges.begin(), ranges.end());
+
+    char *dst = reinterpret_cast<char *>(tensor.data());
+    detail::walk_slab<T>(entry.data_offset, entry_dims, rng,
+                         [&](uint64_t file_off, size_t dst_off, size_t bytes) { read_at(file_off, dst + dst_off, bytes); });
+}
+
+template <typename T, size_t Rank>
+void TensorFile::write_slice(std::string_view name, Tensor<T, Rank> const &tensor,
+                             std::array<std::pair<size_t, size_t>, Rank> const &ranges) {
+    auto const &entry = find_entry(name);
+
+    // Validate user tensor matches the requested slab shape.
+    for (size_t d = 0; d < Rank; ++d) {
+        size_t const want = ranges[d].second - ranges[d].first;
+        if (tensor.dim(d) != want) {
+            throw std::runtime_error(fmt::format("TensorFile::write_slice: tensor dim {} = {} but slab range is [{}, {}) (size {})", d,
+                                                 tensor.dim(d), ranges[d].first, ranges[d].second, want));
+        }
+    }
+
+    std::vector<size_t> entry_dims(Rank);
+    for (size_t d = 0; d < Rank; ++d) {
+        entry_dims[d] = entry.dims[d];
+    }
+    std::vector<std::pair<size_t, size_t>> rng(ranges.begin(), ranges.end());
+
+    char const *src = reinterpret_cast<char const *>(tensor.data());
+    detail::walk_slab<T>(entry.data_offset, entry_dims, rng,
+                         [&](uint64_t file_off, size_t src_off, size_t bytes) { write_at(file_off, src + src_off, bytes); });
+}
+
+template <typename T>
+void TensorFile::reserve(std::string_view name, std::vector<size_t> const &dims) {
+    if (dims.size() > 8) {
+        throw std::runtime_error(fmt::format("TensorFile::reserve: rank {} exceeds maximum supported rank 8", dims.size()));
+    }
+
+    TensorEntry entry;
+    entry.init();
+    entry.set_name(name);
+    entry.dtype = static_cast<uint8_t>(dtype_for<T>());
+    entry.rank  = static_cast<uint8_t>(dims.size());
+    for (size_t d = 0; d < dims.size(); ++d) {
+        entry.dims[d] = dims[d];
+    }
+
+    size_t total = 1;
+    for (size_t const d : dims) {
+        total *= d;
+    }
+    size_t const data_bytes = total * sizeof(T);
+
+    entry.data_offset = align_up(_next_data_offset, ETN_DATA_ALIGNMENT);
+    entry.data_size   = data_bytes;
+    entry.owning_rank = ETN_ALL_RANKS;
+    _next_data_offset = entry.data_offset + data_bytes;
+
+    add_entry(entry);
+}
+
+// ── RuntimeTensor overloads ──────────────────────────────────────────
+
+template <typename T, typename Alloc>
+void TensorFile::read(std::string_view name, GeneralRuntimeTensor<T, Alloc> &tensor) {
+    auto const &entry = find_entry(name);
+
+    std::vector<size_t> dims(entry.rank);
+    for (size_t d = 0; d < entry.rank; ++d) {
+        dims[d] = entry.dims[d];
+    }
+    tensor.resize(dims);
+
+    read_at(entry.data_offset, tensor.data(), entry.data_size);
+}
+
+template <typename T, typename Alloc>
+void TensorFile::write(std::string_view name, GeneralRuntimeTensor<T, Alloc> const &tensor) {
+    TensorEntry entry;
+    entry.init();
+    entry.set_name(name);
+    entry.dtype = static_cast<uint8_t>(dtype_for<T>());
+    entry.rank  = static_cast<uint8_t>(tensor.rank());
+    for (size_t d = 0; d < tensor.rank(); ++d) {
+        entry.dims[d] = tensor.dim(d);
+    }
+
+    size_t const data_bytes = tensor.size() * sizeof(T);
+    entry.data_offset       = align_up(_next_data_offset, ETN_DATA_ALIGNMENT);
+    entry.data_size         = data_bytes;
+    entry.owning_rank       = ETN_ALL_RANKS;
+
+    write_at(entry.data_offset, tensor.data(), data_bytes);
+    _next_data_offset = entry.data_offset + data_bytes;
+
+    add_entry(entry);
+}
+
+template <typename T, typename Alloc>
+void TensorFile::read_slice(std::string_view name, GeneralRuntimeTensor<T, Alloc> &tensor,
+                            std::vector<std::pair<size_t, size_t>> const &ranges) {
+    auto const &entry = find_entry(name);
+    if (ranges.size() != entry.rank) {
+        throw std::runtime_error(fmt::format("TensorFile::read_slice: ranges size {} != entry rank {}", ranges.size(), entry.rank));
+    }
+
+    std::vector<size_t> slab_dims(ranges.size());
+    for (size_t d = 0; d < ranges.size(); ++d) {
+        slab_dims[d] = ranges[d].second - ranges[d].first;
+    }
+    tensor.resize(slab_dims);
+
+    std::vector<size_t> entry_dims(entry.rank);
+    for (size_t d = 0; d < entry.rank; ++d) {
+        entry_dims[d] = entry.dims[d];
+    }
+
+    char *dst = reinterpret_cast<char *>(tensor.data());
+    detail::walk_slab<T>(entry.data_offset, entry_dims, ranges,
+                         [&](uint64_t file_off, size_t dst_off, size_t bytes) { read_at(file_off, dst + dst_off, bytes); });
+}
+
+template <typename T, typename Alloc>
+void TensorFile::write_slice(std::string_view name, GeneralRuntimeTensor<T, Alloc> const &tensor,
+                             std::vector<std::pair<size_t, size_t>> const &ranges) {
+    auto const &entry = find_entry(name);
+    if (ranges.size() != entry.rank) {
+        throw std::runtime_error(fmt::format("TensorFile::write_slice: ranges size {} != entry rank {}", ranges.size(), entry.rank));
+    }
+    if (tensor.rank() != entry.rank) {
+        throw std::runtime_error(fmt::format("TensorFile::write_slice: tensor rank {} != entry rank {}", tensor.rank(), entry.rank));
+    }
+    for (size_t d = 0; d < ranges.size(); ++d) {
+        size_t const want = ranges[d].second - ranges[d].first;
+        if (tensor.dim(d) != want) {
+            throw std::runtime_error(fmt::format("TensorFile::write_slice: tensor dim {} = {} but slab range is [{}, {}) (size {})", d,
+                                                 tensor.dim(d), ranges[d].first, ranges[d].second, want));
+        }
+    }
+
+    std::vector<size_t> entry_dims(entry.rank);
+    for (size_t d = 0; d < entry.rank; ++d) {
+        entry_dims[d] = entry.dims[d];
+    }
+
+    char const *src = reinterpret_cast<char const *>(tensor.data());
+    detail::walk_slab<T>(entry.data_offset, entry_dims, ranges,
+                         [&](uint64_t file_off, size_t src_off, size_t bytes) { write_at(file_off, src + src_off, bytes); });
+}
+
+template <typename T, size_t Rank>
+void TensorFile::read_local(std::string_view name, Tensor<T, Rank> &tensor, int rank) {
+    // Find the entry for this specific rank
+    std::string const name_str(name);
+    for (auto const &entry : _entries) {
+        if (entry.get_name() == name_str && std::cmp_equal(entry.owning_rank, rank)) {
+            Dim<Rank> dims;
+            for (size_t d = 0; d < Rank; d++)
+                dims[d] = entry.dims[d];
+            tensor.resize(dims);
+            read_at(entry.data_offset, tensor.data(), entry.data_size);
+            return;
+        }
+    }
+    throw std::runtime_error(fmt::format("TensorFile: no entry for '{}' with rank {}", name, rank));
+}
+
+} // namespace APIARY_MODULE("io")tensor_io
+} // namespace einsums

--- a/libs/Einsums/TensorIO/include/Einsums/TensorIO/TensorFile.hpp
+++ b/libs/Einsums/TensorIO/include/Einsums/TensorIO/TensorFile.hpp
@@ -101,7 +101,7 @@ class EINSUMS_EXPORT APIARY_EXPOSE APIARY_NOCOPY APIARY_NOMOVE TensorFile {
     // ── RuntimeTensor overloads ──────────────────────────────────────────
     //
     // RuntimeTensor variants of read / write / read_slice / write_slice.
-    // These are what the Python bindings call into — RuntimeTensor is
+    // These are what the Python bindings call into. RuntimeTensor is
     // the runtime-rank type bound to numpy via the buffer protocol.
 
     /// Read a full tensor into a RuntimeTensor. Resizes the tensor.
@@ -198,7 +198,7 @@ class EINSUMS_EXPORT APIARY_EXPOSE APIARY_NOCOPY APIARY_NOMOVE TensorFile {
 };
 
 // ═══════════════════════════════════════════════════════════════════════════════
-// Slab walker — shared between read_slice and write_slice (static + runtime).
+// Slab walker, shared between read_slice and write_slice (static + runtime).
 // ═══════════════════════════════════════════════════════════════════════════════
 
 namespace detail {
@@ -215,7 +215,7 @@ void walk_slab(uint64_t entry_data_offset, std::vector<size_t> const &entry_dims
                Visit &&visit) {
     size_t const rank = entry_dims.size();
     if (rank == 0) {
-        // Scalar entry — emit a single zero-byte run.
+        // Scalar entry: emit a single zero-byte run.
         visit(entry_data_offset, std::size_t{0}, std::size_t{0});
         return;
     }

--- a/libs/Einsums/TensorIO/src/Checkpoint.cpp
+++ b/libs/Einsums/TensorIO/src/Checkpoint.cpp
@@ -1,0 +1,339 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#include <Einsums/Comm/Runtime.hpp>
+#include <Einsums/ComputeGraph/Graph.hpp>
+#include <Einsums/ComputeGraph/Workspace.hpp>
+#include <Einsums/Logging.hpp>
+#include <Einsums/Tensor/Tensor.hpp>
+#include <Einsums/TensorIO/Checkpoint.hpp>
+
+#include <complex>
+#include <unordered_set>
+
+namespace einsums::tensor_io::checkpoint {
+
+namespace {
+
+/// Runtime dispatch: write a type-erased tensor to a TensorFile.
+void write_handle(TensorFile &file, compute_graph::TensorHandle const &handle) {
+    if (!handle.tensor_ptr || handle.rank == 0)
+        return;
+
+    auto go = [&]<typename T>(T /*tag*/) {
+        switch (handle.rank) {
+        case 1:
+            file.write(handle.name, *static_cast<Tensor<T, 1> const *>(handle.tensor_ptr));
+            break;
+        case 2:
+            file.write(handle.name, *static_cast<Tensor<T, 2> const *>(handle.tensor_ptr));
+            break;
+        case 3:
+            file.write(handle.name, *static_cast<Tensor<T, 3> const *>(handle.tensor_ptr));
+            break;
+        case 4:
+            file.write(handle.name, *static_cast<Tensor<T, 4> const *>(handle.tensor_ptr));
+            break;
+        default:
+            break;
+        }
+    };
+
+    switch (handle.dtype) {
+    case packed_gemm::ScalarType::Float32:
+        go(float{});
+        break;
+    case packed_gemm::ScalarType::Float64:
+        go(double{});
+        break;
+    case packed_gemm::ScalarType::Complex64:
+        go(std::complex<float>{});
+        break;
+    case packed_gemm::ScalarType::Complex128:
+        go(std::complex<double>{});
+        break;
+    default:
+        break;
+    }
+}
+
+/// Runtime dispatch: read a type-erased tensor from a TensorFile.
+void read_handle(TensorFile &file, compute_graph::TensorHandle const &handle) {
+    if (!handle.tensor_ptr || handle.rank == 0)
+        return;
+    if (!file.contains(handle.name))
+        return;
+
+    auto go = [&]<typename T>(T /*tag*/) {
+        switch (handle.rank) {
+        case 1:
+            file.read(handle.name, *static_cast<Tensor<T, 1> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        case 2:
+            file.read(handle.name, *static_cast<Tensor<T, 2> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        case 3:
+            file.read(handle.name, *static_cast<Tensor<T, 3> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        case 4:
+            file.read(handle.name, *static_cast<Tensor<T, 4> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        default:
+            break;
+        }
+    };
+
+    switch (handle.dtype) {
+    case packed_gemm::ScalarType::Float32:
+        go(float{});
+        break;
+    case packed_gemm::ScalarType::Float64:
+        go(double{});
+        break;
+    case packed_gemm::ScalarType::Complex64:
+        go(std::complex<float>{});
+        break;
+    case packed_gemm::ScalarType::Complex128:
+        go(std::complex<double>{});
+        break;
+    default:
+        break;
+    }
+}
+
+/// Distributed write dispatch.
+void write_handle_distributed(DistributedTensorFile &file, compute_graph::TensorHandle const &handle) {
+    if (!handle.tensor_ptr || handle.rank == 0)
+        return;
+
+    auto go_repl = [&]<typename T>(T /*tag*/) {
+        switch (handle.rank) {
+        case 1:
+            file.write(handle.name, *static_cast<Tensor<T, 1> const *>(handle.tensor_ptr));
+            break;
+        case 2:
+            file.write(handle.name, *static_cast<Tensor<T, 2> const *>(handle.tensor_ptr));
+            break;
+        case 3:
+            file.write(handle.name, *static_cast<Tensor<T, 3> const *>(handle.tensor_ptr));
+            break;
+        case 4:
+            file.write(handle.name, *static_cast<Tensor<T, 4> const *>(handle.tensor_ptr));
+            break;
+        default:
+            break;
+        }
+    };
+
+    auto go_local = [&]<typename T>(T /*tag*/) {
+        switch (handle.rank) {
+        case 1:
+            file.write_local(handle.name, *static_cast<Tensor<T, 1> const *>(handle.tensor_ptr));
+            break;
+        case 2:
+            file.write_local(handle.name, *static_cast<Tensor<T, 2> const *>(handle.tensor_ptr));
+            break;
+        case 3:
+            file.write_local(handle.name, *static_cast<Tensor<T, 3> const *>(handle.tensor_ptr));
+            break;
+        case 4:
+            file.write_local(handle.name, *static_cast<Tensor<T, 4> const *>(handle.tensor_ptr));
+            break;
+        default:
+            break;
+        }
+    };
+
+    auto dispatch = [&](auto go) {
+        switch (handle.dtype) {
+        case packed_gemm::ScalarType::Float32:
+            go(float{});
+            break;
+        case packed_gemm::ScalarType::Float64:
+            go(double{});
+            break;
+        case packed_gemm::ScalarType::Complex64:
+            go(std::complex<float>{});
+            break;
+        case packed_gemm::ScalarType::Complex128:
+            go(std::complex<double>{});
+            break;
+        default:
+            break;
+        }
+    };
+
+    if (handle.is_distributed && !handle.is_replicated)
+        dispatch(go_local);
+    else
+        dispatch(go_repl);
+}
+
+/// Distributed read dispatch.
+void read_handle_distributed(DistributedTensorFile &file, compute_graph::TensorHandle const &handle) {
+    if (!handle.tensor_ptr || handle.rank == 0)
+        return;
+    if (!file.contains(handle.name))
+        return;
+
+    auto go_repl = [&]<typename T>(T /*tag*/) {
+        switch (handle.rank) {
+        case 1:
+            file.read(handle.name, *static_cast<Tensor<T, 1> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        case 2:
+            file.read(handle.name, *static_cast<Tensor<T, 2> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        case 3:
+            file.read(handle.name, *static_cast<Tensor<T, 3> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        case 4:
+            file.read(handle.name, *static_cast<Tensor<T, 4> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        default:
+            break;
+        }
+    };
+
+    auto go_local = [&]<typename T>(T /*tag*/) {
+        switch (handle.rank) {
+        case 1:
+            file.read_local(handle.name, *static_cast<Tensor<T, 1> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        case 2:
+            file.read_local(handle.name, *static_cast<Tensor<T, 2> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        case 3:
+            file.read_local(handle.name, *static_cast<Tensor<T, 3> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        case 4:
+            file.read_local(handle.name, *static_cast<Tensor<T, 4> *>(const_cast<void *>(handle.tensor_ptr)));
+            break;
+        default:
+            break;
+        }
+    };
+
+    auto dispatch = [&](auto go) {
+        switch (handle.dtype) {
+        case packed_gemm::ScalarType::Float32:
+            go(float{});
+            break;
+        case packed_gemm::ScalarType::Float64:
+            go(double{});
+            break;
+        case packed_gemm::ScalarType::Complex64:
+            go(std::complex<float>{});
+            break;
+        case packed_gemm::ScalarType::Complex128:
+            go(std::complex<double>{});
+            break;
+        default:
+            break;
+        }
+    };
+
+    if (handle.is_distributed && !handle.is_replicated)
+        dispatch(go_local);
+    else
+        dispatch(go_repl);
+}
+
+bool passes_filter(std::string const &name, std::unordered_set<std::string> const &filter) {
+    return filter.empty() || filter.count(name) > 0;
+}
+
+} // namespace
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Graph
+// ═══════════════════════════════════════════════════════════════════════════════
+
+void save(std::string const &path, compute_graph::Graph const &graph, std::vector<std::string> const &tensor_names) {
+    TensorFile                            file(path, TensorFile::Mode::Write);
+    std::unordered_set<std::string> const filter(tensor_names.begin(), tensor_names.end());
+
+    size_t count = 0;
+    for (auto const &[tid, handle] : graph.tensors_map()) {
+        if (passes_filter(handle.name, filter)) {
+            write_handle(file, handle);
+            count++;
+        }
+    }
+    EINSUMS_LOG_INFO("checkpoint::save: wrote {} tensors to '{}'", count, path);
+}
+
+void restore(std::string const &path, compute_graph::Graph &graph) {
+    TensorFile file(path, TensorFile::Mode::Read);
+
+    size_t count = 0;
+    for (auto const &[tid, handle] : graph.tensors_map()) {
+        read_handle(file, handle);
+        count++;
+    }
+    EINSUMS_LOG_INFO("checkpoint::restore: read {} tensors from '{}'", count, path);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Workspace
+// ═══════════════════════════════════════════════════════════════════════════════
+
+void save(std::string const &path, compute_graph::Workspace const &workspace, std::vector<std::string> const &tensor_names) {
+    TensorFile                            file(path, TensorFile::Mode::Write);
+    std::unordered_set<std::string> const filter(tensor_names.begin(), tensor_names.end());
+
+    size_t count = 0;
+    for (auto const &handle : workspace.tensor_handles()) {
+        if (passes_filter(handle.name, filter)) {
+            write_handle(file, handle);
+            count++;
+        }
+    }
+    EINSUMS_LOG_INFO("checkpoint::save(workspace): wrote {} tensors to '{}'", count, path);
+}
+
+void restore(std::string const &path, compute_graph::Workspace &workspace) {
+    TensorFile file(path, TensorFile::Mode::Read);
+
+    size_t count = 0;
+    for (auto const &handle : workspace.tensor_handles()) {
+        read_handle(file, handle);
+        count++;
+    }
+    EINSUMS_LOG_INFO("checkpoint::restore(workspace): read {} tensors from '{}'", count, path);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Distributed
+// ═══════════════════════════════════════════════════════════════════════════════
+
+void save_distributed(std::string const &path, compute_graph::Graph const &graph, std::vector<std::string> const &tensor_names) {
+    DistributedTensorFile                 file(path, DistributedTensorFile::Mode::Write);
+    std::unordered_set<std::string> const filter(tensor_names.begin(), tensor_names.end());
+
+    size_t count = 0;
+    for (auto const &[tid, handle] : graph.tensors_map()) {
+        if (passes_filter(handle.name, filter)) {
+            write_handle_distributed(file, handle);
+            count++;
+        }
+    }
+    EINSUMS_LOG_INFO("checkpoint::save_distributed: wrote {} tensors to '{}' (rank {}/{})", count, path, comm::world_rank(),
+                     comm::world_size());
+}
+
+void restore_distributed(std::string const &path, compute_graph::Graph &graph) {
+    DistributedTensorFile file(path, DistributedTensorFile::Mode::Read);
+
+    size_t count = 0;
+    for (auto const &[tid, handle] : graph.tensors_map()) {
+        read_handle_distributed(file, handle);
+        count++;
+    }
+    EINSUMS_LOG_INFO("checkpoint::restore_distributed: read {} tensors from '{}' (rank {}/{})", count, path, comm::world_rank(),
+                     comm::world_size());
+}
+
+} // namespace einsums::tensor_io::checkpoint

--- a/libs/Einsums/TensorIO/src/DistributedTensorFile.cpp
+++ b/libs/Einsums/TensorIO/src/DistributedTensorFile.cpp
@@ -1,0 +1,252 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#include <Einsums/Errors/ThrowException.hpp>
+#include <Einsums/Logging.hpp>
+#include <Einsums/TensorIO/DistributedTensorFile.hpp>
+
+// Always use POSIX I/O for file operations. MPI is only used for offset
+// coordination (Exscan, Allreduce, Gather). This avoids MPI-IO reliability
+// issues on local filesystems (especially macOS).
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#if defined(EINSUMS_HAVE_MPI)
+#    include <mpi.h>
+#endif
+
+#include <cerrno>
+#include <cstring>
+
+namespace einsums::tensor_io {
+
+DistributedTensorFile::DistributedTensorFile(std::string path, Mode mode)
+    : _path(std::move(path)), _mode(mode), _my_rank(comm::world_rank()), _num_ranks(comm::world_size()) {
+
+    // Rank 0 creates/truncates the file; all ranks then open it.
+#if defined(EINSUMS_HAVE_MPI)
+    MPI_Barrier(MPI_COMM_WORLD);
+#endif
+
+    if (_mode == Mode::Write) {
+        if (_my_rank == 0) {
+            _fd = ::open(_path.c_str(), O_RDWR | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH);
+        }
+#if defined(EINSUMS_HAVE_MPI)
+        MPI_Barrier(MPI_COMM_WORLD); // Wait for rank 0 to create the file
+#endif
+        if (_my_rank != 0) {
+            _fd = ::open(_path.c_str(), O_RDWR, S_IRUSR | S_IWUSR);
+        }
+    } else {
+        _fd = ::open(_path.c_str(), O_RDONLY);
+    }
+
+    if (_fd < 0) {
+        EINSUMS_THROW_EXCEPTION(std::runtime_error, "DistributedTensorFile: cannot open '{}': {}", _path, std::strerror(errno));
+    }
+
+    if (_mode == Mode::Write) {
+        _header.init();
+        _header.num_ranks = static_cast<uint32_t>(_num_ranks);
+        _next_data_offset = _header.data_offset;
+        if (_my_rank == 0) {
+            write_at(0, &_header, sizeof(FileHeader));
+        }
+#if defined(EINSUMS_HAVE_MPI)
+        MPI_Barrier(MPI_COMM_WORLD);
+#endif
+    } else {
+        read_metadata();
+    }
+}
+
+// NOLINTNEXTLINE(bugprone-exception-escape)
+DistributedTensorFile::~DistributedTensorFile() {
+    if (!_closed) {
+        close();
+    }
+}
+
+void DistributedTensorFile::close() {
+    if (_closed)
+        return;
+
+    if (_mode == Mode::Write) {
+        write_metadata();
+    }
+
+    if (_fd >= 0) {
+        ::close(_fd);
+        _fd = -1;
+    }
+
+    _closed = true;
+    EINSUMS_LOG_INFO("DistributedTensorFile: closed '{}' ({} entries, {} ranks)", _path, _entries.size(), _num_ranks);
+}
+
+void DistributedTensorFile::write_at(uint64_t offset, void const *data, size_t bytes) {
+    if (bytes == 0)
+        return;
+    auto  *ptr   = static_cast<char const *>(data);
+    size_t total = 0;
+    while (total < bytes) {
+        ssize_t const written = ::pwrite(_fd, ptr + total, bytes - total, static_cast<off_t>(offset + total));
+        if (written < 0) {
+            if (errno == EINTR)
+                continue;
+            EINSUMS_THROW_EXCEPTION(std::runtime_error, "DistributedTensorFile: pwrite failed at offset {}: {}", offset,
+                                    std::strerror(errno));
+        }
+        total += static_cast<size_t>(written);
+    }
+}
+
+void DistributedTensorFile::read_at(uint64_t offset, void *data, size_t bytes) const {
+    if (bytes == 0)
+        return;
+    auto  *ptr   = static_cast<char *>(data);
+    size_t total = 0;
+    while (total < bytes) {
+        ssize_t const nread = ::pread(_fd, ptr + total, bytes - total, static_cast<off_t>(offset + total));
+        if (nread < 0) {
+            if (errno == EINTR)
+                continue;
+            EINSUMS_THROW_EXCEPTION(std::runtime_error, "DistributedTensorFile: pread failed at offset {}: {}", offset,
+                                    std::strerror(errno));
+        }
+        if (nread == 0)
+            EINSUMS_THROW_EXCEPTION(std::runtime_error, "DistributedTensorFile: unexpected EOF at offset {}", offset + total);
+        total += static_cast<size_t>(nread);
+    }
+}
+
+uint64_t DistributedTensorFile::compute_distributed_offset(size_t local_bytes) {
+    uint64_t const aligned_bytes = align_up(local_bytes, ETN_DATA_ALIGNMENT);
+    uint64_t       my_offset     = 0;
+
+#if defined(EINSUMS_HAVE_MPI)
+    // Exclusive prefix sum: rank r gets offset = sum of all ranks < r
+    uint64_t scan_result = 0;
+    MPI_Exscan(&aligned_bytes, &scan_result, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+    if (my_rank_ == 0)
+        scan_result = 0;
+
+    my_offset = align_up(next_data_offset_, ETN_DATA_ALIGNMENT) + scan_result;
+
+    // All ranks advance next_data_offset_ by the total across all ranks
+    uint64_t total_bytes = 0;
+    MPI_Allreduce(&aligned_bytes, &total_bytes, 1, MPI_UINT64_T, MPI_SUM, MPI_COMM_WORLD);
+    next_data_offset_ = align_up(next_data_offset_, ETN_DATA_ALIGNMENT) + total_bytes;
+#else
+    my_offset                  = align_up(_next_data_offset, ETN_DATA_ALIGNMENT);
+    _next_data_offset          = my_offset + aligned_bytes;
+#endif
+
+    return my_offset;
+}
+
+void DistributedTensorFile::write_metadata() {
+#if defined(EINSUMS_HAVE_MPI)
+    // Gather all entries from all ranks to rank 0
+    int              local_count = static_cast<int>(entries_.size());
+    std::vector<int> all_counts(num_ranks_);
+    MPI_Gather(&local_count, 1, MPI_INT, all_counts.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+    std::vector<TensorEntry> all_entries;
+    if (my_rank_ == 0) {
+        // Compute displacements for Gatherv
+        int              total = 0;
+        std::vector<int> byte_counts(num_ranks_);
+        std::vector<int> displs(num_ranks_);
+        for (int r = 0; r < num_ranks_; r++) {
+            byte_counts[r] = all_counts[r] * static_cast<int>(sizeof(TensorEntry));
+            displs[r]      = total;
+            total += byte_counts[r];
+        }
+        all_entries.resize(total / static_cast<int>(sizeof(TensorEntry)));
+
+        MPI_Gatherv(entries_.data(), local_count * static_cast<int>(sizeof(TensorEntry)), MPI_BYTE, all_entries.data(), byte_counts.data(),
+                    displs.data(), MPI_BYTE, 0, MPI_COMM_WORLD);
+
+        // Deduplicate replicated entries (all ranks added them)
+        std::vector<TensorEntry>              unique_entries;
+        std::unordered_map<std::string, bool> seen_replicated;
+        for (auto const &e : all_entries) {
+            std::string n = e.get_name();
+            if (e.owning_rank == ETN_ALL_RANKS) {
+                if (seen_replicated.count(n))
+                    continue;
+                seen_replicated[n] = true;
+            }
+            unique_entries.push_back(e);
+        }
+
+        header_.num_tensors        = static_cast<uint32_t>(unique_entries.size());
+        header_.entry_table_offset = align_up(next_data_offset_, ETN_DATA_ALIGNMENT);
+        header_.total_size         = header_.entry_table_offset + unique_entries.size() * sizeof(TensorEntry);
+
+        write_at(0, &header_, sizeof(FileHeader));
+        if (!unique_entries.empty()) {
+            write_at(header_.entry_table_offset, unique_entries.data(), unique_entries.size() * sizeof(TensorEntry));
+        }
+        ::ftruncate(fd_, static_cast<off_t>(header_.total_size));
+    } else {
+        MPI_Gatherv(entries_.data(), local_count * static_cast<int>(sizeof(TensorEntry)), MPI_BYTE, nullptr, nullptr, nullptr, MPI_BYTE, 0,
+                    MPI_COMM_WORLD);
+    }
+
+    MPI_Barrier(MPI_COMM_WORLD);
+#else
+    _header.num_tensors        = static_cast<uint32_t>(_entries.size());
+    _header.entry_table_offset = align_up(_next_data_offset, ETN_DATA_ALIGNMENT);
+    _header.total_size         = _header.entry_table_offset + _entries.size() * sizeof(TensorEntry);
+
+    write_at(0, &_header, sizeof(FileHeader));
+    if (!_entries.empty()) {
+        write_at(_header.entry_table_offset, _entries.data(), _entries.size() * sizeof(TensorEntry));
+    }
+    ::ftruncate(_fd, static_cast<off_t>(_header.total_size));
+#endif
+}
+
+void DistributedTensorFile::read_metadata() {
+    read_at(0, &_header, sizeof(FileHeader));
+    if (!_header.is_valid()) {
+        EINSUMS_THROW_EXCEPTION(std::runtime_error, "DistributedTensorFile: '{}' is not a valid .etn file", _path);
+    }
+
+    _entries.resize(_header.num_tensors);
+    if (_header.num_tensors > 0) {
+        read_at(_header.entry_table_offset, _entries.data(), _header.num_tensors * sizeof(TensorEntry));
+    }
+
+    _name_to_index.clear();
+    for (size_t i = 0; i < _entries.size(); i++) {
+        _name_to_index[_entries[i].get_name()] = i;
+    }
+
+    _next_data_offset = _header.data_offset;
+    for (auto const &e : _entries) {
+        uint64_t const end = e.data_offset + e.data_size;
+        if (end > _next_data_offset)
+            _next_data_offset = end;
+    }
+}
+
+bool DistributedTensorFile::contains(std::string_view name) const {
+    return _name_to_index.count(std::string(name)) > 0;
+}
+
+std::vector<std::string> DistributedTensorFile::tensor_names() const {
+    std::vector<std::string> names;
+    names.reserve(_entries.size());
+    for (auto const &e : _entries)
+        names.push_back(e.get_name());
+    return names;
+}
+
+} // namespace einsums::tensor_io

--- a/libs/Einsums/TensorIO/src/InitModule.cpp
+++ b/libs/Einsums/TensorIO/src/InitModule.cpp
@@ -1,0 +1,12 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+// TensorIO module initialization — currently a no-op.
+// Future: register runtime config options for default I/O paths.
+
+namespace {
+// NOLINTNEXTLINE(bugprone-throwing-static-initialization)
+[[maybe_unused]] auto init_Einsums_TensorIO = []() { return 0; }();
+} // namespace

--- a/libs/Einsums/TensorIO/src/InitModule.cpp
+++ b/libs/Einsums/TensorIO/src/InitModule.cpp
@@ -3,7 +3,7 @@
 // Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 //----------------------------------------------------------------------------------------------
 
-// TensorIO module initialization — currently a no-op.
+// TensorIO module initialization. Currently a no-op.
 // Future: register runtime config options for default I/O paths.
 
 namespace {

--- a/libs/Einsums/TensorIO/src/TensorFile.cpp
+++ b/libs/Einsums/TensorIO/src/TensorFile.cpp
@@ -1,0 +1,202 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+#include <Einsums/Errors/ThrowException.hpp>
+#include <Einsums/TensorIO/TensorFile.hpp>
+
+#include <cerrno>
+#include <cstring>
+#include <fcntl.h>
+#include <stdexcept>
+#include <sys/stat.h>
+#include <unistd.h>
+
+namespace einsums::tensor_io {
+
+TensorFile::TensorFile(std::string path, Mode mode) : _path(std::move(path)), _mode(mode) {
+    int          flags = 0;
+    mode_t const perms = S_IRUSR | S_IWUSR | S_IRGRP | S_IROTH;
+
+    switch (_mode) {
+    case Mode::Read:
+        flags = O_RDONLY;
+        break;
+    case Mode::Write:
+        flags = O_RDWR | O_CREAT | O_TRUNC;
+        break;
+    case Mode::ReadWrite:
+        flags = O_RDWR | O_CREAT;
+        break;
+    }
+
+    _fd = ::open(_path.c_str(), flags, perms);
+    if (_fd < 0) {
+        EINSUMS_THROW_EXCEPTION(std::runtime_error, "TensorFile: cannot open '{}': {}", _path, std::strerror(errno));
+    }
+
+    if (_mode == Mode::Write) {
+        // New file: write initial header
+        _header.init();
+        _next_data_offset = _header.data_offset;
+        write_metadata();
+    } else {
+        // Existing file: read header and entries
+        struct stat st;
+        if (::fstat(_fd, &st) == 0 && st.st_size > 0) {
+            read_metadata();
+        } else {
+            // Empty file or new file in ReadWrite mode
+            _header.init();
+            _next_data_offset = _header.data_offset;
+            if (_mode == Mode::ReadWrite) {
+                write_metadata();
+            }
+        }
+    }
+}
+
+// NOLINTNEXTLINE(bugprone-exception-escape)
+TensorFile::~TensorFile() {
+    if (_fd >= 0) {
+        if (_mode != Mode::Read) {
+            write_metadata(); // Flush entry table
+        }
+        ::close(_fd);
+        _fd = -1;
+    }
+}
+
+void TensorFile::write_at(uint64_t offset, void const *data, size_t bytes) {
+    if (bytes == 0)
+        return;
+    auto  *ptr   = static_cast<char const *>(data);
+    size_t total = 0;
+    while (total < bytes) {
+        ssize_t const written = ::pwrite(_fd, ptr + total, bytes - total, static_cast<off_t>(offset + total));
+        if (written < 0) {
+            if (errno == EINTR)
+                continue;
+            EINSUMS_THROW_EXCEPTION(std::runtime_error, "TensorFile: pwrite failed at offset {}: {}", offset, std::strerror(errno));
+        }
+        total += static_cast<size_t>(written);
+    }
+}
+
+void TensorFile::read_at(uint64_t offset, void *data, size_t bytes) const {
+    if (bytes == 0)
+        return;
+    auto  *ptr   = static_cast<char *>(data);
+    size_t total = 0;
+    while (total < bytes) {
+        ssize_t const nread = ::pread(_fd, ptr + total, bytes - total, static_cast<off_t>(offset + total));
+        if (nread < 0) {
+            if (errno == EINTR)
+                continue;
+            EINSUMS_THROW_EXCEPTION(std::runtime_error, "TensorFile: pread failed at offset {}: {}", offset, std::strerror(errno));
+        }
+        if (nread == 0) {
+            EINSUMS_THROW_EXCEPTION(std::runtime_error, "TensorFile: unexpected EOF at offset {} (read {}/{})", offset + total, total,
+                                    bytes);
+        }
+        total += static_cast<size_t>(nread);
+    }
+}
+
+void TensorFile::write_metadata() {
+    // Update header
+    _header.num_tensors        = static_cast<uint32_t>(_entries.size());
+    _header.entry_table_offset = align_up(_next_data_offset, ETN_DATA_ALIGNMENT);
+    _header.total_size         = _header.entry_table_offset + _entries.size() * sizeof(TensorEntry);
+
+    // Write header at offset 0
+    write_at(0, &_header, sizeof(FileHeader));
+
+    // Write entry table at the end
+    if (!_entries.empty()) {
+        write_at(_header.entry_table_offset, _entries.data(), _entries.size() * sizeof(TensorEntry));
+    }
+
+    // Truncate file to exact size
+    if (::ftruncate(_fd, static_cast<off_t>(_header.total_size)) < 0) {
+        // Non-fatal: file may be slightly larger than needed
+    }
+}
+
+void TensorFile::read_metadata() {
+    // Read header
+    read_at(0, &_header, sizeof(FileHeader));
+
+    if (!_header.is_valid()) {
+        EINSUMS_THROW_EXCEPTION(std::runtime_error, "TensorFile: '{}' is not a valid .etn file (bad magic or version)", _path);
+    }
+
+    // Read entry table
+    _entries.resize(_header.num_tensors);
+    if (_header.num_tensors > 0) {
+        read_at(_header.entry_table_offset, _entries.data(), _header.num_tensors * sizeof(TensorEntry));
+    }
+
+    // Build name index
+    _name_to_index.clear();
+    for (size_t i = 0; i < _entries.size(); i++) {
+        _name_to_index[_entries[i].get_name()] = i;
+    }
+
+    // Compute next available data offset (after last data region)
+    _next_data_offset = _header.data_offset;
+    for (auto const &e : _entries) {
+        uint64_t const end = e.data_offset + e.data_size;
+        if (end > _next_data_offset)
+            _next_data_offset = end;
+    }
+}
+
+size_t TensorFile::add_entry(TensorEntry entry) {
+    size_t const idx                 = _entries.size();
+    _name_to_index[entry.get_name()] = idx;
+    _entries.push_back(entry);
+    return idx;
+}
+
+TensorEntry const &TensorFile::find_entry(std::string_view name) const {
+    auto it = _name_to_index.find(std::string(name));
+    if (it == _name_to_index.end()) {
+        EINSUMS_THROW_EXCEPTION(std::runtime_error, "TensorFile: tensor '{}' not found in '{}'", name, _path);
+    }
+    return _entries[it->second];
+}
+
+bool TensorFile::contains(std::string_view name) const {
+    return _name_to_index.count(std::string(name)) > 0;
+}
+
+std::vector<size_t> TensorFile::dims(std::string_view name) const {
+    auto const         &entry = find_entry(name);
+    std::vector<size_t> result(entry.rank);
+    for (size_t d = 0; d < entry.rank; d++)
+        result[d] = entry.dims[d];
+    return result;
+}
+
+DType TensorFile::dtype(std::string_view name) const {
+    return static_cast<DType>(find_entry(name).dtype);
+}
+
+std::vector<std::string> TensorFile::tensor_names() const {
+    std::vector<std::string> names;
+    names.reserve(_entries.size());
+    for (auto const &e : _entries)
+        names.push_back(e.get_name());
+    return names;
+}
+
+void TensorFile::flush() {
+    if (_fd >= 0 && _mode != Mode::Read) {
+        write_metadata();
+        ::fsync(_fd);
+    }
+}
+
+} // namespace einsums::tensor_io

--- a/libs/Einsums/TensorIO/tests/CMakeLists.txt
+++ b/libs/Einsums/TensorIO/tests/CMakeLists.txt
@@ -1,0 +1,14 @@
+#----------------------------------------------------------------------------------------------
+# Copyright (c) The Einsums Developers. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+#----------------------------------------------------------------------------------------------
+
+include(Einsums_Message)
+
+if(EINSUMS_WITH_TESTS)
+  if(EINSUMS_WITH_TESTS_UNIT)
+    einsums_add_pseudo_target(Tests.Unit.Modules.TensorIO)
+    einsums_add_pseudo_dependencies(Tests.Unit.Modules Tests.Unit.Modules.TensorIO)
+    add_subdirectory(unit)
+  endif()
+endif()

--- a/libs/Einsums/TensorIO/tests/unit/CMakeLists.txt
+++ b/libs/Einsums/TensorIO/tests/unit/CMakeLists.txt
@@ -1,0 +1,34 @@
+#----------------------------------------------------------------------------------------------
+# Copyright (c) The Einsums Developers. All rights reserved.
+# Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+#----------------------------------------------------------------------------------------------
+
+set(TensorIOTests
+    TensorFileBasic.cpp
+    TensorFileSliceWrite.cpp
+    GraphSlab.cpp
+)
+
+foreach(test ${TensorIOTests})
+  get_filename_component(TestName ${test} NAME_WE)
+
+  einsums_add_executable(
+    ${TestName}_test INTERNAL_FLAGS
+    SOURCES ${test}
+    NOINSTALL
+  )
+
+  einsums_add_unit_test(
+    "Modules.TensorIO" ${TestName}
+  )
+endforeach()
+
+einsums_add_python_unit_test(
+  "Modules.TensorIO" TensorFilePython
+  SCRIPT test_tensor_file_python.py
+)
+
+einsums_add_python_unit_test(
+  "Modules.TensorIO" GraphSlabPython
+  SCRIPT test_graph_slab_python.py
+)

--- a/libs/Einsums/TensorIO/tests/unit/GraphSlab.cpp
+++ b/libs/Einsums/TensorIO/tests/unit/GraphSlab.cpp
@@ -1,0 +1,239 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+/// @file GraphSlab.cpp
+/// @brief Unit tests for tensor_io::Slab + read_slice_etn / write_slice_etn.
+///
+/// Exercises the graph-aware slab APIs end-to-end: capture a graph that
+/// reads a slab, transforms it, writes it back, then run the graph and
+/// inspect the file. Covers both the static-rank and runtime-rank
+/// dispatcher branches plus the read-transform-write-back loop pattern
+/// that motivated the design (drive a single graph node over multiple
+/// slabs by mutating Slab::ranges between executor invocations).
+
+#include <Einsums/ComputeGraph/CaptureContext.hpp>
+#include <Einsums/ComputeGraph/Executor.hpp>
+#include <Einsums/ComputeGraph/Graph.hpp>
+#include <Einsums/Tensor/RuntimeTensor.hpp>
+#include <Einsums/Tensor/Tensor.hpp>
+#include <Einsums/TensorIO/GraphIO.hpp>
+#include <Einsums/TensorIO/TensorFile.hpp>
+#include <Einsums/TensorUtilities/CreateZeroTensor.hpp>
+
+#include <cstdio>
+
+#include <Einsums/Testing.hpp>
+
+using namespace einsums;
+using namespace einsums::tensor_io;
+
+namespace {
+struct TempFile {
+    std::string path;
+    explicit TempFile(std::string name) : path("/tmp/einsums_graph_slab_" + std::move(name)) {}
+    ~TempFile() { std::remove(path.c_str()); }
+};
+} // namespace
+
+// ── Static-rank: read_slice_etn / write_slice_etn round-trip ────────────
+
+TEST_CASE("read_slice_etn pulls a slab into a static-rank tensor", "[TensorIO][GraphIO][slice]") {
+    TempFile const tmp("static_read.etn");
+
+    // Seed the file: 4×4 with a unique pattern (i*10 + j).
+    auto base = create_zero_tensor<double>("A", 4, 4);
+    for (size_t i = 0; i < 4; ++i) {
+        for (size_t j = 0; j < 4; ++j) {
+            base(i, j) = static_cast<double>(10 * i + j);
+        }
+    }
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", base);
+    }
+
+    Tensor<double, 2> block("blk", 2, 2);
+    Slab const        slab{{{1, 3}, {1, 3}}};
+
+    compute_graph::Graph g;
+    {
+        compute_graph::CaptureGuard const guard(g);
+        read_slice_etn(tmp.path, "A", slab, &block);
+    }
+
+    // graph.execute() drives the default sequential executor.
+    g.execute();
+
+    REQUIRE(block(0, 0) == 11.0);
+    REQUIRE(block(0, 1) == 12.0);
+    REQUIRE(block(1, 0) == 21.0);
+    REQUIRE(block(1, 1) == 22.0);
+}
+
+TEST_CASE("write_slice_etn patches a slab via the graph", "[TensorIO][GraphIO][slice]") {
+    TempFile const tmp("static_write.etn");
+
+    // Reserve a 4×4 zero tensor.
+    auto base = create_zero_tensor<double>("A", 4, 4);
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", base);
+    }
+
+    // Build a 2×2 patch of 7's.
+    Tensor<double, 2> patch("p", 2, 2);
+    for (size_t i = 0; i < 2; ++i) {
+        for (size_t j = 0; j < 2; ++j) {
+            patch(i, j) = 7.0;
+        }
+    }
+
+    Slab const slab{{{1, 3}, {1, 3}}};
+
+    compute_graph::Graph g;
+    {
+        compute_graph::CaptureGuard const guard(g);
+        write_slice_etn(tmp.path, "A", slab, &patch);
+    }
+
+    // graph.execute() drives the default sequential executor.
+    g.execute();
+
+    Tensor<double, 2> rt("rt", 4, 4);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read("A", rt);
+    }
+    for (size_t i = 0; i < 4; ++i) {
+        for (size_t j = 0; j < 4; ++j) {
+            double const expected = (i >= 1 && i < 3 && j >= 1 && j < 3) ? 7.0 : 0.0;
+            REQUIRE(rt(i, j) == expected);
+        }
+    }
+}
+
+// ── The motivating pattern: read-transform-write-back loop ──────────────
+
+TEST_CASE("Slab loop: read→transform→write-back tiles via the graph", "[TensorIO][GraphIO][slice][loop]") {
+    TempFile tmp("loop.etn");
+
+    // Seed file with arange(16) reshaped to 4×4.
+    Tensor<double, 2> seed("A", 4, 4);
+    for (size_t i = 0; i < 4; ++i) {
+        for (size_t j = 0; j < 4; ++j) {
+            seed(i, j) = static_cast<double>(4 * i + j);
+        }
+    }
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", seed);
+    }
+
+    Tensor<double, 2> block("blk", 2, 2);
+    Slab              slab{{{0, 2}, {0, 2}}}; // mutated each iteration
+
+    // Build the graph ONCE — read this slab, the user transforms in
+    // place, then write back. Driver loop mutates `slab.ranges` and
+    // re-runs the graph for every 2×2 tile.
+    compute_graph::Graph g;
+    {
+        compute_graph::CaptureGuard const guard(g);
+        read_slice_etn(tmp.path, "A", slab, &block);
+        // Compute step is implicit between executor runs — see loop body.
+        write_slice_etn(tmp.path, "A", slab, &block);
+    }
+
+    // graph.execute() drives the default sequential executor.
+
+    auto run_tile = [&](size_t bi, size_t bj) {
+        slab.ranges = {{bi * 2, bi * 2 + 2}, {bj * 2, bj * 2 + 2}};
+        g.execute();
+        // After read_slice_etn finished and before write_slice_etn fires
+        // we'd want a compute step; but SequentialExecutor runs nodes
+        // in topo order in one pass, so we transform between *graph
+        // runs* instead. The test exercises the surface; in practice
+        // the user would record a compute node between the read and
+        // the write, or use Graph::add_loop in Step 4.
+        // (We just multiply by 10 here to prove the round-trip works.)
+        for (size_t i = 0; i < 2; ++i) {
+            for (size_t j = 0; j < 2; ++j) {
+                block(i, j) *= 10.0;
+            }
+        }
+        // Re-run only the write half. Easiest: a dedicated mini-graph.
+        compute_graph::Graph g_write;
+        {
+            compute_graph::CaptureGuard const guard(g_write);
+            write_slice_etn(tmp.path, "A", slab, &block);
+        }
+        g_write.execute();
+    };
+
+    for (size_t bi = 0; bi < 2; ++bi) {
+        for (size_t bj = 0; bj < 2; ++bj) {
+            run_tile(bi, bj);
+        }
+    }
+
+    // Verify every tile got multiplied by 10.
+    Tensor<double, 2> rt("rt", 4, 4);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read("A", rt);
+    }
+    for (size_t i = 0; i < 4; ++i) {
+        for (size_t j = 0; j < 4; ++j) {
+            REQUIRE(rt(i, j) == static_cast<double>(4 * i + j) * 10.0);
+        }
+    }
+}
+
+// ── Runtime-rank dispatcher branch ──────────────────────────────────────
+
+TEST_CASE("read_slice_etn / write_slice_etn dispatch on RuntimeTensor", "[TensorIO][GraphIO][slice][runtime]") {
+    TempFile const tmp("rt_slab.etn");
+
+    // Seed file.
+    GeneralRuntimeTensor<double, std::allocator<double>> seed("A", std::vector<size_t>{4, 4});
+    for (size_t i = 0; i < seed.size(); ++i) {
+        seed.data()[i] = static_cast<double>(i);
+    }
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", seed);
+    }
+
+    GeneralRuntimeTensor<double, std::allocator<double>> block("blk", std::vector<size_t>{2, 2});
+    Slab const                                           slab{{{1, 3}, {1, 3}}};
+
+    compute_graph::Graph g_read;
+    {
+        compute_graph::CaptureGuard const guard(g_read);
+        read_slice_etn(tmp.path, "A", slab, &block);
+    }
+    // graph.execute() drives the default sequential executor.
+    g_read.execute();
+
+    // Mutate and write back.
+    block.set_all(99.0);
+    compute_graph::Graph g_write;
+    {
+        compute_graph::CaptureGuard const guard(g_write);
+        write_slice_etn(tmp.path, "A", slab, &block);
+    }
+    g_write.execute();
+
+    // Verify.
+    GeneralRuntimeTensor<double, std::allocator<double>> rt("rt", std::vector<size_t>{4, 4});
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read("A", rt);
+    }
+    for (size_t i = 1; i < 3; ++i) {
+        for (size_t j = 1; j < 3; ++j) {
+            REQUIRE(rt.data()[j * 4 + i] == 99.0); // column-major
+        }
+    }
+}

--- a/libs/Einsums/TensorIO/tests/unit/GraphSlab.cpp
+++ b/libs/Einsums/TensorIO/tests/unit/GraphSlab.cpp
@@ -9,9 +9,9 @@
 /// Exercises the graph-aware slab APIs end-to-end: capture a graph that
 /// reads a slab, transforms it, writes it back, then run the graph and
 /// inspect the file. Covers both the static-rank and runtime-rank
-/// dispatcher branches plus the read-transform-write-back loop pattern
-/// that motivated the design (drive a single graph node over multiple
-/// slabs by mutating Slab::ranges between executor invocations).
+/// dispatcher branches, plus the read-transform-write-back loop pattern
+/// that motivated the design, where a single graph node drives multiple
+/// slabs by mutating Slab::ranges between executor invocations.
 
 #include <Einsums/ComputeGraph/CaptureContext.hpp>
 #include <Einsums/ComputeGraph/Executor.hpp>
@@ -134,14 +134,14 @@ TEST_CASE("Slab loop: read→transform→write-back tiles via the graph", "[Tens
     Tensor<double, 2> block("blk", 2, 2);
     Slab              slab{{{0, 2}, {0, 2}}}; // mutated each iteration
 
-    // Build the graph ONCE — read this slab, the user transforms in
-    // place, then write back. Driver loop mutates `slab.ranges` and
-    // re-runs the graph for every 2×2 tile.
+    // Build the graph once: read this slab, the user transforms in
+    // place, then write back. The driver loop mutates `slab.ranges` and
+    // re-runs the graph for every 2x2 tile.
     compute_graph::Graph g;
     {
         compute_graph::CaptureGuard const guard(g);
         read_slice_etn(tmp.path, "A", slab, &block);
-        // Compute step is implicit between executor runs — see loop body.
+        // Compute step is implicit between executor runs; see loop body.
         write_slice_etn(tmp.path, "A", slab, &block);
     }
 
@@ -150,13 +150,13 @@ TEST_CASE("Slab loop: read→transform→write-back tiles via the graph", "[Tens
     auto run_tile = [&](size_t bi, size_t bj) {
         slab.ranges = {{bi * 2, bi * 2 + 2}, {bj * 2, bj * 2 + 2}};
         g.execute();
-        // After read_slice_etn finished and before write_slice_etn fires
-        // we'd want a compute step; but SequentialExecutor runs nodes
-        // in topo order in one pass, so we transform between *graph
-        // runs* instead. The test exercises the surface; in practice
-        // the user would record a compute node between the read and
-        // the write, or use Graph::add_loop in Step 4.
-        // (We just multiply by 10 here to prove the round-trip works.)
+        // After read_slice_etn finishes and before write_slice_etn fires
+        // we would want a compute step, but SequentialExecutor runs nodes
+        // in topo order in one pass, so we transform between graph runs
+        // instead. The test exercises the surface; in practice the user
+        // would record a compute node between the read and the write, or
+        // use Graph::add_loop in Step 4. Here we just multiply by 10 to
+        // prove the round-trip works.
         for (size_t i = 0; i < 2; ++i) {
             for (size_t j = 0; j < 2; ++j) {
                 block(i, j) *= 10.0;

--- a/libs/Einsums/TensorIO/tests/unit/TensorFileBasic.cpp
+++ b/libs/Einsums/TensorIO/tests/unit/TensorFileBasic.cpp
@@ -1,0 +1,604 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+/// @file TensorFileBasic.cpp
+/// @brief Unit tests for the .etn tensor file format and TensorFile class.
+
+#include <Einsums/Comm/Runtime.hpp>
+#include <Einsums/Tensor/Tensor.hpp>
+#include <Einsums/TensorIO/TensorFile.hpp>
+#include <Einsums/TensorUtilities/CreateRandomTensor.hpp>
+#include <Einsums/TensorUtilities/CreateZeroTensor.hpp>
+
+#include <cstdio>
+
+#include <Einsums/Testing.hpp>
+
+using namespace einsums;
+using namespace einsums::tensor_io;
+
+// Helper: create a temp file path and clean up after test.
+// Uses per-rank paths for serial TensorFile tests to avoid contention under MPI.
+namespace {
+struct TempFile {
+    std::string path;
+    bool        distributed; ///< True for distributed tests (shared path across ranks)
+    TempFile(std::string const &name = "test.etn", bool dist = false) : distributed(dist) {
+        if (dist) {
+            // Shared path — all ranks use the same file
+            path = "/tmp/einsums_test_" + name;
+        } else {
+            // Per-rank path to avoid contention
+            path = "/tmp/einsums_test_r" + std::to_string(comm::world_rank()) + "_" + name;
+        }
+    }
+    ~TempFile() { std::remove(path.c_str()); }
+};
+} // namespace
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Format sanity
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("Format - header and entry sizes", "[TensorIO][Format]") {
+    CHECK(sizeof(FileHeader) == 64);
+    CHECK(sizeof(TensorEntry) == 160);
+    CHECK(ETN_DATA_ALIGNMENT == 64);
+}
+
+TEST_CASE("Format - header init and validate", "[TensorIO][Format]") {
+    FileHeader h;
+    h.init();
+    CHECK(h.is_valid());
+    CHECK(h.version == ETN_VERSION);
+    CHECK(h.num_tensors == 0);
+}
+
+TEST_CASE("Format - dtype mapping", "[TensorIO][Format]") {
+    CHECK(dtype_for<float>() == DType::Float32);
+    CHECK(dtype_for<double>() == DType::Float64);
+    CHECK(dtype_for<std::complex<float>>() == DType::Complex64);
+    CHECK(dtype_for<std::complex<double>>() == DType::Complex128);
+    CHECK(dtype_for<int32_t>() == DType::Int32);
+    CHECK(dtype_for<int64_t>() == DType::Int64);
+
+    CHECK(dtype_size(DType::Float32) == 4);
+    CHECK(dtype_size(DType::Float64) == 8);
+    CHECK(dtype_size(DType::Complex128) == 16);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Write and read round-trip
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("TensorFile - write and read double matrix", "[TensorIO][RoundTrip]") {
+    TempFile const tmp("matrix.etn");
+
+    auto A = create_random_tensor<double>("A", 10, 8);
+
+    // Write
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", A);
+        CHECK(out.num_tensors() == 1);
+    }
+
+    // Read back
+    auto B = create_zero_tensor<double>("B", 10, 8);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        CHECK(in.contains("A"));
+        CHECK(in.num_tensors() == 1);
+        CHECK(in.dims("A") == std::vector<size_t>{10, 8});
+        CHECK(in.dtype("A") == DType::Float64);
+
+        in.read("A", B);
+    }
+
+    // Verify
+    for (size_t i = 0; i < A.size(); i++) {
+        CHECK(A.data()[i] == B.data()[i]);
+    }
+}
+
+TEST_CASE("TensorFile - write and read float vector", "[TensorIO][RoundTrip]") {
+    TempFile const tmp("vector.etn");
+
+    auto V = create_random_tensor<float>("V", 100);
+
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("V", V);
+    }
+
+    auto W = create_zero_tensor<float>("W", 100);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read("V", W);
+    }
+
+    for (size_t i = 0; i < V.size(); i++) {
+        CHECK(V.data()[i] == W.data()[i]);
+    }
+}
+
+TEST_CASE("TensorFile - write and read complex tensor", "[TensorIO][RoundTrip]") {
+    TempFile const tmp("complex.etn");
+
+    auto C = Tensor<std::complex<double>, 2>("C", 5, 5);
+    for (size_t i = 0; i < 5; i++)
+        for (size_t j = 0; j < 5; j++)
+            C(i, j) = {static_cast<double>(i), static_cast<double>(j)};
+
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("C", C);
+    }
+
+    auto D = Tensor<std::complex<double>, 2>("D", 5, 5);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read("C", D);
+    }
+
+    for (size_t i = 0; i < 5; i++)
+        for (size_t j = 0; j < 5; j++) {
+            CHECK(D(i, j).real() == C(i, j).real());
+            CHECK(D(i, j).imag() == C(i, j).imag());
+        }
+}
+
+TEST_CASE("TensorFile - write and read rank-4 tensor", "[TensorIO][RoundTrip]") {
+    TempFile const tmp("rank4.etn");
+
+    auto T = create_random_tensor<double>("T", 4, 3, 5, 2);
+
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("T", T);
+    }
+
+    auto U = create_zero_tensor<double>("U", 4, 3, 5, 2);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read("T", U);
+    }
+
+    for (size_t i = 0; i < T.size(); i++) {
+        CHECK(T.data()[i] == U.data()[i]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Multiple tensors in one file
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("TensorFile - multiple tensors", "[TensorIO][Multi]") {
+    TempFile const tmp("multi.etn");
+
+    auto A = create_random_tensor<double>("A", 10, 10);
+    auto B = create_random_tensor<float>("B", 20);
+    auto C = create_random_tensor<double>("C", 3, 3, 3);
+
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", A);
+        out.write("B", B);
+        out.write("C", C);
+        CHECK(out.num_tensors() == 3);
+    }
+
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        CHECK(in.num_tensors() == 3);
+        CHECK(in.contains("A"));
+        CHECK(in.contains("B"));
+        CHECK(in.contains("C"));
+        CHECK_FALSE(in.contains("D"));
+
+        auto names = in.tensor_names();
+        CHECK(names.size() == 3);
+
+        auto A2 = create_zero_tensor<double>("A2", 10, 10);
+        auto B2 = create_zero_tensor<float>("B2", 20);
+        auto C2 = create_zero_tensor<double>("C2", 3, 3, 3);
+
+        in.read("A", A2);
+        in.read("B", B2);
+        in.read("C", C2);
+
+        for (size_t i = 0; i < A.size(); i++)
+            CHECK(A.data()[i] == A2.data()[i]);
+        for (size_t i = 0; i < B.size(); i++)
+            CHECK(B.data()[i] == B2.data()[i]);
+        for (size_t i = 0; i < C.size(); i++)
+            CHECK(C.data()[i] == C2.data()[i]);
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Slice reads
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("TensorFile - read_slice 2D", "[TensorIO][Slice]") {
+    TempFile const tmp("slice2d.etn");
+
+    auto A = create_random_tensor<double>("A", 20, 16);
+
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", A);
+    }
+
+    // Read a 5x8 slice starting at (3, 4)
+    auto slice = Tensor<double, 2>("slice", 5, 8);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read_slice<double, 2>("A", slice, {{{3, 8}, {4, 12}}});
+    }
+
+    for (size_t i = 0; i < 5; i++)
+        for (size_t j = 0; j < 8; j++)
+            CHECK(slice(i, j) == A(3 + i, 4 + j));
+}
+
+TEST_CASE("TensorFile - read_slice 1D", "[TensorIO][Slice]") {
+    TempFile const tmp("slice1d.etn");
+
+    auto V = create_random_tensor<double>("V", 100);
+
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("V", V);
+    }
+
+    auto slice = Tensor<double, 1>("slice", 20);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read_slice<double, 1>("V", slice, {{{10, 30}}});
+    }
+
+    for (size_t i = 0; i < 20; i++)
+        CHECK(slice(i) == V(10 + i));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Error handling
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("TensorFile - read nonexistent tensor throws", "[TensorIO][Error]") {
+    TempFile const tmp("empty.etn");
+
+    {
+        TensorFile const out(tmp.path, TensorFile::Mode::Write);
+        // Don't write anything
+    }
+
+    auto       A = Tensor<double, 2>("A", 3, 3);
+    TensorFile in(tmp.path, TensorFile::Mode::Read);
+    REQUIRE_THROWS(in.read("nonexistent", A));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Distributed I/O (works with both mock and real MPI)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#include <Einsums/Comm/Collectives.hpp>
+#include <Einsums/Comm/Runtime.hpp>
+#include <Einsums/TensorIO/DistributedTensorFile.hpp>
+
+#include <span>
+
+TEST_CASE("DistributedTensorFile - write and read replicated", "[TensorIO][Distributed]") {
+    TempFile const tmp("dist_repl.etn", true);
+
+    auto A = create_random_tensor<double>("A", 8, 6);
+    // NOLINTNEXTLINE(bugprone-unused-return-value)
+    (void)comm::broadcast<double>(std::span<double>(A.data(), A.size()), 0);
+
+    // Write (collective)
+    {
+        DistributedTensorFile out(tmp.path, DistributedTensorFile::Mode::Write);
+        out.write("A", A);
+    }
+
+    // Read back (collective)
+    auto B = create_zero_tensor<double>("B", 8, 6);
+    {
+        DistributedTensorFile in(tmp.path, DistributedTensorFile::Mode::Read);
+        CHECK(in.contains("A"));
+        in.read("A", B);
+    }
+
+    for (size_t i = 0; i < A.size(); i++) {
+        CHECK(A.data()[i] == B.data()[i]);
+    }
+}
+
+TEST_CASE("DistributedTensorFile - write_local and read_local", "[TensorIO][Distributed]") {
+    TempFile const tmp("dist_local.etn", true);
+    int const      rank   = comm::world_rank();
+    int const      nprocs = comm::world_size();
+
+    // Each rank has a different-sized local tensor
+    size_t const local_rows = 10 + static_cast<size_t>(rank) * 2; // rank 0: 10, rank 1: 12, etc.
+    auto         local      = create_random_tensor<double>("local", local_rows, 8);
+
+    // Write (collective)
+    {
+        DistributedTensorFile out(tmp.path, DistributedTensorFile::Mode::Write);
+        out.write_local("data", local);
+    }
+
+    // Read back (collective)
+    auto restored = create_zero_tensor<double>("restored", local_rows, 8);
+    {
+        DistributedTensorFile in(tmp.path, DistributedTensorFile::Mode::Read);
+        in.read_local("data", restored);
+    }
+
+    for (size_t i = 0; i < local.size(); i++) {
+        CHECK(local.data()[i] == restored.data()[i]);
+    }
+}
+
+TEST_CASE("DistributedTensorFile - mixed replicated and local", "[TensorIO][Distributed]") {
+    TempFile const tmp("dist_mixed.etn", true);
+    int const      rank = comm::world_rank();
+
+    auto global = create_random_tensor<double>("global", 5, 5);
+    // NOLINTNEXTLINE(bugprone-unused-return-value)
+    (void)comm::broadcast<double>(std::span<double>(global.data(), global.size()), 0);
+    auto local = create_random_tensor<double>("local", 3 + static_cast<size_t>(rank), 4);
+
+    {
+        DistributedTensorFile out(tmp.path, DistributedTensorFile::Mode::Write);
+        out.write("global_tensor", global);
+        out.write_local("local_tensor", local);
+    }
+
+    auto global2 = create_zero_tensor<double>("global2", 5, 5);
+    auto local2  = create_zero_tensor<double>("local2", 3 + static_cast<size_t>(rank), 4);
+
+    {
+        DistributedTensorFile in(tmp.path, DistributedTensorFile::Mode::Read);
+        CHECK(in.contains("global_tensor"));
+        in.read("global_tensor", global2);
+        in.read_local("local_tensor", local2);
+    }
+
+    for (size_t i = 0; i < global.size(); i++)
+        CHECK(global.data()[i] == global2.data()[i]);
+    for (size_t i = 0; i < local.size(); i++)
+        CHECK(local.data()[i] == local2.data()[i]);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Checkpoint (ComputeGraph integration)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#include <Einsums/ComputeGraph.hpp>
+#include <Einsums/TensorAlgebra/Detail/Index.hpp>
+#include <Einsums/TensorIO/Checkpoint.hpp>
+
+namespace cg = einsums::compute_graph;
+using namespace einsums::index;
+
+TEST_CASE("Checkpoint - save and restore graph tensors", "[TensorIO][Checkpoint]") {
+    TempFile const tmp("checkpoint.etn");
+
+    auto A = create_random_tensor<double>("A", 6, 8);
+    auto B = create_random_tensor<double>("B", 8, 4);
+    auto C = create_zero_tensor<double>("C", 6, 4);
+
+    // Build a graph and execute
+    cg::Graph graph("ckpt_test");
+    {
+        cg::CaptureGuard const guard(graph);
+        cg::einsum("ik;kj->ij", &C, A, B);
+    }
+    graph.execute();
+
+    // Save checkpoint
+    checkpoint::save(tmp.path, graph);
+
+    // Corrupt C to verify restore works
+    double const saved_val = C(0, 0);
+    C(0, 0)                = -999.0;
+    CHECK(C(0, 0) == -999.0);
+
+    // Restore from checkpoint
+    checkpoint::restore(tmp.path, graph);
+    CHECK(C(0, 0) == saved_val);
+}
+
+TEST_CASE("Checkpoint - save subset of tensors", "[TensorIO][Checkpoint]") {
+    TempFile const tmp("checkpoint_subset.etn");
+
+    auto A = create_random_tensor<double>("A", 5, 5);
+    auto B = create_random_tensor<double>("B", 5, 5);
+    auto C = create_zero_tensor<double>("C", 5, 5);
+
+    cg::Graph graph("ckpt_subset");
+    {
+        cg::CaptureGuard const guard(graph);
+        cg::einsum("ik;kj->ij", &C, A, B);
+    }
+    graph.execute();
+
+    // Save only C
+    checkpoint::save(tmp.path, graph, {"C"});
+
+    // Verify only C is in the file
+    TensorFile const in(tmp.path, TensorFile::Mode::Read);
+    CHECK(in.contains("C"));
+    CHECK_FALSE(in.contains("A"));
+    CHECK_FALSE(in.contains("B"));
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// GraphIO integration (read_etn/write_etn in ComputeGraph capture)
+// ═══════════════════════════════════════════════════════════════════════════════
+
+#include <Einsums/TensorIO/GraphIO.hpp>
+
+TEST_CASE("GraphIO - read_etn and write_etn in graph", "[TensorIO][GraphIO]") {
+    TempFile const tmp_in("graphio_in.etn");
+    TempFile const tmp_out("graphio_out.etn");
+
+    // Create input file with tensor A
+    auto A = create_random_tensor<double>("A", 6, 4);
+    {
+        TensorFile out(tmp_in.path, TensorFile::Mode::Write);
+        out.write("A", A);
+    }
+
+    // Build a graph: read A from .etn → compute C = A * B → write C to .etn
+    auto B = create_random_tensor<double>("B", 4, 5);
+    auto C = create_zero_tensor<double>("C", 6, 5);
+
+    cg::Graph graph("graphio_test");
+    {
+        cg::CaptureGuard const guard(graph);
+        tensor_io::read_etn(tmp_in.path, "A", &A);
+        cg::einsum("ik;kj->ij", &C, A, B);
+        tensor_io::write_etn(tmp_out.path, "C", &C);
+    }
+
+    graph.execute();
+
+    // Verify C was written to the output file
+    auto C2 = create_zero_tensor<double>("C2", 6, 5);
+    {
+        TensorFile in(tmp_out.path, TensorFile::Mode::Read);
+        CHECK(in.contains("C"));
+        in.read("C", C2);
+    }
+
+    // C and C2 should match
+    for (size_t idx = 0; idx < C.size(); idx++) {
+        CHECK(C.data()[idx] == C2.data()[idx]);
+    }
+}
+
+TEST_CASE("GraphIO - read_etn outside capture executes immediately", "[TensorIO][GraphIO]") {
+    TempFile const tmp("graphio_imm.etn");
+
+    auto A = create_random_tensor<double>("A", 3, 3);
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", A);
+    }
+
+    // Zero A, then read back from .etn (outside capture = immediate)
+    A.zero();
+    CHECK(A(0, 0) == 0.0);
+
+    // This should work outside capture mode
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read("A", A);
+    }
+
+    CHECK(A(0, 0) != 0.0); // Restored from file
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Additional coverage
+// ═══════════════════════════════════════════════════════════════════════════════
+
+TEST_CASE("Checkpoint - save and restore Workspace", "[TensorIO][Checkpoint]") {
+    TempFile const tmp("ckpt_ws.etn");
+
+    cg::Workspace ws("test_ws");
+    auto         &A = ws.declare_tensor<double, 2>(std::string("A"), 4, 4);
+    auto         &B = ws.declare_tensor<double, 2>(std::string("B"), 3, 5);
+    A.materialize();
+    B.materialize();
+    for (size_t idx = 0; idx < A.size(); idx++)
+        A.data()[idx] = static_cast<double>(idx);
+    for (size_t idx = 0; idx < B.size(); idx++)
+        B.data()[idx] = static_cast<double>(idx * 10);
+
+    checkpoint::save(tmp.path, ws);
+
+    // Corrupt
+    A.zero();
+    B.zero();
+    CHECK(A(0, 0) == 0.0);
+
+    checkpoint::restore(tmp.path, ws);
+    CHECK(A(0, 0) == 0.0); // First element is index 0
+    CHECK(A(1, 0) == 1.0); // Second element (column-major: data[1])
+    CHECK(B(0, 0) == 0.0);
+    CHECK(B(1, 0) == 10.0); // Column-major: data[1] = 1 * 10
+}
+
+TEST_CASE("TensorFile - ReadWrite mode appends tensors", "[TensorIO][ReadWrite]") {
+    TempFile const tmp("readwrite.etn");
+
+    auto A = create_random_tensor<double>("A", 5, 5);
+    auto B = create_random_tensor<double>("B", 3, 3);
+
+    // Write A first
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", A);
+    }
+
+    // Append B in ReadWrite mode
+    {
+        TensorFile rw(tmp.path, TensorFile::Mode::ReadWrite);
+        CHECK(rw.contains("A"));
+        CHECK(rw.num_tensors() == 1);
+        rw.write("B", B);
+        CHECK(rw.num_tensors() == 2);
+    }
+
+    // Verify both are readable
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        CHECK(in.contains("A"));
+        CHECK(in.contains("B"));
+        CHECK(in.num_tensors() == 2);
+
+        auto A2 = create_zero_tensor<double>("A2", 5, 5);
+        auto B2 = create_zero_tensor<double>("B2", 3, 3);
+        in.read("A", A2);
+        in.read("B", B2);
+
+        for (size_t idx = 0; idx < A.size(); idx++)
+            CHECK(A.data()[idx] == A2.data()[idx]);
+        for (size_t idx = 0; idx < B.size(); idx++)
+            CHECK(B.data()[idx] == B2.data()[idx]);
+    }
+}
+
+TEST_CASE("TensorFile - tensor_names lists all tensors", "[TensorIO][Query]") {
+    TempFile const tmp("query.etn");
+
+    auto X = create_random_tensor<double>("X", 2, 2);
+    auto Y = create_random_tensor<float>("Y", 3);
+    auto Z = create_random_tensor<double>("Z", 4, 4, 4);
+
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("X", X);
+        out.write("Y", Y);
+        out.write("Z", Z);
+    }
+
+    TensorFile const in(tmp.path, TensorFile::Mode::Read);
+    auto             names = in.tensor_names();
+    CHECK(names.size() == 3);
+
+    // Check dims query
+    CHECK(in.dims("X") == std::vector<size_t>{2, 2});
+    CHECK(in.dims("Y") == std::vector<size_t>{3});
+    CHECK(in.dims("Z") == std::vector<size_t>{4, 4, 4});
+
+    CHECK(in.dtype("X") == DType::Float64);
+    CHECK(in.dtype("Y") == DType::Float32);
+}

--- a/libs/Einsums/TensorIO/tests/unit/TensorFileBasic.cpp
+++ b/libs/Einsums/TensorIO/tests/unit/TensorFileBasic.cpp
@@ -27,7 +27,7 @@ struct TempFile {
     bool        distributed; ///< True for distributed tests (shared path across ranks)
     TempFile(std::string const &name = "test.etn", bool dist = false) : distributed(dist) {
         if (dist) {
-            // Shared path — all ranks use the same file
+            // Shared path: all ranks use the same file
             path = "/tmp/einsums_test_" + name;
         } else {
             // Per-rank path to avoid contention

--- a/libs/Einsums/TensorIO/tests/unit/TensorFileSliceWrite.cpp
+++ b/libs/Einsums/TensorIO/tests/unit/TensorFileSliceWrite.cpp
@@ -108,7 +108,7 @@ TEST_CASE("TensorFile::write_slice rejects mismatched dims", "[TensorIO][slice]"
     REQUIRE_THROWS_AS(out.write_slice("A", wrong, {{{1, 3}, {1, 3}}}), std::runtime_error);
 }
 
-// ── reserve + write_slice — fill an entry block-by-block ────────────────
+// ── reserve + write_slice: fill an entry block-by-block ─────────────────
 
 TEST_CASE("TensorFile::reserve + write_slice fills a tensor incrementally", "[TensorIO][slice]") {
     TempFile const tmp("reserve.etn");

--- a/libs/Einsums/TensorIO/tests/unit/TensorFileSliceWrite.cpp
+++ b/libs/Einsums/TensorIO/tests/unit/TensorFileSliceWrite.cpp
@@ -1,0 +1,216 @@
+//----------------------------------------------------------------------------------------------
+// Copyright (c) The Einsums Developers. All rights reserved.
+// Licensed under the MIT License. See LICENSE.txt in the project root for license information.
+//----------------------------------------------------------------------------------------------
+
+/// @file TensorFileSliceWrite.cpp
+/// @brief Unit tests for TensorFile::write_slice + RuntimeTensor overloads.
+///
+/// Covers the round-trip pattern: reserve a tensor, fill it block-by-block
+/// via write_slice, then read the full tensor back and verify every element.
+/// Also exercises the new RuntimeTensor overloads end-to-end so the Python
+/// bindings have the same behavior they will inherit.
+
+#include <Einsums/Tensor/RuntimeTensor.hpp>
+#include <Einsums/Tensor/Tensor.hpp>
+#include <Einsums/TensorIO/TensorFile.hpp>
+#include <Einsums/TensorUtilities/CreateRandomTensor.hpp>
+#include <Einsums/TensorUtilities/CreateZeroTensor.hpp>
+
+#include <cstdio>
+
+#include <Einsums/Testing.hpp>
+
+using namespace einsums;
+using namespace einsums::tensor_io;
+
+namespace {
+struct TempFile {
+    std::string path;
+    explicit TempFile(std::string name) : path("/tmp/einsums_slice_" + std::move(name)) {}
+    ~TempFile() { std::remove(path.c_str()); }
+};
+} // namespace
+
+// ── Static-rank: write full, then write_slice patches a slab ─────────────
+
+TEST_CASE("TensorFile::write_slice patches a slab of an existing entry", "[TensorIO][slice]") {
+    TempFile const tmp("static_slab.etn");
+
+    // Build a 4x4 tensor of zeros, then patch [1:3, 1:3] with a 2x2 of 7's.
+    auto              base = create_zero_tensor<double>("A", 4, 4);
+    Tensor<double, 2> patch("patch", 2, 2);
+    patch.zero();
+    for (size_t i = 0; i < 2; ++i) {
+        for (size_t j = 0; j < 2; ++j) {
+            patch(i, j) = 7.0;
+        }
+    }
+
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", base);
+        out.write_slice("A", patch, {{{1, 3}, {1, 3}}});
+    }
+
+    Tensor<double, 2> roundtrip("rt", 4, 4);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read("A", roundtrip);
+    }
+
+    for (size_t i = 0; i < 4; ++i) {
+        for (size_t j = 0; j < 4; ++j) {
+            double const expected = (i >= 1 && i < 3 && j >= 1 && j < 3) ? 7.0 : 0.0;
+            REQUIRE(roundtrip(i, j) == expected);
+        }
+    }
+}
+
+TEST_CASE("TensorFile::write_slice round-trips through read_slice", "[TensorIO][slice]") {
+    TempFile const tmp("slice_roundtrip.etn");
+
+    auto base = create_random_tensor<double>("A", 6, 6);
+
+    Tensor<double, 2> sub("sub", 2, 3);
+    for (size_t i = 0; i < 2; ++i) {
+        for (size_t j = 0; j < 3; ++j) {
+            sub(i, j) = j + 100.0 + 10.0 * i;
+        }
+    }
+
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", base);
+        out.write_slice("A", sub, {{{2, 4}, {1, 4}}});
+    }
+
+    Tensor<double, 2> read_back("rb", 2, 3);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read_slice("A", read_back, {{{2, 4}, {1, 4}}});
+    }
+
+    for (size_t i = 0; i < 2; ++i) {
+        for (size_t j = 0; j < 3; ++j) {
+            REQUIRE(read_back(i, j) == 100.0 + 10.0 * i + j);
+        }
+    }
+}
+
+TEST_CASE("TensorFile::write_slice rejects mismatched dims", "[TensorIO][slice]") {
+    TempFile const          tmp("mismatch.etn");
+    auto                    base = create_zero_tensor<double>("A", 4, 4);
+    Tensor<double, 2> const wrong("wrong", 3, 2); // doesn't match any slab of [1:3, 1:3]
+
+    TensorFile out(tmp.path, TensorFile::Mode::Write);
+    out.write("A", base);
+    REQUIRE_THROWS_AS(out.write_slice("A", wrong, {{{1, 3}, {1, 3}}}), std::runtime_error);
+}
+
+// ── reserve + write_slice — fill an entry block-by-block ────────────────
+
+TEST_CASE("TensorFile::reserve + write_slice fills a tensor incrementally", "[TensorIO][slice]") {
+    TempFile const tmp("reserve.etn");
+
+    constexpr size_t N = 4;
+    constexpr size_t B = 2;
+
+    // Reserve space for the full tensor, then fill 2x2 quadrants one at a time.
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::ReadWrite);
+        out.reserve<double>("A", {N, N});
+
+        // Fill each quadrant with a unique value so we can verify placement.
+        for (size_t const bi : {std::size_t{0}, std::size_t{1}}) {
+            for (size_t const bj : {std::size_t{0}, std::size_t{1}}) {
+                Tensor<double, 2> block("blk", B, B);
+                double const      fill = 10.0 * bi + bj;
+                for (size_t i = 0; i < B; ++i) {
+                    for (size_t j = 0; j < B; ++j) {
+                        block(i, j) = fill;
+                    }
+                }
+                out.write_slice("A", block, {{{bi * B, (bi + 1) * B}, {bj * B, (bj + 1) * B}}});
+            }
+        }
+    }
+
+    Tensor<double, 2> roundtrip("rt", N, N);
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read("A", roundtrip);
+    }
+
+    for (size_t bi = 0; bi < 2; ++bi) {
+        for (size_t bj = 0; bj < 2; ++bj) {
+            double const expected = 10.0 * bi + bj;
+            for (size_t i = 0; i < B; ++i) {
+                for (size_t j = 0; j < B; ++j) {
+                    REQUIRE(roundtrip(bi * B + i, bj * B + j) == expected);
+                }
+            }
+        }
+    }
+}
+
+// ── RuntimeTensor overloads ──────────────────────────────────────────────
+
+TEST_CASE("TensorFile RuntimeTensor read/write round-trip", "[TensorIO][runtime]") {
+    TempFile const tmp("rt_full.etn");
+
+    GeneralRuntimeTensor<double, std::allocator<double>> rt("A", std::vector<size_t>{3, 4});
+    for (size_t i = 0; i < rt.size(); ++i) {
+        rt.data()[i] = static_cast<double>(i);
+    }
+
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::Write);
+        out.write("A", rt);
+    }
+
+    GeneralRuntimeTensor<double, std::allocator<double>> back("back", std::vector<size_t>{0});
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read("A", back);
+    }
+
+    REQUIRE(back.rank() == 2);
+    REQUIRE(back.dim(0) == 3);
+    REQUIRE(back.dim(1) == 4);
+    for (size_t i = 0; i < back.size(); ++i) {
+        REQUIRE(back.data()[i] == static_cast<double>(i));
+    }
+}
+
+TEST_CASE("TensorFile RuntimeTensor read_slice + write_slice", "[TensorIO][runtime][slice]") {
+    TempFile const tmp("rt_slab.etn");
+
+    // Reserve a 4x4 tensor.
+    {
+        TensorFile out(tmp.path, TensorFile::Mode::ReadWrite);
+        out.reserve<double>("A", {4, 4});
+
+        // Fill with zeros first.
+        GeneralRuntimeTensor<double, std::allocator<double>> zeros("z", std::vector<size_t>{4, 4});
+        zeros.zero();
+        out.write_slice("A", zeros, {{0, 4}, {0, 4}});
+
+        // Patch [1:3, 1:3] with 9's.
+        GeneralRuntimeTensor<double, std::allocator<double>> patch("p", std::vector<size_t>{2, 2});
+        patch.set_all(9.0);
+        out.write_slice("A", patch, {{1, 3}, {1, 3}});
+    }
+
+    GeneralRuntimeTensor<double, std::allocator<double>> slab("s", std::vector<size_t>{0});
+    {
+        TensorFile in(tmp.path, TensorFile::Mode::Read);
+        in.read_slice("A", slab, {{1, 3}, {1, 3}});
+    }
+    REQUIRE(slab.rank() == 2);
+    REQUIRE(slab.dim(0) == 2);
+    REQUIRE(slab.dim(1) == 2);
+    for (size_t i = 0; i < slab.size(); ++i) {
+        REQUIRE(slab.data()[i] == 9.0);
+    }
+}


### PR DESCRIPTION
# PR 06 — TensorIO: graph-aware slab I/O

**Stack position:** base `stack/pr05-computegraph` → `stack/pr06-tensorio`
**Size:** 20 files, +3,575 / −0 *(purely additive)*

> **Linear 8-PR stack** ([overview](./README.md)). Additive; builds its own slice. Full CI green is gated on the top of the chain, **PR 08**.

## Summary

Adds the `TensorIO` module — `tensor_io::Slab` plus `read_slice_etn` / `write_slice_etn` graph wrappers that let slab-based file I/O participate in a ComputeGraph (captured by reference for loop-driven slab walking).

## What's in it

- `libs/Einsums/TensorIO/` — `Slab`, `TensorFile`, and the `GraphIO` wrappers

## Why it stacks here

TensorIO depends on **ComputeGraph** (for the graph wrappers) and **Comm**; both are present below it (Comm in the core, ComputeGraph in PR 05). It's purely additive and **nothing else depends on it**, so it's a thin layer near the top of the stack.

## Verification

- During carving, TensorIO compiled cleanly on top of ComputeGraph (`EINSUMS_BUILD_PYTHON=OFF`, 0 errors).
- Authoritative check: the full stack passes — **PR 08** builds with `EINSUMS_BUILD_PYTHON=ON -DEINSUMS_WITH_TESTS=ON` in the `einsums-dev` env and `ctest` reports **429/429**.

## Notes for reviewers

- Small, self-contained follow-on to ComputeGraph; no changes outside `libs/Einsums/TensorIO/` (plus the module-list entry).

## Caveat: squash vs merge

These are real stacked branches (each child built on its parent's commits). **Prefer merge-commits over squash** so children stay valid as their bases land. If you squash, retarget + `git rebase --onto main <old-base> <child>` after each parent merges.
