### PR TITLE
PR9: C++20: lower the C++ requirement from C++23 to C++20

### DIFF
--- a/.github/workflows/macos-build-and-test.yml
+++ b/.github/workflows/macos-build-and-test.yml
@@ -100,7 +100,11 @@ jobs:
           export BINARIES="$(find . -name "*_test")"
           echo "PROFILES=$PROFILES"
           echo "BINARIES=$BINARIES"
-          llvm-profdata merge $PROFILES -o default.profdata
+          # --failure-mode=warn: a stray/truncated default.profraw (an instrumented
+          # binary that ran without LLVM_PROFILE_FILE set) is occasionally malformed
+          # ("symbol name is empty") and would otherwise fail the whole merge. Warn
+          # and skip the bad file instead of erroring; valid coverage is kept.
+          llvm-profdata merge --failure-mode=warn $PROFILES -o default.profdata
           llvm-cov export -format=lcov -ignore-filename-regex="_deps|einsums-env" -instr-profile=default.profdata $BINARIES > coverage.info
 
       - name: Upload C++ coverage to Codecov

--- a/cmake/Einsums_CheckCXXStandard.cmake
+++ b/cmake/Einsums_CheckCXXStandard.cmake
@@ -7,13 +7,13 @@
 # that requirement has to be propagated to users of einsums as well. Ideally, users should not set
 # CMAKE_CXX_STANDARD when building einsums.
 einsums_option(
-  EINSUMS_WITH_CXX_STANDARD STRING "C++ standard to use for compiling einsums (default: 23)" "23"
+  EINSUMS_WITH_CXX_STANDARD STRING "C++ standard to use for compiling einsums (default: 20)" "20"
   ADVANCED CATEGORY "Generic"
 )
 
-if(EINSUMS_WITH_CXX_STANDARD LESS 23)
+if(EINSUMS_WITH_CXX_STANDARD LESS 20)
   einsums_error(
-    "You've set EINSUMS_WITH_CXX_STANDARD to ${EINSUMS_WITH_CXX_STANDARD}, which is less than 23 which is the minimum required by einsums"
+    "You've set EINSUMS_WITH_CXX_STANDARD to ${EINSUMS_WITH_CXX_STANDARD}, which is less than 20 which is the minimum required by einsums"
   )
 endif()
 

--- a/cmake/Einsums_CheckCXXStandard.cmake
+++ b/cmake/Einsums_CheckCXXStandard.cmake
@@ -3,7 +3,7 @@
 # Licensed under the MIT License. See LICENSE.txt in the project root for license information.
 #----------------------------------------------------------------------------------------------
 
-# We require at least C++23. However, if a higher standard is set by the user in CMAKE_CXX_STANDARD
+# We require at least C++20. However, if a higher standard is set by the user in CMAKE_CXX_STANDARD
 # that requirement has to be propagated to users of einsums as well. Ideally, users should not set
 # CMAKE_CXX_STANDARD when building einsums.
 einsums_option(
@@ -26,9 +26,9 @@ endif()
 set(CMAKE_CXX_STANDARD ${EINSUMS_WITH_CXX_STANDARD})
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-# We explicitly set the default to 98 to force CMake to emit a -std=c++XX flag. Some compilers
-# (clang) have a different default standard for cpp and cu files, but CMake does not know about this
-# difference. If the standard is set to the .cpp default in CMake, CMake will omit the flag,
+# We explicitly set the default to 98 to force CMake to emit a -std=c++XX flag. Some compilers, such
+# as clang, have a different default standard for cpp and cu files, but CMake does not know about
+# this difference. If the standard is set to the .cpp default in CMake, CMake will omit the flag,
 # resulting in the wrong standard for .cu files.
 set(CMAKE_CXX_STANDARD_DEFAULT 98)
 

--- a/devtools/docker/run-ci-leg.sh
+++ b/devtools/docker/run-ci-leg.sh
@@ -5,6 +5,12 @@
 # creation cost of roughly 10 minutes and every subsequent rebuild/test cycle
 # is incremental.
 #
+# PREREQUISITE: the external/apiary submodule must be checked out on the host
+# before running. This script copies the host working tree into the container
+# (it does NOT run `git submodule update`), so an uninitialized submodule yields
+# a confusing CMake error ("external/apiary does not contain a CMakeLists.txt").
+# Run once:  git submodule update --init --recursive external/apiary
+#
 # Usage (run from repo root):
 #
 #     # First-time setup: start the persistent container.

--- a/libs/Einsums/ComputeGraph/tests/performance/BenchmarkExecutors.cpp
+++ b/libs/Einsums/ComputeGraph/tests/performance/BenchmarkExecutors.cpp
@@ -14,8 +14,9 @@
 #include <Einsums/TensorUtilities/CreateRandomTensor.hpp>
 #include <Einsums/TensorUtilities/CreateZeroTensor.hpp>
 
+#include <fmt/format.h>
+
 #include <cstdio>
-#include <print>
 
 #include <Einsums/Testing.hpp>
 
@@ -74,7 +75,7 @@ EINSUMS_TEST_CASE("Bench Executor: linear chain 4 nodes N=50", "[ComputeGraph][E
         },
         20);
 
-    std::println("[Executor linear N=50] seq: {:.2f} us  omp: {:.2f} us  df: {:.2f} us", t_seq.avg, t_omp.avg, t_df.avg);
+    fmt::println("[Executor linear N=50] seq: {:.2f} us  omp: {:.2f} us  df: {:.2f} us", t_seq.avg, t_omp.avg, t_df.avg);
 
     // Publish structured results to profiler server
     ProfileAnnotate("topology", "linear_chain");
@@ -143,8 +144,8 @@ EINSUMS_TEST_CASE("Bench Executor: 8 independent nodes N=30", "[ComputeGraph][Ex
         },
         20);
 
-    std::println("[Executor fanout-8 N=30] seq: {:.2f} us  omp: {:.2f} us  df: {:.2f} us", t_seq.avg, t_omp.avg, t_df.avg);
-    std::println("  seq/omp: {:.2f}x  seq/df: {:.2f}x", t_seq.avg / t_omp.avg, t_seq.avg / t_df.avg);
+    fmt::println("[Executor fanout-8 N=30] seq: {:.2f} us  omp: {:.2f} us  df: {:.2f} us", t_seq.avg, t_omp.avg, t_df.avg);
+    fmt::println("  seq/omp: {:.2f}x  seq/df: {:.2f}x", t_seq.avg / t_omp.avg, t_seq.avg / t_df.avg);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -204,8 +205,8 @@ EINSUMS_TEST_CASE("Bench Executor: diamond DAG N=50", "[ComputeGraph][Executor][
         },
         20);
 
-    std::println("[Executor diamond N=50] seq: {:.2f} us  omp: {:.2f} us  df: {:.2f} us", t_seq.avg, t_omp.avg, t_df.avg);
-    std::println("  seq/omp: {:.2f}x  seq/df: {:.2f}x", t_seq.avg / t_omp.avg, t_seq.avg / t_df.avg);
+    fmt::println("[Executor diamond N=50] seq: {:.2f} us  omp: {:.2f} us  df: {:.2f} us", t_seq.avg, t_omp.avg, t_df.avg);
+    fmt::println("  seq/omp: {:.2f}x  seq/df: {:.2f}x", t_seq.avg / t_omp.avg, t_seq.avg / t_df.avg);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -245,7 +246,7 @@ EINSUMS_TEST_CASE("Bench Executor: replay overhead 100 iterations N=20", "[Compu
         100);
 
     double const overhead_pct = ((t_graph.avg - t_bare.avg) / t_bare.avg) * 100.0;
-    std::println("[Replay N=20] bare: {:.2f} us  graph: {:.2f} us  overhead: {:.1f}%", t_bare.avg, t_graph.avg, overhead_pct);
+    fmt::println("[Replay N=20] bare: {:.2f} us  graph: {:.2f} us  overhead: {:.1f}%", t_bare.avg, t_graph.avg, overhead_pct);
 }
 
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -279,5 +280,5 @@ EINSUMS_TEST_CASE("Bench PassManager: create_default on 10-node graph", "[Comput
         },
         50);
 
-    std::println("[PassManager 10-node] {:.2f} us avg  ({} nodes after)", t.avg, graph.num_nodes());
+    fmt::println("[PassManager 10-node] {:.2f} us avg  ({} nodes after)", t.avg, graph.num_nodes());
 }

--- a/libs/Einsums/ComputeGraph/tests/unit/test_linalg_new_python.py
+++ b/libs/Einsums/ComputeGraph/tests/unit/test_linalg_new_python.py
@@ -143,10 +143,11 @@ def test_pow_square_recovers_matmul(dtype):
     # Mac Accelerate's float32 SGEMM accumulates wider rounding than Linux
     # OpenBLAS / MKL, observed ~2.5e-5 relative on macOS CI vs <1e-6 on Linux.
     # Default c32/f32 rtol is 1e-5; loosen to 1e-4 for this matmul-of-matmul
-    # shape (still tight enough to catch real bugs). f64 likewise: pow() goes
-    # through an eigendecomposition whose reconstruction differs from the direct
-    # A@A at the ~1e-12 level (BLAS-dependent; ~2.2e-12 observed on clang/OpenBLAS),
-    # so loosen f64 from 1e-12 to 1e-10 — matching test_pow_inverse_round_trip below.
+    # shape, which is still tight enough to catch real bugs. f64 likewise: pow()
+    # goes through an eigendecomposition whose reconstruction differs from the
+    # direct A@A at the ~1e-12 level. The gap is BLAS-dependent, about 2.2e-12 on
+    # clang/OpenBLAS, so loosen f64 from 1e-12 to 1e-10 to match
+    # test_pow_inverse_round_trip below.
     assert_close(got, expected, rtol=1e-4 if dtype.endswith("32") else 1e-10)
 
 

--- a/libs/Einsums/ComputeGraph/tests/unit/test_linalg_new_python.py
+++ b/libs/Einsums/ComputeGraph/tests/unit/test_linalg_new_python.py
@@ -143,8 +143,11 @@ def test_pow_square_recovers_matmul(dtype):
     # Mac Accelerate's float32 SGEMM accumulates wider rounding than Linux
     # OpenBLAS / MKL, observed ~2.5e-5 relative on macOS CI vs <1e-6 on Linux.
     # Default c32/f32 rtol is 1e-5; loosen to 1e-4 for this matmul-of-matmul
-    # shape (still tight enough to catch real bugs).
-    assert_close(got, expected, rtol=1e-4 if dtype.endswith("32") else 1e-12)
+    # shape (still tight enough to catch real bugs). f64 likewise: pow() goes
+    # through an eigendecomposition whose reconstruction differs from the direct
+    # A@A at the ~1e-12 level (BLAS-dependent; ~2.2e-12 observed on clang/OpenBLAS),
+    # so loosen f64 from 1e-12 to 1e-10 — matching test_pow_inverse_round_trip below.
+    assert_close(got, expected, rtol=1e-4 if dtype.endswith("32") else 1e-10)
 
 
 @pytest.mark.parametrize("dtype", REAL_DTYPES)

--- a/libs/Einsums/PackedGemm/include/Einsums/PackedGemm/Packing.hpp
+++ b/libs/Einsums/PackedGemm/include/Einsums/PackedGemm/Packing.hpp
@@ -196,7 +196,7 @@ inline void sort_k_dims_for_packing(PackingPlan &plan) {
 
     // Build index permutation sorted descending by max(stride_A, stride_B).
     std::vector<size_t> perm(n);
-    std::ranges::iota(perm, size_t{0});
+    std::iota(perm.begin(), perm.end(), size_t{0});
     std::ranges::sort(perm, [&](size_t a, size_t b) {
         int64_t const max_a = std::max(plan.k_dims_in_a[a].tensor_stride, plan.k_dims_in_b[a].tensor_stride);
         int64_t const max_b = std::max(plan.k_dims_in_a[b].tensor_stride, plan.k_dims_in_b[b].tensor_stride);

--- a/libs/Einsums/Profile/src/OMPT.cpp
+++ b/libs/Einsums/Profile/src/OMPT.cpp
@@ -9,6 +9,8 @@
 #include <Einsums/Print.hpp>
 #include <Einsums/StringUtil/FromString.hpp>
 
+#include <fmt/format.h>
+
 #include <cstdlib>
 
 // The CMake file should prevent this entire file from being compiled.
@@ -85,7 +87,7 @@ ompt_start_tool_result_t *ompt_start_tool(unsigned int omp_version, char const *
     // section. Unfortunately, within this function OpenMP is still initializing and that function
     // may hang.
     if (use_ompt)
-        std::println(stdout, "ompt_start_tool: running on omp_version {}, runtime_version {}", omp_version, runtime_version);
+        fmt::println(stdout, "ompt_start_tool: running on omp_version {}, runtime_version {}", omp_version, runtime_version);
 
     static ompt_start_tool_result_t result;
     result.initialize      = &ompt_initialize;

--- a/libs/Einsums/TensorBase/include/Einsums/TensorBase/Common.hpp
+++ b/libs/Einsums/TensorBase/include/Einsums/TensorBase/Common.hpp
@@ -11,6 +11,7 @@
 
 #include <array>
 #include <concepts>
+#include <cstdint>
 #include <sstream>
 #include <type_traits>
 


### PR DESCRIPTION
> Supersedes #274, which GitHub auto-closed when its head branch `cxx20` was renamed to `stack/pr09-cxx20` (a rename closes any PR that uses the branch as its head). Same commits, reconciled onto the updated stack.

# Lower the C++ requirement from C++23 to C++20

**Stack position:** base `stack/pr08-strictness` (#272) → `stack/pr09-cxx20`
**Size:** 4 commits (the last two are incidental CI flake/tolerance fixes surfaced by this PR's CI, unrelated to C++20)

> **Follow-on to the #262 split**, not part of it. Stacked on the split's top (#272) so it builds against the complete codebase. Merge after the 8-PR stack lands (or rebase onto `main` once it does).

## Summary

Makes **C++20** the default/minimum standard (`EINSUMS_WITH_CXX_STANDARD`), down from C++23. The codebase was already largely C++20-ready — the `CXX23` module is a compatibility shim with C++20 fallbacks — so the change is small.

## What's in it

- `cmake/Einsums_CheckCXXStandard.cmake` — default `20`, floor `20`.
- `PackedGemm/Packing.hpp` — `std::ranges::iota` (C++23) → `std::iota` (`<numeric>`).
- `Profile/OMPT.cpp` + `ComputeGraph/.../BenchmarkExecutors.cpp` — `std::println` (C++23) → `fmt::println` (fmt is a core dep). Clang's libc++ allows `std::print` in C++20, but **GCC's libstdc++ gates it behind C++23**, so this is required for the gcc legs.
- docs note in `devtools/docker/run-ci-leg.sh` — the `external/apiary` submodule must be checked out before running (the script copies the host tree; it doesn't `git submodule update`).
- `macos-build-and-test.yml` — `llvm-profdata merge --failure-mode=warn` so an occasionally-truncated stray `default.profraw` (instrumented binary run without `LLVM_PROFILE_FILE`) doesn't flake the macOS coverage leg. Pre-existing flake, unrelated to C++20, fixed here for convenience.
- `test_linalg_new_python.py` — loosen f64 rtol `1e-12 → 1e-10` for `test_pow_square_recovers_matmul` (pow via eigendecomposition differs from direct `A@A` at ~2.2e-12 on clang/OpenBLAS; matches the sibling round-trip test). A pre-existing too-tight tolerance, not a C++20 effect (values come from BLAS).

## Why it's small

The only real blockers were the two stdlib calls above. The `CXX23` module already provides C++20 fallbacks for `std::expected`, `std::unreachable`, and `std::flat_map`/`flat_set`; `EINSUMS_HAVE_CXX23_STATIC_CALL_OPERATOR` is a conditional feature test. **No C++23 language features** were in use (no deducing-this, `[[assume]]`, `if consteval`, multidim subscript).

## Verification

- **Clang 22** (local, full): build with `EINSUMS_WITH_CXX_STANDARD=20 -DEINSUMS_WITH_TESTS=ON` — library + 340 test exes + 14 benchmarks compile clean (0 errors).
- **gcc15 + libstdc++** (arm64 docker leg, C++20): **0 compile errors**, no `std::print`/`iota` issues, 371/373 ctest pass. The 2 failures are arch/env artifacts (CPU-brand detection returns "Unknown CPU" in the container; a GPU test with no GPU) — not C++20. CI-exact x86_64-GCC confirmation comes from the `gcc-openblas` CI leg.
