### PR TITLE
Avoid GNU src on Mac

### DIFF
--- a/libs/Einsums/BLASVendor/CMakeLists.txt
+++ b/libs/Einsums/BLASVendor/CMakeLists.txt
@@ -42,9 +42,12 @@ set(BLASVendorSources
     direct_prod.cpp
 )
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
-  set(BLASVendorx64Sources direct_prod_kernels/sdirprod-x86_64-avx2.S direct_prod_kernels/ddirprod-x86_64-avx2.S
-      direct_prod_kernels/cdirprod-x86_64-avx2.S direct_prod_kernels/zdirprod-x86_64-avx2.S)
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 AND NOT APPLE)
+  set(BLASVendorx64Sources
+      direct_prod_kernels/sdirprod-x86_64-avx2.S
+      direct_prod_kernels/ddirprod-x86_64-avx2.S
+      direct_prod_kernels/cdirprod-x86_64-avx2.S
+      direct_prod_kernels/zdirprod-x86_64-avx2.S)
   list(APPEND BLASVendorSources ${BLASVendorx64Sources})
 endif()
 


### PR DESCRIPTION
On c-f for Intel Mac I was getting the error below, which chatgpt diagnosed as "this is Linux/GNU assembly being compiled on Darwin/macOS". So this PR skips that bit for Apple.

```
[28/204] Building C object libs/Einsums/BLASVendor/CMakeFiles/Einsums_BLASVendor.dir/src/direct_prod.c.o
[29/204] Building CXX object libs/Einsums/BLASVendor/CMakeFiles/Einsums_BLASVendor.dir/src/scal.cpp.o[30/204] Building CXX object libs/Einsums/BLASVendor/CMakeFiles/Einsums_BLASVendor.dir/src/syev.cpp.o
[31/204] Building ASM object libs/Einsums/BLASVendor/CMakeFiles/Einsums_BLASVendor.dir/src/direct_prod_kernels/ddirprod-x86_64-avx2.S.o
FAILED: [code=1] libs/Einsums/BLASVendor/CMakeFiles/Einsums_BLASVendor.dir/src/direct_prod_kernels/ddirprod-x86_64-avx2.S.o/Users/runner/miniforge3/conda-bld/einsums-split_1781714762938/_build_env/bin/x86_64-apple-darwin13.4.0-clang -DEINSUMS_ACTIVE_LOG_LEVEL=2 -DEINSUMS_EXPORTS -DFMT_SHARED -DNDEBUG -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -DSPDLOG_SHARED_LIB -D_GNU_SOURCE -I/Users/runner/miniforge3/conda-bld/einsums-split_1781714762938/work/libs/Einsums/BLASVendor/include -I/Users/runner/miniforge3/conda-bld/einsums-split_1781714762938/work/build/libs/Einsums/BLASVendor/include -I/Users/runner/miniforge3/conda-bld/einsums-split_1781714762938/work/build -I/Users/runner/miniforge3/conda-bld/einsums-
```

Also, one ctest is failing on both Intel & Silicon Mac. Can't recognize `--einsums` argument? I've skipped it for now on c-f.

```
026-06-17T20:57:29.1020280Z  17/223 Test  #19: Tests.Unit.Modules.Einsums.BufferAllocator.Allocator .......................................................   Passed    0.07 sec
2026-06-17T20:57:29.1024390Z         Start  21: Tests.Headers.Modules.Einsums.CommandLine.AllHeaders
2026-06-17T20:57:31.9810870Z  18/223 Test  #18: Tests.Headers.Modules.Einsums.BufferAllocator.AllHeaders ...................................................   Passed    3.03 sec
2026-06-17T20:57:32.0488420Z         Start  22: Tests.Unit.Modules.Einsums.CommandLine.cl
2026-06-17T20:57:32.1204810Z  19/223 Test  #22: Tests.Unit.Modules.Einsums.CommandLine.cl ..................................................................***Failed    0.09 sec
2026-06-17T20:57:32.1223310Z [2026-06-17 20:57:32.096761000] [einsums] [info    ] [InitLogging.cpp:87/init_logging] logging submodule has been initialized
2026-06-17T20:57:32.1397330Z [2026-06-17 20:57:32.097577000] [einsums] [info    ] [InitLogging.cpp:88/init_logging] log level: 2 (0=TRACE,1=DEBUG,2=INFO,3=WARN,4=ERROR,5=CRITICAL)
2026-06-17T20:57:32.1411140Z [2026-06-17 20:57:32.097593000] [einsums] [info    ] [InitRuntime.cpp:101/run] Starting Einsums: v2.0.0-trunk, Git: unknown
2026-06-17T20:57:32.1442690Z [2026-06-17 20:57:32.097596000] [einsums] [info    ] [InitRuntime.cpp:113/run] Runtime options:
2026-06-17T20:57:32.1470430Z [2026-06-17 20:57:32.097598000] [einsums] [info    ] [InitRuntime.cpp:116/run] "hdf5-file-name": "einsums.47806.h5"
2026-06-17T20:57:32.1482950Z [2026-06-17 20:57:32.097602000] [einsums] [info    ] [InitRuntime.cpp:116/run] "scratch-dir": "/tmp"
2026-06-17T20:57:32.1541350Z [2026-06-17 20:57:32.097604000] [einsums] [info    ] [InitRuntime.cpp:116/run] "profiler-filename": "profile.txt"
2026-06-17T20:57:32.1556420Z [2026-06-17 20:57:32.097605000] [einsums] [info    ] [InitRuntime.cpp:116/run] "log-destination": "cerr"
2026-06-17T20:57:32.1598750Z [2026-06-17 20:57:32.097607000] [einsums] [info    ] [InitRuntime.cpp:116/run] "buffer-size": "4MB"
2026-06-17T20:57:32.1609950Z [2026-06-17 20:57:32.097610000] [einsums] [info    ] [InitRuntime.cpp:116/run] "log-format": "[%Y-%m-%d %H:%M:%S.%F] [%n] [%^%-8l%$] [%s:%#/%!] %v"
2026-06-17T20:57:32.1623110Z [2026-06-17 20:57:32.097613000] [einsums] [info    ] [InitRuntime.cpp:116/run] "work-buffer-size": "0"
2026-06-17T20:57:32.1683830Z [2026-06-17 20:57:32.097615000] [einsums] [info    ] [InitRuntime.cpp:116/run] "executable-prefix": "/Users/runner/miniforge3/conda-bld/einsums-split_1781729072956/work/build/libs/Einsums/CommandLine/tests"
2026-06-17T20:57:32.1697230Z [2026-06-17 20:57:32.097619000] [einsums] [info    ] [InitRuntime.cpp:120/run] "profiler-detailed": false
2026-06-17T20:57:32.1759560Z [2026-06-17 20:57:32.097621000] [einsums] [info    ] [InitRuntime.cpp:120/run] "delete-hdf5-files": false
2026-06-17T20:57:32.2739310Z [2026-06-17 20:57:32.097623000] [einsums] [info    ] [InitRuntime.cpp:120/run] "diagnostics-on-terminate": true
2026-06-17T20:57:32.2799560Z [2026-06-17 20:57:32.097625000] [einsums] [info    ] [InitRuntime.cpp:120/run] "profiler-report": true
2026-06-17T20:57:32.2844400Z [2026-06-17 20:57:32.097626000] [einsums] [info    ] [InitRuntime.cpp:120/run] "profiler-append": true
2026-06-17T20:57:32.2936390Z [2026-06-17 20:57:32.097628000] [einsums] [info    ] [InitRuntime.cpp:120/run] "attach-debugger": true
2026-06-17T20:57:32.3033760Z [2026-06-17 20:57:32.097630000] [einsums] [info    ] [InitRuntime.cpp:120/run] "install-signal-handlers": true
2026-06-17T20:57:32.4034260Z [2026-06-17 20:57:32.097632000] [einsums] [info    ] [InitRuntime.cpp:128/run] "log-level": 2
2026-06-17T20:57:32.4147190Z [2026-06-17 20:57:32.097634000] [einsums] [info    ] [InitRuntime.cpp:128/run] "pid": 47806
2026-06-17T20:57:32.4282410Z [2026-06-17 20:57:32.098477000] [einsums] [info    ] [Runtime.cpp:145/init] Runtime::init: initializing...
2026-06-17T20:57:32.4339000Z [2026-06-17 20:57:32.098508000] [einsums] [info    ] [Runtime.cpp:132/state] Runtime state changed from Invalid to PreStartup
2026-06-17T20:57:32.4747410Z [2026-06-17 20:57:32.098512000] [einsums] [info    ] [Runtime.cpp:132/state] Runtime state changed from PreStartup to Startup
2026-06-17T20:57:32.5190390Z [2026-06-17 20:57:32.099375000] [einsums] [info    ] [Runtime.cpp:132/state] Runtime state changed from Startup to Running
2026-06-17T20:57:32.5327070Z [2026-06-17 20:57:32.099470000] [einsums] [info    ] [Runtime.cpp:258/run] running user provided function
2026-06-17T20:57:32.5497950Z 
2026-06-17T20:57:32.5932020Z Error(s) in input:
2026-06-17T20:57:32.6305130Z   Unrecognised token: --einsums
2026-06-17T20:57:32.6529390Z 
2026-06-17T20:57:32.7340170Z Run with -? for usage
2026-06-17T20:57:32.7401990Z 
2026-06-17T20:57:32.7570390Z Randomness seeded to: 699714125
2026-06-17T20:57:32.7670160Z error: value for '--t7-ranged' out of range [5, 15]
2026-06-17T20:57:32.8222960Z Usage: prog [options]
2026-06-17T20:57:32.8299990Z 
2026-06-17T20:57:32.8351580Z Help:
2026-06-17T20:57:32.8643230Z   --help       -h    Show this help message and exit
2026-06-17T20:57:32.8744080Z   --version          Show version and exit
2026-06-17T20:57:32.8993800Z 
2026-06-17T20:57:32.9489230Z prog 9.9
2026-06-17T20:57:32.9536250Z 
2026-06-17T20:57:32.9625550Z ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2026-06-17T20:57:33.0631040Z cl_test is a Catch2 v3.15.1 host application.
2026-06-17T20:57:33.0760950Z Run with -? for options
2026-06-17T20:57:33.0976630Z 
2026-06-17T20:57:33.1147050Z -------------------------------------------------------------------------------
2026-06-17T20:57:33.1849310Z Flag default and implicit override
2026-06-17T20:57:33.2192670Z   Both flags
2026-06-17T20:57:33.2261220Z -------------------------------------------------------------------------------
2026-06-17T20:57:33.2358960Z /Users/runner/miniforge3/conda-bld/einsums-split_1781729072956/work/libs/Einsums/CommandLine/tests/unit/cl.cpp:123
2026-06-17T20:57:33.3361470Z ...............................................................................
2026-06-17T20:57:33.3586990Z 
2026-06-17T20:57:33.4012470Z /Users/runner/miniforge3/conda-bld/einsums-split_1781729072956/work/libs/Einsums/CommandLine/tests/unit/cl.cpp:127: FAILED:
2026-06-17T20:57:33.4547990Z   REQUIRE( !pr.ok )
2026-06-17T20:57:33.4646090Z with expansion:
2026-06-17T20:57:33.5236140Z   false
2026-06-17T20:57:33.5254730Z 
2026-06-17T20:57:33.5560410Z ===============================================================================
2026-06-17T20:57:33.5651990Z test cases:  9 |  8 passed | 1 failed
2026-06-17T20:57:33.6247220Z assertions: 56 | 55 passed | 1 failed
```