### PR TITLE
Update direct_prod.c

### DIFF
--- a/devtools/conda-envs/snippets/common.yml
+++ b/devtools/conda-envs/snippets/common.yml
@@ -13,7 +13,7 @@ dependencies:
   # Prebuilts to save einsums the work
   - catch2
   - fftw
-  - fmt
+  - fmt<=12.1
   - cpptrace
   - spdlog
   # HDF5

--- a/libs/Einsums/BLASVendor/CMakeLists.txt
+++ b/libs/Einsums/BLASVendor/CMakeLists.txt
@@ -42,7 +42,7 @@ set(BLASVendorSources
     direct_prod.cpp
 )
 
-if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64)
+if(and(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64, CMAKE_HOST_SYSTEM STREQUAL Linux))
   set(BLASVendorx64Sources direct_prod_kernels/sdirprod-x86_64-avx2.S direct_prod_kernels/ddirprod-x86_64-avx2.S
       direct_prod_kernels/cdirprod-x86_64-avx2.S direct_prod_kernels/zdirprod-x86_64-avx2.S)
   list(APPEND BLASVendorSources ${BLASVendorx64Sources})

--- a/libs/Einsums/BLASVendor/CMakeLists.txt
+++ b/libs/Einsums/BLASVendor/CMakeLists.txt
@@ -42,7 +42,7 @@ set(BLASVendorSources
     direct_prod.cpp
 )
 
-if(and(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64, CMAKE_HOST_SYSTEM STREQUAL Linux))
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL x86_64 AND CMAKE_HOST_SYSTEM STREQUAL Linux)
   set(BLASVendorx64Sources direct_prod_kernels/sdirprod-x86_64-avx2.S direct_prod_kernels/ddirprod-x86_64-avx2.S
       direct_prod_kernels/cdirprod-x86_64-avx2.S direct_prod_kernels/zdirprod-x86_64-avx2.S)
   list(APPEND BLASVendorSources ${BLASVendorx64Sources})

--- a/libs/Einsums/BLASVendor/src/direct_prod.c
+++ b/libs/Einsums/BLASVendor/src/direct_prod.c
@@ -3,7 +3,7 @@
 
 #include <stddef.h>
 
-#if defined(__AVX2__) && defined(__FMA3__)
+#if defined(__AVX2__) && defined(__FMA3__) && !defined(__ICC) && !defined(__INTEL_COMPILER)
 extern int sdirprod_kernel_avx2(size_t n, float alpha, float const *x, float const *y, float *z);
 extern int ddirprod_kernel_avx2(size_t n, double alpha, double const *x, double const *y, double *z);
 extern int cdirprod_kernel_avx2(size_t n, _Complex float alpha, _Complex float const *x, _Complex float const *y,


### PR DESCRIPTION
We'll see if we can fix the issue #279 here. I have a suspicion that the intel compiler uses intel syntax. Since the FMA3 instructions are weird in intel syntax, I'm just not going to bother. The intel compiler knows how to vectorize anyways.